### PR TITLE
Add simple email sending and refactor notify

### DIFF
--- a/apts/__init__.py
+++ b/apts/__init__.py
@@ -59,4 +59,4 @@ except ValueError:
 # Disable label trimming in pandas tables
 pd.set_option("display.max_colwidth", None)
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/apts/notify.py
+++ b/apts/notify.py
@@ -14,11 +14,10 @@ logger = logging.getLogger(__name__)
 
 class Notify:
     """
-    Handles sending email notifications with observation details and plots.
+    Handles sending email notifications using configured SMTP settings.
 
-    This class requires SMTP server details to be passed during initialization.
-    It reads these settings (host, port, user, password, TLS preference) and
-    uses them to connect to the specified SMTP server for sending emails.
+    It reads SMTP server details from apts.config ("notification" section).
+    Provides methods for sending complex notifications (with plots) and simple emails.
     """
 
     def __init__(self, recipient_email):
@@ -30,106 +29,149 @@ class Notify:
         self.smtp_use_tls = config.getboolean(
             "notification", "smtp_use_tls", fallback=True
         )
-        self.sender_email = config.get(
-            "notification", "sender_email", fallback=None
-        )
+        self.sender_email = config.get("notification", "sender_email", fallback=None)
 
         if not self.smtp_host or not self.smtp_user:
             logger.warning(
                 f"SMTP host ('{self.smtp_host}') or user ('{self.smtp_user}') not configured. Email notifications may fail."
             )
 
-    def send(self, observations, custom_template=None, css=None):
-        # Overall message container: multipart/alternative for text and HTML versions
-        msg_root = MIMEMultipart('alternative')
-        msg_root["Subject"] = f"Good weather in {observations.place.name}"
-        msg_root["From"] = self.sender_email
-        msg_root["To"] = self.recipient_email
-
-        # Fallback plain text message
-        plain_text_fallback = "This is a fallback message. Please enable HTML to see the full content."
-        text_part = MIMEText(plain_text_fallback, "plain")
-        msg_root.attach(text_part)
-
-        # Create multipart/related for HTML and inline images
-        msg_related = MIMEMultipart('related')
-        
-        # HTML message content
-        html_content = observations.to_html(custom_template=custom_template, css=css)
-        html_part = MIMEText(html_content, "html")
-        msg_related.attach(html_part) # First part of related is the HTML
-
-        # Add weather image (inline)
-        logger.info("Generating weather plot for email...")
-        weather_plot_fig = observations.plot_weather() # Call public method
-        if weather_plot_fig:
-            self.attach_image(msg_related, weather_plot_fig, filename="weather_plot.png")
-        else:
-            logger.warning("observations.plot_weather() returned None or an invalid plot object, not attaching weather plot.")
-
-        # Add messier image (inline)
-        logger.info("Generating messier plot for email...")
-        messier_plot_fig = observations.plot_messier() # Call public method
-        if messier_plot_fig:
-            self.attach_image(msg_related, messier_plot_fig, filename="messier_plot.png")
-        else:
-            logger.warning("observations.plot_messier() returned None or an invalid plot object, not attaching messier plot.")
-            
-        # Attach the multipart/related part to the multipart/alternative part
-        msg_root.attach(msg_related)
-
+    def _send_email(self, msg):
+        """Internal helper to send a MIME message using configured SMTP."""
         try:
             server = smtplib.SMTP(self.smtp_host, self.smtp_port)
             server.ehlo()
             if self.smtp_use_tls:
                 server.starttls()
                 server.ehlo()
-            
+
             if self.smtp_user and self.smtp_password:
                 server.login(self.smtp_user, self.smtp_password)
 
             logger.info(
-                f"Sending email to {self.recipient_email} via {self.smtp_host}:{self.smtp_port}"
+                f"Sending email to {msg['To']} via {self.smtp_host}:{self.smtp_port}"
             )
-            server.sendmail(msg_root["From"], self.recipient_email, msg_root.as_string())
+            server.sendmail(msg["From"], msg["To"], msg.as_string())
             logger.info("Email sent successfully")
+            return True
         except Exception as e:
-            logger.error(
-                f"Failed to send email: {e}", exc_info=True
-            )
+            logger.error(f"Failed to send email: {e}", exc_info=True)
+            return False
         finally:
             try:
-                if 'server' in locals() and server: 
+                if "server" in locals() and server:
                     server.quit()
             except Exception:
                 pass
 
+    def send_simple_email(self, subject, body, html_body=None):
+        """Sends a simple email with optional HTML content."""
+        msg_root = MIMEMultipart("alternative")
+        msg_root["Subject"] = subject
+        msg_root["From"] = self.sender_email
+        msg_root["To"] = self.recipient_email
+
+        # Plain text part
+        text_part = MIMEText(body, "plain")
+        msg_root.attach(text_part)
+
+        # Optional HTML part
+        if html_body:
+            html_part = MIMEText(html_body, "html")
+            msg_root.attach(html_part)
+
+        return self._send_email(msg_root)  # Use the internal helper
+
+    def send(self, observations, custom_template=None, css=None):
+        """Sends a complex email notification with observation details and plots."""
+        # Overall message container: multipart/alternative for text and HTML versions
+        msg_root = MIMEMultipart("alternative")
+        msg_root["Subject"] = f"Good weather in {observations.place.name}"
+        msg_root["From"] = self.sender_email
+        msg_root["To"] = self.recipient_email
+
+        # Fallback plain text message
+        plain_text_fallback = (
+            "This is a fallback message. Please enable HTML to see the full content."
+        )
+        text_part = MIMEText(plain_text_fallback, "plain")
+        msg_root.attach(text_part)
+
+        # Create multipart/related for HTML and inline images
+        msg_related = MIMEMultipart("related")
+
+        # HTML message content
+        html_content = observations.to_html(custom_template=custom_template, css=css)
+        html_part = MIMEText(html_content, "html")
+        msg_related.attach(html_part)  # First part of related is the HTML
+
+        # Add weather image (inline)
+        logger.info("Generating weather plot for email...")
+        weather_plot_fig = observations.plot_weather()  # Call public method
+        if weather_plot_fig:
+            self.attach_image(
+                msg_related, weather_plot_fig, filename="weather_plot.png"
+            )
+        else:
+            logger.warning(
+                "observations.plot_weather() returned None or an invalid plot object, not attaching weather plot."
+            )
+
+        # Add messier image (inline)
+        logger.info("Generating messier plot for email...")
+        messier_plot_fig = observations.plot_messier()  # Call public method
+        if messier_plot_fig:
+            self.attach_image(
+                msg_related, messier_plot_fig, filename="messier_plot.png"
+            )
+        else:
+            logger.warning(
+                "observations.plot_messier() returned None or an invalid plot object, not attaching messier plot."
+            )
+
+        # Attach the multipart/related part to the multipart/alternative part
+        msg_root.attach(msg_related)
+
+        return self._send_email(msg_root)  # Use the internal helper
+
+
     @staticmethod
     def attach_image(message, plot, filename="image.png"):
         """Attaches a plot image to the email message for inline display."""
-        if plot is None: # Check if plot object itself is None
+        if plot is None:  # Check if plot object itself is None
             logger.warning(f"Plot object for {filename} is None. Skipping attachment.")
             return
 
-        plot_bytes = Utils.plot_to_bytes(plot) 
+        plot_bytes = Utils.plot_to_bytes(plot)
         if plot_bytes is None:
-            logger.warning(f"plot_to_bytes returned None for {filename}. Skipping attachment.")
+            logger.warning(
+                f"plot_to_bytes returned None for {filename}. Skipping attachment."
+            )
             return
 
         try:
-            img_data = plot_bytes.getvalue() if hasattr(plot_bytes, 'getvalue') else plot_bytes.read()
+            img_data = (
+                plot_bytes.getvalue()
+                if hasattr(plot_bytes, "getvalue")
+                else plot_bytes.read()
+            )
 
             if not img_data:
-                logger.warning(f"Image data is empty for {filename} after plot_to_bytes. Skipping attachment.")
+                logger.warning(
+                    f"Image data is empty for {filename} after plot_to_bytes. Skipping attachment."
+                )
                 return
-            
+
             image = MIMEImage(img_data)
-            image.add_header('Content-ID', f'<{filename}>') 
-            image.add_header('Content-Disposition', 'inline', filename=filename)
+            image.add_header("Content-ID", f"<{filename}>")
+            image.add_header("Content-Disposition", "inline", filename=filename)
             message.attach(image)
             logger.info(f"Attached inline image {filename} with CID <{filename}>")
         except Exception as e:
-            logger.error(f"Failed to create or attach MIMEImage for {filename}: {e}", exc_info=True)
+            logger.error(
+                f"Failed to create or attach MIMEImage for {filename}: {e}",
+                exc_info=True,
+            )
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
Extract common SMTP sending logic into an internal helper method (`_send_email`). This allows adding a new public method `send_simple_email` for basic notifications while reusing the sending logic for the existing complex notification method.