### PR TITLE
feat: Add flags to disable event calculations

### DIFF
--- a/apts/config.py
+++ b/apts/config.py
@@ -45,3 +45,16 @@ def get_dark_mode() -> bool:
             "Defaulting to False."
         )
         return False
+
+def get_event_settings() -> dict:
+    """
+    Reads the event settings from the [events] section.
+
+    Returns:
+        dict: A dictionary of event types and their enabled/disabled status.
+    """
+    event_settings = {}
+    if config.has_section('events'):
+        for option in config.options('events'):
+            event_settings[option] = config.getboolean('events', option)
+    return event_settings

--- a/apts/events.py
+++ b/apts/events.py
@@ -4,6 +4,7 @@ from itertools import combinations
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
 import time
+from .config import get_event_settings
 
 logger = logging.getLogger(__name__)
 
@@ -28,22 +29,33 @@ class AstronomicalEvents:
             elevation_m=self.place.elevation,
         )
         self.events = []
+        self.event_settings = get_event_settings()
 
     def get_events(self):
         start_time = time.time()
         with ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(self.calculate_moon_phases),
-                executor.submit(self.calculate_conjunctions),
-                executor.submit(self.calculate_oppositions),
-                executor.submit(self.calculate_meteor_showers),
-                executor.submit(self.calculate_highest_altitudes),
-                executor.submit(self.calculate_lunar_occultations),
-                executor.submit(self.calculate_aphelion_perihelion),
-                executor.submit(self.calculate_moon_apogee_perigee),
-                executor.submit(self.calculate_mercury_inferior_conjunctions),
-                executor.submit(self.calculate_moon_messier_conjunctions),
-            ]
+            futures = []
+            if self.event_settings.get("moon_phases", False):
+                futures.append(executor.submit(self.calculate_moon_phases))
+            if self.event_settings.get("conjunctions", False):
+                futures.append(executor.submit(self.calculate_conjunctions))
+            if self.event_settings.get("oppositions", False):
+                futures.append(executor.submit(self.calculate_oppositions))
+            if self.event_settings.get("meteor_showers", False):
+                futures.append(executor.submit(self.calculate_meteor_showers))
+            if self.event_settings.get("highest_altitudes", False):
+                futures.append(executor.submit(self.calculate_highest_altitudes))
+            if self.event_settings.get("lunar_occultations", False):
+                futures.append(executor.submit(self.calculate_lunar_occultations))
+            if self.event_settings.get("aphelion_perihelion", False):
+                futures.append(executor.submit(self.calculate_aphelion_perihelion))
+            if self.event_settings.get("moon_apogee_perigee", False):
+                futures.append(executor.submit(self.calculate_moon_apogee_perigee))
+            if self.event_settings.get("mercury_inferior_conjunctions", False):
+                futures.append(executor.submit(self.calculate_mercury_inferior_conjunctions))
+            if self.event_settings.get("moon_messier_conjunctions", False):
+                futures.append(executor.submit(self.calculate_moon_messier_conjunctions))
+
             for future in as_completed(futures):
                 self.events.extend(future.result())
         if not self.events:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 pytest>=7.0.0
-unittest
 requests-mock>=1.12.1


### PR DESCRIPTION
This change adds the ability to disable event calculations via the `apts.ini` configuration file. This is useful for you if you only want to see a subset of the available events, or if you want to speed up the event calculation process.

The following changes were made:

*   A new `[events]` section was added to `apts.ini` to control which event calculations are enabled.
*   The `apts/config.py` file was modified to read the new `[events]` section.
*   The `apts/events.py` file was modified to conditionally calculate events based on the settings in `apts.ini`.