### PR TITLE
Refactor: Move unit registry to units.py

### DIFF
--- a/apts/catalogs.py
+++ b/apts/catalogs.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from importlib import resources
-from .utils import ureg
+from .units import ureg
 
 
 class Catalogs:

--- a/apts/objects/solar_objects.py
+++ b/apts/objects/solar_objects.py
@@ -7,7 +7,7 @@ import pint
 
 from .objects import Objects
 from ..constants import ObjectTableLabels
-from ..utils import ureg
+from ..units import ureg
 from apts.place import Place
 from skyfield.api import load
 from skyfield import almanac

--- a/apts/opticalequipment/abstract.py
+++ b/apts/opticalequipment/abstract.py
@@ -2,7 +2,8 @@ import uuid
 import numpy as np # For np.nan
 
 from ..constants import OpticalType
-from ..utils import ConnectionType, ureg
+from ..units import ureg
+from ..utils import ConnectionType
 
 
 class OpticalEquipment:

--- a/apts/opticalequipment/binoculars.py
+++ b/apts/opticalequipment/binoculars.py
@@ -1,5 +1,5 @@
 from ..constants import OpticalType, GraphConstants
-from ..utils import ureg
+from ..units import ureg
 from .abstract import OpticalEquipment
 
 class Binoculars(OpticalEquipment):

--- a/apts/opticalequipment/camera.py
+++ b/apts/opticalequipment/camera.py
@@ -4,7 +4,8 @@ import numpy
 
 from .abstract import OutputOpticalEqipment
 from ..constants import GraphConstants
-from ..utils import ConnectionType, ureg
+from ..units import ureg
+from ..utils import ConnectionType
 
 
 class Camera(OutputOpticalEqipment):

--- a/apts/opticalequipment/eyepiece.py
+++ b/apts/opticalequipment/eyepiece.py
@@ -1,7 +1,8 @@
 from .abstract import OutputOpticalEqipment
 from ..constants import GraphConstants
 
-from ..utils import ureg, ConnectionType
+from ..units import ureg
+from ..utils import ConnectionType
 
 class Eyepiece(OutputOpticalEqipment):
   """

--- a/apts/opticalequipment/telescope.py
+++ b/apts/opticalequipment/telescope.py
@@ -1,7 +1,8 @@
 import numpy
 
 from .abstract import OpticalEquipment
-from ..utils import ConnectionType, ureg
+from ..units import ureg
+from ..utils import ConnectionType
 from ..constants import GraphConstants
 
 

--- a/apts/optics.py
+++ b/apts/optics.py
@@ -1,7 +1,7 @@
 import functools
 import operator
 from .opticalequipment.binoculars import Binoculars
-from .utils import ureg
+from .units import ureg
 
 
 class OpticsUtils:

--- a/apts/units.py
+++ b/apts/units.py
@@ -1,0 +1,20 @@
+from pint import UnitRegistry
+
+_ureg = None
+
+def get_unit_registry():
+    global _ureg
+    if _ureg is None:
+        _ureg = UnitRegistry()
+        # Define astronomical units that might not be in Pint by default
+        _ureg.define("mag = [] = magnitude")  # Astronomical magnitude
+        _ureg.define("hour = 60 * minute = h = hr")  # Hour for Right Ascension
+        _ureg.define("AU = 149597870700 * meter = au")  # Astronomical Unit
+        _ureg.define("arcsecond = degree / 3600 = arcsec")  # Arc second
+    return _ureg
+
+def set_unit_registry(registry):
+    global _ureg
+    _ureg = registry
+
+ureg = get_unit_registry()

--- a/apts/utils/__init__.py
+++ b/apts/utils/__init__.py
@@ -2,18 +2,10 @@ import io
 from aenum import Enum, auto
 
 import matplotlib.dates as mdates
-from pint import UnitRegistry
 from matplotlib import pyplot
 
 from apts.constants.graphconstants import get_plot_style
-
-# Unit registry
-ureg = UnitRegistry()
-# Define astronomical units that might not be in Pint by default
-ureg.define("mag = [] = magnitude")  # Astronomical magnitude
-ureg.define("hour = 60 * minute = h = hr")  # Hour for Right Ascension
-ureg.define("AU = 149597870700 * meter = au")  # Astronomical Unit
-ureg.define("arcsecond = degree / 3600 = arcsec")  # Arc second
+from apts.units import ureg
 
 
 class ConnectionType(Enum):

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -7,7 +7,7 @@ from apts.observations import Observation
 from apts.opticalequipment import Telescope, Eyepiece
 import unittest
 import pint
-from apts.utils import ureg
+from apts.units import ureg
 
 
 class CacheTest(unittest.TestCase):

--- a/tests/equipment_test.py
+++ b/tests/equipment_test.py
@@ -11,7 +11,8 @@ from apts.constants import EquipmentTableLabels, GraphConstants, NodeLabels
 from apts.constants.graphconstants import OpticalType, get_plot_style, get_plot_colors # Added get_plot_colors
 from apts.config import get_dark_mode
 from apts.opticalequipment import Barlow, Binoculars, Telescope, Camera, Eyepiece # Added Telescope, Camera, Eyepiece
-from apts.utils import ureg, ConnectionType # Added ureg, ConnectionType
+from apts.units import ureg
+from apts.utils import ConnectionType
 from . import setup_equipment
 
 

--- a/tests/observations_test.py
+++ b/tests/observations_test.py
@@ -15,7 +15,7 @@ from apts.constants.graphconstants import (
 from apts.constants.objecttablelabels import (
     ObjectTableLabels,
 )  # Added ObjectTableLabels
-from apts.utils import ureg  # Added ureg for Quantity
+from apts.units import ureg
 from tests import setup_observation
 from apts.conditions import Conditions  # Import Conditions at the top level
 


### PR DESCRIPTION
Move the unit registry to a dedicated units.py file to improve organization and avoid circular dependencies.