### PR TITLE
Add Moon to planets list

### DIFF
--- a/apts/objects/planets.py
+++ b/apts/objects/planets.py
@@ -24,6 +24,7 @@ class Planets(Objects):
                 ephem.Saturn(),
                 ephem.Uranus(),
                 ephem.Neptune(),
+                ephem.Moon(),
             ],
             columns=[ObjectTableLabels.EPHEM],
         )

--- a/tests/messier_test.py
+++ b/tests/messier_test.py
@@ -47,7 +47,7 @@ def test_visiable_messier():
 def test_visible_planets():
   o = setup_observation()
   p = o.get_visible_planets()
-  assert len(p) == 7
+  assert len(p) == 8
   
   # Check that Name is string type
   assert p["Name"].dtype == "string"


### PR DESCRIPTION
This commit adds the Moon to the list of planets in the `Planets` class. The tests have been updated to reflect this change.