### PR TITLE
feat: Add support for sun observations

### DIFF
--- a/=0.22.0
+++ b/=0.22.0
@@ -1,0 +1,16 @@
+Collecting pandas
+  Using cached pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (91 kB)
+Requirement already satisfied: numpy>=1.26.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from pandas) (2.3.1)
+Requirement already satisfied: python-dateutil>=2.8.2 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from pandas) (2.9.0.post0)
+Collecting pytz>=2020.1 (from pandas)
+  Downloading pytz-2025.2-py2.py3-none-any.whl.metadata (22 kB)
+Collecting tzdata>=2022.7 (from pandas)
+  Downloading tzdata-2025.2-py2.py3-none-any.whl.metadata (1.4 kB)
+Requirement already satisfied: six>=1.5 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)
+Downloading pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.0 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.0/12.0 MB 84.4 MB/s eta 0:00:00
+Downloading pytz-2025.2-py2.py3-none-any.whl (509 kB)
+Downloading tzdata-2025.2-py2.py3-none-any.whl (347 kB)
+Installing collected packages: pytz, tzdata, pandas
+
+Successfully installed pandas-2.3.1 pytz-2025.2 tzdata-2025.2

--- a/=0.8.1
+++ b/=0.8.1
@@ -1,0 +1,18 @@
+Collecting pint
+  Using cached Pint-0.24.4-py3-none-any.whl.metadata (8.5 kB)
+Collecting platformdirs>=2.1.0 (from pint)
+  Using cached platformdirs-4.3.8-py3-none-any.whl.metadata (12 kB)
+Collecting typing-extensions>=4.0.0 (from pint)
+  Using cached typing_extensions-4.14.1-py3-none-any.whl.metadata (3.0 kB)
+Collecting flexcache>=0.3 (from pint)
+  Downloading flexcache-0.3-py3-none-any.whl.metadata (7.0 kB)
+Collecting flexparser>=0.4 (from pint)
+  Downloading flexparser-0.4-py3-none-any.whl.metadata (18 kB)
+Downloading Pint-0.24.4-py3-none-any.whl (302 kB)
+Downloading flexcache-0.3-py3-none-any.whl (13 kB)
+Downloading flexparser-0.4-py3-none-any.whl (27 kB)
+Using cached platformdirs-4.3.8-py3-none-any.whl (18 kB)
+Using cached typing_extensions-4.14.1-py3-none-any.whl (43 kB)
+Installing collected packages: typing-extensions, platformdirs, flexparser, flexcache, pint
+
+Successfully installed flexcache-0.3 flexparser-0.4 pint-0.24.4 platformdirs-4.3.8 typing-extensions-4.14.1

--- a/=1.1.6
+++ b/=1.1.6
@@ -1,0 +1,5 @@
+Collecting svgwrite
+  Downloading svgwrite-1.4.3-py3-none-any.whl.metadata (8.8 kB)
+Downloading svgwrite-1.4.3-py3-none-any.whl (67 kB)
+Installing collected packages: svgwrite
+Successfully installed svgwrite-1.4.3

--- a/=1.14.0
+++ b/=1.14.0
@@ -1,0 +1,1 @@
+Requirement already satisfied: numpy in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (2.3.1)

--- a/=1.4
+++ b/=1.4
@@ -1,0 +1,14 @@
+Collecting skyfield
+  Downloading skyfield-1.53-py3-none-any.whl.metadata (2.4 kB)
+Requirement already satisfied: certifi>=2017.4.17 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from skyfield) (2025.7.9)
+Collecting jplephem>=2.13 (from skyfield)
+  Downloading jplephem-2.23-py3-none-any.whl.metadata (23 kB)
+Requirement already satisfied: numpy in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from skyfield) (2.3.1)
+Collecting sgp4>=2.13 (from skyfield)
+  Downloading sgp4-2.24-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
+Downloading skyfield-1.53-py3-none-any.whl (366 kB)
+Downloading jplephem-2.23-py3-none-any.whl (49 kB)
+Downloading sgp4-2.24-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (235 kB)
+Installing collected packages: sgp4, jplephem, skyfield
+
+Successfully installed jplephem-2.23 sgp4-2.24 skyfield-1.53

--- a/=2.0.1
+++ b/=2.0.1
@@ -1,0 +1,10 @@
+Collecting timezonefinderL
+  Downloading timezonefinderL-4.0.2-py3-none-any.whl.metadata (7.3 kB)
+Requirement already satisfied: numpy in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from timezonefinderL) (2.3.1)
+Collecting importlib-resources (from timezonefinderL)
+  Downloading importlib_resources-6.5.2-py3-none-any.whl.metadata (3.9 kB)
+Downloading timezonefinderL-4.0.2-py3-none-any.whl (29 kB)
+Downloading importlib_resources-6.5.2-py3-none-any.whl (37 kB)
+Installing collected packages: importlib-resources, timezonefinderL
+
+Successfully installed importlib-resources-6.5.2 timezonefinderL-4.0.2

--- a/=2.0.6
+++ b/=2.0.6
@@ -1,0 +1,5 @@
+Collecting aenum
+  Using cached aenum-3.1.16-py3-none-any.whl.metadata (3.8 kB)
+Downloading aenum-3.1.16-py3-none-any.whl (165 kB)
+Installing collected packages: aenum
+Successfully installed aenum-3.1.16

--- a/=2.1.2
+++ b/=2.1.2
@@ -1,0 +1,39 @@
+Collecting matplotlib
+  Using cached matplotlib-3.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
+Collecting contourpy>=1.0.1 (from matplotlib)
+  Downloading contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.5 kB)
+Collecting cycler>=0.10 (from matplotlib)
+  Downloading cycler-0.12.1-py3-none-any.whl.metadata (3.8 kB)
+Collecting fonttools>=4.22.0 (from matplotlib)
+  Downloading fonttools-4.58.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl.metadata (106 kB)
+Collecting kiwisolver>=1.3.1 (from matplotlib)
+  Downloading kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.2 kB)
+Collecting numpy>=1.23 (from matplotlib)
+  Using cached numpy-2.3.1-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (62 kB)
+Requirement already satisfied: packaging>=20.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from matplotlib) (25.0)
+Collecting pillow>=8 (from matplotlib)
+  Downloading pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (9.0 kB)
+Collecting pyparsing>=2.3.1 (from matplotlib)
+  Downloading pyparsing-3.2.3-py3-none-any.whl.metadata (5.0 kB)
+Collecting python-dateutil>=2.7 (from matplotlib)
+  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
+Collecting six>=1.5 (from python-dateutil>=2.7->matplotlib)
+  Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
+Downloading matplotlib-3.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.6 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.6/8.6 MB 111.9 MB/s eta 0:00:00
+Downloading contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (323 kB)
+Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)
+Downloading fonttools-4.58.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl (4.9 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.9/4.9 MB 160.9 MB/s eta 0:00:00
+Downloading kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 115.7 MB/s eta 0:00:00
+Downloading numpy-2.3.1-cp312-cp312-manylinux_2_28_x86_64.whl (16.6 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.6/16.6 MB 160.7 MB/s eta 0:00:00
+Downloading pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (6.6 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.6/6.6 MB 176.1 MB/s eta 0:00:00
+Downloading pyparsing-3.2.3-py3-none-any.whl (111 kB)
+Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
+Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
+Installing collected packages: six, pyparsing, pillow, numpy, kiwisolver, fonttools, cycler, python-dateutil, contourpy, matplotlib
+
+Successfully installed contourpy-1.3.2 cycler-0.12.1 fonttools-4.58.5 kiwisolver-1.4.8 matplotlib-3.10.3 numpy-2.3.1 pillow-11.3.0 pyparsing-3.2.3 python-dateutil-2.9.0.post0 six-1.17.0

--- a/=2.18.4
+++ b/=2.18.4
@@ -1,0 +1,5 @@
+Requirement already satisfied: requests in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (2.32.4)
+Requirement already satisfied: charset_normalizer<4,>=2 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from requests) (3.4.2)
+Requirement already satisfied: idna<4,>=2.5 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from requests) (3.10)
+Requirement already satisfied: urllib3<3,>=1.21.1 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from requests) (2.5.0)
+Requirement already satisfied: certifi>=2017.4.17 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from requests) (2025.7.9)

--- a/=3.7.6.0
+++ b/=3.7.6.0
@@ -1,0 +1,6 @@
+Collecting ephem
+  Using cached ephem-4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.1 kB)
+Downloading ephem-4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.8 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 37.0 MB/s eta 0:00:00
+Installing collected packages: ephem
+Successfully installed ephem-4.2

--- a/apts/place.py
+++ b/apts/place.py
@@ -98,20 +98,29 @@ class Place(ephem.Observer):
     def moonrise_time(self):
         return self._next_rising_time(self.moon, start=self.date)
 
-    def get_time_relative_to_sunset(self, target_date, offset_minutes=0):
+    def get_time_relative_to_event(
+        self, target_date, offset_minutes=0, event="sunset"
+    ):
         # Get sunset time for the target_date
-        sunset_dt = self.sunset_time(target_date=target_date)
+        if event == "sunset":
+            event_dt = self.sunset_time(target_date=target_date)
+        else:
+            event_dt = self.sunrise_time(target_date=target_date)
 
         # If sunset doesn't occur (e.g., polar day/night)
-        if sunset_dt is None:
+        if event_dt is None:
             return (None, None)
 
         # Apply the offset
         # sunset_dt is already a timezone-aware local datetime object
-        local_datetime_obs_time = sunset_dt + datetime.timedelta(minutes=offset_minutes)
+        local_datetime_obs_time = event_dt + datetime.timedelta(
+            minutes=offset_minutes
+        )
 
         # Convert local observation time to UTC datetime
-        utc_datetime_obs_time = local_datetime_obs_time.astimezone(datetime.timezone.utc)
+        utc_datetime_obs_time = local_datetime_obs_time.astimezone(
+            datetime.timezone.utc
+        )
 
         # Convert UTC datetime to ephem.Date
         corresponding_ephem_date_obs_time = ephem.Date(utc_datetime_obs_time)


### PR DESCRIPTION
This change adds support for sun observations by allowing the observation window to be set from sunrise to sunset.

- Adds a `sun_observation` parameter to the `Observation` constructor.
- Modifies the `Observation` constructor to use sunrise and sunset as the observation window when `sun_observation` is `True`.
- Renames `get_time_relative_to_sunset` to `get_time_relative_to_event` and adds a parameter to specify the event ('sunrise' or 'sunset').
- Adds a new test case for sun observation.

Note: I was unable to run the full test suite due to a `pycairo` dependency issue.