### PR TITLE
A fix to how camera brightness is displayed in the equipment data.

### DIFF
--- a/apts/opticalequipment/abstract.py
+++ b/apts/opticalequipment/abstract.py
@@ -1,4 +1,5 @@
 import uuid
+import numpy as np # For np.nan
 
 from ..constants import OpticalType
 from ..utils import ConnectionType, ureg
@@ -70,8 +71,58 @@ class OutputOpticalEqipment(OpticalEquipment):
   def __init__(self, focal_length, vendor):
     super(OutputOpticalEqipment, self).__init__(focal_length, vendor)
 
+  def is_visual_output(self):
+    """Indicates if the output is primarily for visual observation."""
+    return True # Default for eyepieces etc.
+
   def exit_pupil(self, telescop, zoom):
-    return telescop.aperture / zoom
+    # Ensure zoom is not zero and is a Quantity to prevent division by zero or type errors
+    if not hasattr(zoom, 'magnitude') or zoom.magnitude == 0:
+        # Return a zero Quantity or NaN Quantity if zoom is invalid
+        # For exit pupil calculation, perhaps a large value or NaN is more appropriate
+        # to indicate an issue, as zero exit pupil is physically unlikely with valid zoom.
+        # However, to prevent issues in brightness, let's ensure it results in zero/NaN brightness.
+        # Let's return a value that would lead to zero or NaN brightness.
+        # A very large number for zoom would make exit pupil very small.
+        # Or, more directly, handle this in brightness.
+        # For now, let's assume zoom is valid if it's not zero.
+        # The original code didn't have this check, let's proceed with caution.
+        # If zoom can be non-Quantity, that's another issue. For now, assume it's a Quantity.
+        return telescop.aperture / zoom # This line remains, but its usage in brightness will be safer.
 
   def brightness(self, telescop, zoom):
-    return (self.exit_pupil(telescop, zoom) / (7 * ureg.mm)) ** 2 * 100
+    if not self.is_visual_output():
+        return np.nan * ureg.dimensionless # Return NaN Quantity
+
+    # Ensure zoom is a Quantity and its magnitude is not zero
+    if not hasattr(zoom, 'magnitude') or not hasattr(zoom, 'units') or zoom.magnitude == 0:
+        return np.nan * ureg.dimensionless # Or 0.0 * ureg.dimensionless if preferred for zero zoom
+
+    ep_val = self.exit_pupil(telescop, zoom)
+
+    # Ensure ep_val is a Quantity (it should be if aperture and zoom are)
+    if not hasattr(ep_val, 'units'):
+        # This case should ideally not be reached if inputs are correct
+        return np.nan * ureg.dimensionless
+
+    # Ensure telescope.aperture is a Quantity with units
+    if not hasattr(telescop.aperture, 'units'):
+        # This indicates an issue with telescope object's aperture
+        return np.nan * ureg.dimensionless
+
+    try:
+        ep_mm = ep_val.to(ureg.mm)
+    except Exception: # Broad exception for any Pint conversion error
+        return np.nan * ureg.dimensionless # Failed to convert exit pupil to mm
+
+    seven_mm = 7 * ureg.mm
+    # seven_mm.magnitude cannot be zero unless ureg.mm is redefined, which is unlikely.
+
+    # Ratio will be dimensionless if ep_mm and seven_mm are compatible (both lengths)
+    # Pint handles unit cancellation automatically.
+    ratio = ep_mm / seven_mm
+
+    # The result of (ratio ** 2) is a dimensionless Quantity.
+    # Multiplying by 100 keeps it a dimensionless Quantity.
+    # Ensure the result is explicitly dimensionless for safety, though Pint should handle it.
+    return (ratio ** 2) * 100 * ureg.dimensionless

--- a/apts/opticalequipment/camera.py
+++ b/apts/opticalequipment/camera.py
@@ -41,6 +41,9 @@ class Camera(OutputOpticalEqipment):
     # Connect camera with output image node
     equipment.add_edge(self.id(), GraphConstants.IMAGE_ID)
 
+  def is_visual_output(self):
+    return False
+
   def __str__(self):
     # Format: <vendor> <width>x<height>
     return "{} {}x{}".format(self.vendor, self.sensor_width.magnitude, self.sensor_height.magnitude)

--- a/tests/equipment_test.py
+++ b/tests/equipment_test.py
@@ -1,10 +1,11 @@
 import pytest
 import numpy as np # Added for np.log10
+import pandas as pd # Added for DataFrame operations
 
 from apts import equipment
 from apts.constants import EquipmentTableLabels, GraphConstants # Added GraphConstants
-from apts.opticalequipment import Barlow, Binoculars # Added Binoculars
-from apts.utils import ureg # Added ureg
+from apts.opticalequipment import Barlow, Binoculars, Telescope, Camera, Eyepiece # Added Telescope, Camera, Eyepiece
+from apts.utils import ureg, ConnectionType # Added ureg, ConnectionType
 from . import setup_equipment
 
 
@@ -530,3 +531,52 @@ def test_connection_specificity_barlow_no_t2_output_to_t2_camera():
 
     assert not problematic_path_found, \
         f"Path formed with Barlow (no T2 out) to Camera (T2 in): {row[EquipmentTableLabels.LABEL] if problematic_path_found else ''}"
+
+
+# --- Brightness Tests ---
+
+def test_camera_path_brightness_is_nan():
+    """Test that brightness for a camera path is NaN."""
+    eq = equipment.Equipment()
+    # Telescope with T2 output
+    scope_t2 = Telescope(aperture=80, focal_length=400, vendor="TestScopeT2", t2_output=True)
+    # Camera with T2 input (default)
+    cam = Camera(sensor_width=22.2, sensor_height=14.8, width=5184, height=3456, vendor="TestCamT2")
+
+    eq.register(scope_t2)
+    eq.register(cam)
+
+    df = eq.data()
+    assert not df.empty, "Equipment data frame is empty"
+
+    camera_rows = df[df[EquipmentTableLabels.TYPE] == GraphConstants.IMAGE_ID]
+    assert not camera_rows.empty, "No camera output paths found in DataFrame."
+
+    # Check if all brightness values in camera_rows are NaN
+    assert camera_rows[EquipmentTableLabels.BRIGHTNESS].isnull().all(), \
+        f"Brightness for camera paths should be NaN. Got: {camera_rows[EquipmentTableLabels.BRIGHTNESS].values}"
+
+def test_eyepiece_path_brightness_is_numeric():
+    """Test that brightness for an eyepiece path is numeric and non-negative."""
+    eq = equipment.Equipment()
+    # Telescope with default F_1_25 output
+    scope = Telescope(aperture=80, focal_length=400, vendor="TestScopeVisual")
+    # Eyepiece with F_1_25 input
+    ep = Eyepiece(focal_length=10, vendor="TestEPVisual", fov=50, connection_type=ConnectionType.F_1_25)
+
+    eq.register(scope)
+    eq.register(ep)
+
+    df = eq.data()
+    assert not df.empty, "Equipment data frame is empty"
+
+    eyepiece_rows = df[df[EquipmentTableLabels.TYPE] == GraphConstants.EYE_ID]
+    assert not eyepiece_rows.empty, "No eyepiece output paths found in DataFrame."
+
+    # Check that all brightness values are not NaN (i.e., they are numbers)
+    assert eyepiece_rows[EquipmentTableLabels.BRIGHTNESS].notnull().all(), \
+        f"Brightness for eyepiece paths should be a number. Got: {eyepiece_rows[EquipmentTableLabels.BRIGHTNESS].values}"
+
+    # Check that all brightness values are non-negative
+    assert (eyepiece_rows[EquipmentTableLabels.BRIGHTNESS] >= 0).all(), \
+        f"Brightness for eyepiece paths should be non-negative. Got: {eyepiece_rows[EquipmentTableLabels.BRIGHTNESS].values}"


### PR DESCRIPTION
Previously, the brightness calculation was geared towards visual perception (how the exit pupil relates to the human eye). This wasn't suitable for cameras and could sometimes show misleadingly high brightness values for them.

Here's what I've changed in the code:
- I've added a new method called `is_visual_output()` to the `OutputOpticalEqipment` class. By default, it assumes the output is visual, but I've adjusted it in the `Camera` class so it correctly identifies camera output as non-visual.
- Now, when the `brightness()` method in `OutputOpticalEqipment` is called, it first checks if the output is visual using `is_visual_output()`. If it's not (meaning it's a camera), it will return `np.nan * ureg.dimensionless`.
- This change means that for camera paths, you'll now see 'NaN' in the 'BRIGHTNESS' column of the `Equipment.data()` table. This more accurately shows that the visual brightness measurement doesn't apply to cameras.
- Don't worry, the brightness calculation for visual paths (like eyepieces and binoculars) hasn't changed.

I've also added a couple of new test cases to `tests/equipment_test.py` to ensure this works as expected:
- `test_camera_path_brightness_is_nan`: This checks that camera paths correctly display NaN for brightness.
- `test_eyepiece_path_brightness_is_numeric`: This confirms that eyepiece paths continue to show a valid, non-negative number for brightness.