### PR TITLE
Add Binoculars

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: "3.13"
     - name: Install dependencies
       run: |
-        sudo rm /var/lib/apt/lists/*
+        sudo rm -rd /var/lib/apt/lists/*
         sudo apt update
         sudo apt install libcairo2-dev pkg-config python3-dev
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: "3.13"
     - name: Install dependencies
       run: |
+        sudo rm /var/lib/apt/lists/*
+        sudo apt update
         sudo apt install libcairo2-dev pkg-config python3-dev
         python -m pip install --upgrade pip
         pip install flake8 pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,8 +25,6 @@ jobs:
         python-version: "3.13"
     - name: Install dependencies
       run: |
-        sudo rm -rd /var/lib/apt/lists/*
-        sudo apt update
         sudo apt install libcairo2-dev pkg-config python3-dev
         python -m pip install --upgrade pip
         pip install flake8 pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: "3.13"
     - name: Install dependencies
       run: |
+        sudo rm -rd /var/lib/apt/lists/*
+        sudo apt update
         sudo apt install libcairo2-dev pkg-config python3-dev
         python -m pip install --upgrade pip
         pip install flake8 pytest

--- a/apts/__init__.py
+++ b/apts/__init__.py
@@ -59,4 +59,4 @@ except ValueError:
 # Disable label trimming in pandas tables
 pd.set_option("display.max_colwidth", None)
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/apts/constants/graphconstants.py
+++ b/apts/constants/graphconstants.py
@@ -6,6 +6,7 @@ class OpticalType(Enum):
   INPUT = auto()
   OUTPUT = auto()
   GENERIC = auto()
+  BINOCULARS = auto()
 
 
 class GraphConstants:
@@ -17,5 +18,6 @@ class GraphConstants:
     OpticalType.GENERIC: "#FFFF00",
     OpticalType.INPUT: "#D3D3D3",
     OpticalType.OPTICAL: "#4B0082",
-    OpticalType.OUTPUT: "#A9A9A9"
+    OpticalType.OUTPUT: "#A9A9A9",
+    OpticalType.BINOCULARS: "#00FF00"  # Green for Binoculars
   }

--- a/apts/equipment.py
+++ b/apts/equipment.py
@@ -57,88 +57,92 @@ class Equipment:
     return result
 
   def data(self) -> pd.DataFrame:
-    columns = [EquipmentTableLabels.LABEL,
-               EquipmentTableLabels.TYPE,
-               EquipmentTableLabels.ZOOM,
-               EquipmentTableLabels.USEFUL_ZOOM,
-               EquipmentTableLabels.FOV,
-               EquipmentTableLabels.EXIT_PUPIL,
-               EquipmentTableLabels.DAWES_LIMIT,
-               EquipmentTableLabels.RANGE,
-               EquipmentTableLabels.BRIGHTNESS,
-               EquipmentTableLabels.ELEMENTS]
+    columns = [
+        EquipmentTableLabels.LABEL,
+        EquipmentTableLabels.TYPE,
+        EquipmentTableLabels.ZOOM,
+        EquipmentTableLabels.USEFUL_ZOOM,
+        EquipmentTableLabels.FOV,
+        EquipmentTableLabels.EXIT_PUPIL,
+        EquipmentTableLabels.DAWES_LIMIT,
+        EquipmentTableLabels.RANGE,
+        EquipmentTableLabels.BRIGHTNESS,
+        EquipmentTableLabels.ELEMENTS
+    ]
+
+    # Import Binoculars here to keep it local to where it's used for isinstance
+    # and avoid potential circular imports if Binoculars ever needed Equipment.
+    from .opticalequipment.binoculars import Binoculars
 
     def append(result_data, paths):
-            rows = []
-            logging.debug(f"Appending paths {paths}") # Corrected f-string
-            for path in paths:
-                # path.telescope is the main optic (telescope or binoculars)
-                # path.output is the final element (eyepiece, camera, or binoculars itself)
+        rows = []
+        logging.debug(f"Appending paths {paths}")
+        for path in paths:
+            # path.telescope is the main optic (telescope or binoculars)
+            # path.output is the final element (eyepiece, camera, or binoculars itself)
 
-                # Determine if the main optic is Binoculars
-                is_binoculars = isinstance(path.telescope, Binoculars)
+            # Determine if the main optic is Binoculars
+            is_binoculars = isinstance(path.telescope, Binoculars)
 
-                # Calculate useful_zoom
-                useful_zoom_value = True # Default for binoculars
-                if not is_binoculars:
-                    if hasattr(path.telescope, 'max_useful_zoom'):
-                        # max_useful_zoom() on Telescope returns a float, zoom() is a Quantity
-                        useful_zoom_value = path.zoom().magnitude < path.telescope.max_useful_zoom()
-                    else:
-                        useful_zoom_value = False # Should not happen for Telescope objects
-
-                # Get output type. For Binoculars, path.output is the Binocular instance.
-                output_type_value = path.output.output_type()
-
-                # Calculate Exit Pupil
-                # path.exit_pupil() now returns a Quantity (e.g., mm)
-                exit_pupil_value = path.exit_pupil().to('mm').magnitude
-                if exit_pupil_value < 0: # Guard against potential negative values
-                    exit_pupil_value = 0
-
-                rows.append([path.label(),
-                            output_type_value,
-                            path.zoom().magnitude,
-                            useful_zoom_value,
-                            path.fov().magnitude,
-                            exit_pupil_value,
-                            path.telescope.dawes_limit().magnitude, # dawes_limit() in Binoculars/Telescope returns Quantity
-                            path.telescope.limiting_magnitude(),    # limiting_magnitude() in Binoculars/Telescope returns float/int
-                            path.brightness().magnitude, # brightness() in OpticalPath returns Quantity
-                            path.length()]) # length() in OpticalPath returns int
-
-            if rows:
-                new_data = pd.DataFrame(rows, columns=columns)
-                if result_data.empty:
-                    result_data = new_data
+            # Calculate useful_zoom
+            useful_zoom_value = True # Default for binoculars
+            if not is_binoculars:
+                if hasattr(path.telescope, 'max_useful_zoom'):
+                    # max_useful_zoom() on Telescope returns a float, zoom() is a Quantity
+                    useful_zoom_value = path.zoom().magnitude < path.telescope.max_useful_zoom()
                 else:
-                    for col in result_data.columns:
-                        if result_data[col].dtype != new_data[col].dtype:
-                            # Try to convert new_data's column to result_data's dtype if they are compatible
-                            try:
-                                new_data[col] = new_data[col].astype(result_data[col].dtype)
-                            except Exception as e:
-                                logging.warning(f"Could not align dtype for column {col}: {e}. This might lead to concat issues.")
-                    result_data = pd.concat([result_data, new_data], ignore_index=True)
-            return result_data
+                    useful_zoom_value = False # Should not happen for Telescope objects
 
-        # Import Binoculars for the isinstance check
-        from .opticalequipment.binoculars import Binoculars
+            # Get output type. For Binoculars, path.output is the Binocular instance.
+            output_type_value = path.output.output_type()
 
-        result = pd.DataFrame(columns=columns)
-        result = append(result, self._get_paths(GraphConstants.EYE_ID))
-        result = append(result, self._get_paths(GraphConstants.IMAGE_ID))
+            # Calculate Exit Pupil
+            # path.exit_pupil() now returns a Quantity (e.g., mm)
+            exit_pupil_value = path.exit_pupil().to('mm').magnitude
+            if exit_pupil_value < 0: # Guard against potential negative values
+                exit_pupil_value = 0
 
-        # Add ID column as first
-        if not result.empty: # Only add ID if DataFrame is not empty
-            result['ID'] = result.index
-            result = result[['ID'] + columns]
-        else: # If empty, ensure ID column exists for consistency if expected by other code
-            result['ID'] = [] # Initialize with empty list or appropriate empty type for ID
-            result = result[['ID'] + columns]
+            rows.append([
+                path.label(),
+                output_type_value,
+                path.zoom().magnitude,
+                useful_zoom_value,
+                path.fov().magnitude,
+                exit_pupil_value,
+                path.telescope.dawes_limit().magnitude, # dawes_limit() in Binoculars/Telescope returns Quantity
+                path.telescope.limiting_magnitude(),    # limiting_magnitude() in Binoculars/Telescope returns float/int
+                path.brightness().magnitude, # brightness() in OpticalPath returns Quantity
+                path.length() # length() in OpticalPath returns int
+            ])
 
+        if rows:
+            new_data = pd.DataFrame(rows, columns=columns)
+            if result_data.empty:
+                result_data = new_data
+            else:
+                for col in result_data.columns:
+                    if result_data[col].dtype != new_data[col].dtype:
+                        # Try to convert new_data's column to result_data's dtype if they are compatible
+                        try:
+                            new_data[col] = new_data[col].astype(result_data[col].dtype)
+                        except Exception as e:
+                            logging.warning(f"Could not align dtype for column {col}: {e}. This might lead to concat issues.")
+                result_data = pd.concat([result_data, new_data], ignore_index=True)
+        return result_data
 
-        return result
+    result = pd.DataFrame(columns=columns)
+    result = append(result, self._get_paths(GraphConstants.EYE_ID))
+    result = append(result, self._get_paths(GraphConstants.IMAGE_ID))
+
+    # Add ID column as first
+    if not result.empty: # Only add ID if DataFrame is not empty
+        result['ID'] = result.index
+        result = result[['ID'] + columns]
+    else: # If empty, ensure ID column exists for consistency if expected by other code
+        result['ID'] = [] # Initialize with empty list or appropriate empty type for ID
+        result = result[['ID'] + columns]
+
+    return result
 
   def plot_zoom(self, **args):
     """

--- a/apts/equipment.py
+++ b/apts/equipment.py
@@ -69,38 +69,76 @@ class Equipment:
                EquipmentTableLabels.ELEMENTS]
 
     def append(result_data, paths):
-        rows = []
-        logging.debug("Appending paths {paths}")
-        for path in paths:
-            rows.append([path.label(),
-                        path.output.output_type(),
-                        path.zoom().magnitude,
-                        path.zoom() < path.telescope.max_useful_zoom(),
-                        path.fov().magnitude,
-                        path.output.focal_length / (path.telescope.focal_ratio() * path.effective_barlow()),
-                        path.telescope.dawes_limit(),
-                        path.telescope.limiting_magnitude(),
-                        path.brightness().magnitude,
-                        path.length()])
+            rows = []
+            logging.debug(f"Appending paths {paths}") # Corrected f-string
+            for path in paths:
+                # path.telescope is the main optic (telescope or binoculars)
+                # path.output is the final element (eyepiece, camera, or binoculars itself)
 
-        if rows:  # Only create and concatenate if there are rows to add
-            new_data = pd.DataFrame(rows, columns=columns)
-            if result_data.empty:
-                result_data = new_data
-            else:
-                # Ensure dtypes match before concatenation
-                for col in result_data.columns:
-                    new_data[col] = new_data[col].astype(result_data[col].dtype)
-                result_data = pd.concat([result_data, new_data], ignore_index=True)
-        return result_data
+                # Determine if the main optic is Binoculars
+                is_binoculars = isinstance(path.telescope, Binoculars)
+
+                # Calculate useful_zoom
+                useful_zoom_value = True # Default for binoculars
+                if not is_binoculars:
+                    if hasattr(path.telescope, 'max_useful_zoom'):
+                        # max_useful_zoom() on Telescope returns a float, zoom() is a Quantity
+                        useful_zoom_value = path.zoom().magnitude < path.telescope.max_useful_zoom()
+                    else:
+                        useful_zoom_value = False # Should not happen for Telescope objects
+
+                # Get output type. For Binoculars, path.output is the Binocular instance.
+                output_type_value = path.output.output_type()
+
+                # Calculate Exit Pupil
+                # path.exit_pupil() now returns a Quantity (e.g., mm)
+                exit_pupil_value = path.exit_pupil().to('mm').magnitude
+                if exit_pupil_value < 0: # Guard against potential negative values
+                    exit_pupil_value = 0
+
+                rows.append([path.label(),
+                            output_type_value,
+                            path.zoom().magnitude,
+                            useful_zoom_value,
+                            path.fov().magnitude,
+                            exit_pupil_value,
+                            path.telescope.dawes_limit().magnitude, # dawes_limit() in Binoculars/Telescope returns Quantity
+                            path.telescope.limiting_magnitude(),    # limiting_magnitude() in Binoculars/Telescope returns float/int
+                            path.brightness().magnitude, # brightness() in OpticalPath returns Quantity
+                            path.length()]) # length() in OpticalPath returns int
+
+            if rows:
+                new_data = pd.DataFrame(rows, columns=columns)
+                if result_data.empty:
+                    result_data = new_data
+                else:
+                    for col in result_data.columns:
+                        if result_data[col].dtype != new_data[col].dtype:
+                            # Try to convert new_data's column to result_data's dtype if they are compatible
+                            try:
+                                new_data[col] = new_data[col].astype(result_data[col].dtype)
+                            except Exception as e:
+                                logging.warning(f"Could not align dtype for column {col}: {e}. This might lead to concat issues.")
+                    result_data = pd.concat([result_data, new_data], ignore_index=True)
+            return result_data
+
+        # Import Binoculars for the isinstance check
+        from .opticalequipment.binoculars import Binoculars
+
+        result = pd.DataFrame(columns=columns)
+        result = append(result, self._get_paths(GraphConstants.EYE_ID))
+        result = append(result, self._get_paths(GraphConstants.IMAGE_ID))
+
+        # Add ID column as first
+        if not result.empty: # Only add ID if DataFrame is not empty
+            result['ID'] = result.index
+            result = result[['ID'] + columns]
+        else: # If empty, ensure ID column exists for consistency if expected by other code
+            result['ID'] = [] # Initialize with empty list or appropriate empty type for ID
+            result = result[['ID'] + columns]
 
 
-    result = pd.DataFrame(columns=columns)
-    result = append(result, self._get_paths(GraphConstants.EYE_ID))
-    result = append(result, self._get_paths(GraphConstants.IMAGE_ID))
-    # Add ID column as first
-    result['ID'] = result.index
-    return result[['ID'] + columns]
+        return result
 
   def plot_zoom(self, **args):
     """

--- a/apts/opticalequipment/__init__.py
+++ b/apts/opticalequipment/__init__.py
@@ -3,7 +3,8 @@ from .telescope import Telescope
 from .camera import Camera
 from .eyepiece import Eyepiece
 from .abstract import OpticalEquipment
+from .binoculars import Binoculars
 
-__all__ = ['Barlow', 'Telescope', 'Camera', 'Eyepiece', 'OpticalEquipment']
+__all__ = ['Barlow', 'Telescope', 'Camera', 'Eyepiece', 'OpticalEquipment', 'Binoculars']
 
 __version__ = '0.1.0'

--- a/apts/opticalequipment/binoculars.py
+++ b/apts/opticalequipment/binoculars.py
@@ -1,0 +1,82 @@
+from ..constants import OpticalType, GraphConstants
+from ..utils import ureg
+from .abstract import OpticalEquipment
+
+class Binoculars(OpticalEquipment):
+    """
+    Class representing binoculars
+    """
+
+    def __init__(self, magnification, objective_diameter, vendor, apparent_fov_deg, focal_length=1):
+        # Call grandparent's init (OpticalEquipment)
+        # We use a nominal focal_length (e.g., 1mm) because it's required by OpticalEquipment,
+        # but not really used in the traditional sense for optical train calculations with binoculars.
+        super().__init__(focal_length=focal_length, vendor=vendor)
+
+        self.magnification = magnification
+        self.objective_diameter = objective_diameter * ureg.mm
+        self.apparent_fov_deg = apparent_fov_deg * ureg.deg
+        self._type = OpticalType.BINOCULARS
+
+    def get_name(self):
+        return "Binoculars"
+
+    def __str__(self):
+        # Format: <vendor> <magnification>x<objective_diameter>
+        return f"{self.vendor} {self.magnification}x{self.objective_diameter.to('mm').magnitude:.0f}"
+
+    def fov(self):
+        # True Field of View = Apparent FOV / Magnification
+        return self.apparent_fov_deg / self.magnification
+
+    def exit_pupil(self):
+        return self.objective_diameter / self.magnification
+
+    def dawes_limit(self):
+        """
+        Calculate the maximum resolving power using the Dawes' Limit formula.
+        :return: limit in arcsecond
+        """
+        return round((11.6 / self.objective_diameter.to('cm')).magnitude, 3) * ureg.arcsecond
+
+    def rayleigh_limit(self):
+        """
+        Calculate the maximum resolving power using the Rayleigh Limit formula.
+        :return: limit in arcsecond
+        """
+        return round((13.8 / self.objective_diameter.to('cm')).magnitude, 3) * ureg.arcsecond
+
+    def limiting_magnitude(self):
+        """
+        Calculate approximate limiting magnitude.
+        :return: range in magnitude
+        """
+        # Using the same formula as Telescope, based on aperture (objective_diameter for binoculars)
+        import numpy
+        return 7.7 + 5 * numpy.log10(self.objective_diameter.to('cm').magnitude)
+
+    def brightness(self):
+        # Relative brightness: (Exit Pupil (mm) / 7mm)^2 * 100
+        # Assuming 7mm is the max human eye pupil diameter
+        return (self.exit_pupil().to('mm').magnitude / 7) ** 2 * 100
+
+
+    def register(self, equipment):
+        """
+        Register binoculars in the optical equipment graph.
+        Binoculars connect directly from SPACE to EYE.
+        """
+        # Add binocular node
+        super()._register(equipment)
+        # Connect binocular node to space node
+        equipment.add_edge(GraphConstants.SPACE_ID, self.id())
+        # Connect binocular node to eye node
+        equipment.add_edge(self.id(), GraphConstants.EYE_ID)
+
+    def output_type(self):
+        # Describes the type of view produced, similar to Eyepiece or Camera
+        return "Visual" # Or a more specific enum/constant if available
+
+    def max_useful_zoom(self):
+        # For binoculars, their own magnification is effectively the max useful zoom
+        return self.magnification

--- a/apts/optics.py
+++ b/apts/optics.py
@@ -1,13 +1,21 @@
 import functools
 import operator
+from .opticalequipment.binoculars import Binoculars
+from .utils import ureg
 
 
 class OpticsUtils:
 
   @staticmethod
   def expand(path):
-    # First item in the path should be the telescope
-    telescope = path[0]
+    # First item in the path should be the telescope or binoculars
+    main_optic = path[0]
+    if isinstance(main_optic, Binoculars):
+        # Treat binoculars as the 'output' as well for path structure consistency
+        return (main_optic, [], main_optic)
+
+    # Original logic for telescopes
+    telescope = main_optic
     # Last item in the path is output
     output = path[-1]
     # Barlow lenses are in the middle
@@ -22,11 +30,19 @@ class OpticsUtils:
 
   @staticmethod
   def compute_zoom(telescope, barlows, output):
+    if isinstance(telescope, Binoculars):
+        return telescope.magnification * ureg.dimensionless
+
+    # Original logic
     magnification = OpticsUtils.barlows_multiplications(barlows)
     return telescope.focal_length * magnification / output._zoom_divider()
 
   @staticmethod
   def compute_field_of_view(telescope, barlows, output):
+    if isinstance(telescope, Binoculars):
+        return telescope.fov()
+
+    # Original logic
     magnification = OpticsUtils.barlows_multiplications(barlows)
     zoom = OpticsUtils.compute_zoom(telescope, barlows, output)
     # TODO: this is not best way to do it
@@ -55,16 +71,48 @@ class OpticalPath:
     return OpticsUtils.barlows_multiplications(self.barlows)
 
   def label(self):
+    if isinstance(self.telescope, Binoculars):
+        return str(self.telescope)
     return ", ".join([str(self.telescope)] + [str(item) for item in self.barlows] + [str(self.output)])
 
   def length(self):
+    # For binoculars, path is [Binoculars], expanded to (Binoculars, [], Binoculars)
+    # So self.barlows is []. Length should be 1 for a direct binocular path.
+    # Original: return 2 + len(self.barlows) (Telescope + Output + Barlows)
+    if isinstance(self.telescope, Binoculars):
+        return 1 # Just the binoculars itself
     return 2 + len(self.barlows)
+
 
   def fov(self):
     return OpticsUtils.compute_field_of_view(self.telescope, self.barlows, self.output)
 
   def brightness(self):
+    if isinstance(self.telescope, Binoculars):
+        # self.telescope.brightness() returns a float like 75.0 (for 75%)
+        # OutputOpticalEquipment.brightness returns a value like <Quantity(75.0, 'dimensionless')>
+        # To be consistent so that .magnitude can be called later:
+        return self.telescope.brightness() * ureg.dimensionless
+    # This already returns a pint Quantity from OutputOpticalEquipment's method
     return self.output.brightness(self.telescope, self.zoom())
+
+  def exit_pupil(self):
+      if isinstance(self.telescope, Binoculars):
+          return self.telescope.exit_pupil() # This returns a Quantity
+
+      # Original logic for telescopes:
+      # telescope.aperture should be a Quantity (e.g., mm)
+      # self.zoom() returns a dimensionless Quantity
+      # The result will be in units of aperture (e.g., mm)
+      if hasattr(self.telescope, 'aperture'):
+          zoom_value = self.zoom()
+          if zoom_value.magnitude == 0: # Avoid division by zero
+              return 0 * ureg.mm
+          return self.telescope.aperture / zoom_value
+
+      # If it's not Binoculars and telescope has no aperture (should not happen for Telescopes)
+      # return a zero quantity to avoid crashes, though this indicates a data problem.
+      return 0 * ureg.mm
 
   def elements(self):
     """

--- a/docs/source/apts.rst
+++ b/docs/source/apts.rst
@@ -28,6 +28,14 @@ apts\.optics module
     :undoc-members:
     :show-inheritance:
 
+apts\.opticalequipment module
+-----------------------------
+
+.. automodule:: apts.opticalequipment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 apts\.utils module
 ------------------
 

--- a/tests/equipment_test.py
+++ b/tests/equipment_test.py
@@ -1,8 +1,10 @@
 import pytest
+import numpy as np # Added for np.log10
 
 from apts import equipment
-from apts.constants import EquipmentTableLabels
-from apts.opticalequipment import Barlow
+from apts.constants import EquipmentTableLabels, GraphConstants # Added GraphConstants
+from apts.opticalequipment import Barlow, Binoculars # Added Binoculars
+from apts.utils import ureg # Added ureg
 from . import setup_equipment
 
 
@@ -57,3 +59,137 @@ def test_camera():
 def test_telecsope():
   t = equipment.Telescope(150, 750)
   assert t.dawes_limit().magnitude == pytest.approx(0.773, 0.001)
+
+# --- Binocular Tests ---
+
+def test_binoculars_instantiation():
+    bino = Binoculars(
+        magnification=10,
+        objective_diameter=50,
+        vendor="TestBino",
+        apparent_fov_deg=65,
+        focal_length=1 # Nominal
+    )
+    assert bino.magnification == 10
+    assert bino.objective_diameter.magnitude == 50
+    assert bino.objective_diameter.units == ureg.mm
+    assert bino.vendor == "TestBino"
+    assert bino.apparent_fov_deg.magnitude == 65
+    assert bino.apparent_fov_deg.units == ureg.deg
+    assert str(bino) == "TestBino 10x50"
+    assert bino.fov().magnitude == pytest.approx(6.5) # 65/10
+    assert bino.fov().units == ureg.deg
+    assert bino.exit_pupil().magnitude == pytest.approx(5) # 50/10
+    assert bino.exit_pupil().units == ureg.mm
+    assert bino.dawes_limit().magnitude == pytest.approx(11.6 / 5.0) # 11.6 / 5.0 cm = 2.32
+    assert bino.rayleigh_limit().magnitude == pytest.approx(13.8 / 5.0) # 13.8 / 5.0 cm = 2.76
+    # limiting_magnitude: 7.7 + 5 * log10(objective_diameter_cm) = 7.7 + 5 * log10(5.0)
+    assert bino.limiting_magnitude() == pytest.approx(7.7 + 5 * np.log10(5.0), abs=1e-3)
+    assert bino.brightness() == pytest.approx((5.0/7.0)**2 * 100) # (exit_pupil_mm / 7)^2 * 100
+    assert bino.output_type() == "Visual"
+    assert bino.max_useful_zoom() == 10
+
+def test_binoculars_registration_and_graph():
+    eq = equipment.Equipment() # Fresh equipment instance
+    bino = Binoculars(magnification=10, objective_diameter=50, vendor="TestBino", apparent_fov_deg=65)
+    eq.register(bino)
+
+    # Check graph connections
+    # 1. Binoculars node exists
+    bino_node_id_in_graph = None
+    for v in eq.connection_garph.vs:
+        if v[equipment.NodeLabels.EQUIPMENT] == bino: # equipment.NodeLabels should work
+            bino_node_id_in_graph = v[equipment.NodeLabels.NAME]
+            break
+    assert bino_node_id_in_graph is not None, "Binoculars node not found in graph"
+
+    # 2. Connected from SPACE
+    space_node = eq.connection_garph.vs.find(name=GraphConstants.SPACE_ID)
+    bino_vertex_index = eq.connection_garph.vs.find(name=bino_node_id_in_graph).index
+    assert eq.connection_garph.are_adjacent(space_node.index, bino_vertex_index), \
+        "Binoculars not connected from SPACE"
+
+    # 3. Connected to EYE
+    eye_node = eq.connection_garph.vs.find(name=GraphConstants.EYE_ID)
+    assert eq.connection_garph.are_adjacent(bino_vertex_index, eye_node.index), \
+        "Binoculars not connected to EYE"
+
+    # 4. Ensure no input/output connection points were created for binoculars
+    bino_internal_id = bino.id() # The ID of the equipment itself
+    for v_node in eq.connection_garph.vs:
+        node_name = v_node[equipment.NodeLabels.NAME]
+        if node_name.startswith(bino_internal_id + "_") and \
+           (node_name.endswith("_IN") or node_name.endswith("_OUT")):
+            pytest.fail(f"Binoculars created an unexpected connection node: {node_name}")
+
+
+def test_binoculars_in_equipment_data():
+    eq = equipment.Equipment()
+    bino = Binoculars(
+        magnification=8,
+        objective_diameter=42,
+        vendor="TestBino8x42",
+        apparent_fov_deg=60
+    )
+    eq.register(bino)
+
+    data_df = eq.data()
+
+    assert len(data_df) == 1, f"Expected 1 optical path for binoculars, got {len(data_df)}"
+
+    bino_row = data_df.iloc[0]
+
+    assert bino_row[EquipmentTableLabels.LABEL] == "TestBino8x42 8x42"
+    assert bino_row[EquipmentTableLabels.TYPE] == "Visual"
+    assert bino_row[EquipmentTableLabels.ZOOM] == pytest.approx(8)
+    assert bino_row[EquipmentTableLabels.USEFUL_ZOOM] is True
+    assert bino_row[EquipmentTableLabels.FOV] == pytest.approx(60 / 8) # 7.5
+
+    expected_exit_pupil = 42.0 / 8.0  # 5.25
+    assert bino_row[EquipmentTableLabels.EXIT_PUPIL] == pytest.approx(expected_exit_pupil)
+
+    expected_dawes = 11.6 / 4.2 # Dawes: 11.6 / 4.2cm
+    assert bino_row[EquipmentTableLabels.DAWES_LIMIT] == pytest.approx(expected_dawes)
+
+    expected_range = 7.7 + 5 * np.log10(4.2) # Range: 7.7 + 5 * log10(4.2cm)
+    assert bino_row[EquipmentTableLabels.RANGE] == pytest.approx(expected_range)
+
+    expected_brightness = (expected_exit_pupil / 7.0)**2 * 100 # Brightness: (5.25mm / 7mm)^2 * 100
+    assert bino_row[EquipmentTableLabels.BRIGHTNESS] == pytest.approx(expected_brightness)
+
+    assert bino_row[EquipmentTableLabels.ELEMENTS] == 1
+
+def test_binoculars_do_not_connect_with_telescope_equipment():
+    eq = setup_equipment()
+
+    bino = Binoculars(magnification=10, objective_diameter=50, vendor="TestBino", apparent_fov_deg=65)
+    eq.register(bino)
+
+    data_df = eq.data()
+
+    found_bino_only_path = False
+    found_tele_eyepiece_path = False
+
+    # These checks assume setup_equipment() creates a telescope "SkyWatcher" and an eyepiece "Plossl"
+    # and that these result in one or more paths.
+    # If setup_equipment() changes, these string checks might need adjustment.
+    for index, row in data_df.iterrows():
+        label = row[EquipmentTableLabels.LABEL]
+        elements = row[EquipmentTableLabels.ELEMENTS]
+
+        if "TestBino" in label:
+            assert elements == 1, f"Binocular path '{label}' should have 1 element, got {elements}"
+            assert "SkyWatcher" not in label, "Binocular path should not include Telescope parts"
+            assert "Plossl" not in label, "Binocular path should not include Eyepiece parts"
+            found_bino_only_path = True
+        elif "SkyWatcher" in label and ("Plossl" in label or elements > 1) : # Making it more robust if eyepiece name changes
+            # Assuming a telescope path will have more than 1 element (telescope + eyepiece/camera)
+            assert elements > 1, f"Telescope path '{label}' should have more than 1 element, got {elements}"
+            assert "TestBino" not in label, "Telescope path should not include Binocular parts"
+            found_tele_eyepiece_path = True
+
+    assert found_bino_only_path, "Did not find a dedicated optical path for binoculars"
+    assert found_tele_eyepiece_path, "Did not find the original telescope path from setup_equipment"
+
+    bino_paths_count = sum(["TestBino" in label for label in data_df[EquipmentTableLabels.LABEL]])
+    assert bino_paths_count == 1, "Expected exactly one path containing the TestBino"

--- a/tests/equipment_test.py
+++ b/tests/equipment_test.py
@@ -148,7 +148,7 @@ def test_binoculars_in_equipment_data():
     expected_exit_pupil = 42.0 / 8.0  # 5.25
     assert bino_row[EquipmentTableLabels.EXIT_PUPIL] == pytest.approx(expected_exit_pupil)
 
-    expected_dawes = 11.6 / 4.2 # Dawes: 11.6 / 4.2cm
+    expected_dawes = round(11.6 / 4.2, 3) # Dawes: 11.6 / 4.2cm, rounded to 3 decimal places
     assert bino_row[EquipmentTableLabels.DAWES_LIMIT] == pytest.approx(expected_dawes)
 
     expected_range = 7.7 + 5 * np.log10(4.2) # Range: 7.7 + 5 * log10(4.2cm)

--- a/tests/equipment_test.py
+++ b/tests/equipment_test.py
@@ -142,7 +142,7 @@ def test_binoculars_in_equipment_data():
     assert bino_row[EquipmentTableLabels.LABEL] == "TestBino8x42 8x42"
     assert bino_row[EquipmentTableLabels.TYPE] == "Visual"
     assert bino_row[EquipmentTableLabels.ZOOM] == pytest.approx(8)
-    assert bino_row[EquipmentTableLabels.USEFUL_ZOOM] is True
+    assert bino_row[EquipmentTableLabels.USEFUL_ZOOM] == True
     assert bino_row[EquipmentTableLabels.FOV] == pytest.approx(60 / 8) # 7.5
 
     expected_exit_pupil = 42.0 / 8.0  # 5.25
@@ -179,10 +179,10 @@ def test_binoculars_do_not_connect_with_telescope_equipment():
 
         if "TestBino" in label:
             assert elements == 1, f"Binocular path '{label}' should have 1 element, got {elements}"
-            assert "SkyWatcher" not in label, "Binocular path should not include Telescope parts"
-            assert "Plossl" not in label, "Binocular path should not include Eyepiece parts"
+            assert "unknown telescope 150/750" not in label, "Binocular path should not include Telescope parts"
+            assert "unknown ocular f=25" not in label, "Binocular path should not include Eyepiece parts"
             found_bino_only_path = True
-        elif "SkyWatcher" in label and ("Plossl" in label or elements > 1) : # Making it more robust if eyepiece name changes
+        elif "unknown telescope 150/750" in label and "unknown ocular f=25" in label:
             # Assuming a telescope path will have more than 1 element (telescope + eyepiece/camera)
             assert elements > 1, f"Telescope path '{label}' should have more than 1 element, got {elements}"
             assert "TestBino" not in label, "Telescope path should not include Binocular parts"


### PR DESCRIPTION
feat: Add support for binoculars as new optical equipment

This commit introduces support for binoculars as a distinct type of optical equipment.

Key changes include:
- A new `Binoculars` class in `apts.opticalequipment.binoculars` with specific attributes (magnification, objective diameter, apparent FOV) and methods for optical calculations (actual FOV, exit pupil, Dawes' limit, limiting magnitude, brightness).
- Binoculars register in the equipment graph by connecting directly from SPACE to EYE, without intermediate connection points for other optical elements.
- Modifications to `apts.optics.OpticalPath` and `apts.optics.OpticsUtils` to correctly identify and process optical paths involving only binoculars, ensuring that calculations for zoom, FOV, brightness, exit pupil, and path length are handled appropriately.
- Updates to `apts.equipment.Equipment.data()` to accurately represent binoculars in the output DataFrame, including new logic for 'useful zoom' (always true for binoculars) and 'output type'.
- Addition of `OpticalType.BINOCULARS` to constants.
- Comprehensive unit tests in `tests/equipment_test.py` covering instantiation, graph registration, data table representation, and ensuring binoculars do not incorrectly combine with other equipment.
- Inclusion of the `apts.opticalequipment` module in Sphinx documentation via `apts.rst`.