### PR TITLE
Refactor weather feature to be modular and add new providers

### DIFF
--- a/apts/config.py
+++ b/apts/config.py
@@ -58,3 +58,22 @@ def get_event_settings() -> dict:
         for option in config.options('events'):
             event_settings[option] = config.getboolean('events', option)
     return event_settings
+
+
+def get_weather_settings() -> tuple[str, str]:
+    """
+    Reads the weather settings from the [weather] section.
+
+    Returns:
+        tuple: A tuple containing the provider name and the API key.
+    """
+    provider = 'pirateweather'
+    api_key = '12345'  # Default dummy key
+
+    if config.has_section('weather'):
+        if config.has_option('weather', 'provider'):
+            provider = config.get('weather', 'provider')
+        if config.has_option('weather', 'api_key'):
+            api_key = config.get('weather', 'api_key')
+
+    return provider, api_key

--- a/apts/weather_providers.py
+++ b/apts/weather_providers.py
@@ -1,0 +1,197 @@
+import json
+import logging
+from abc import ABC, abstractmethod
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class WeatherProvider(ABC):
+    def __init__(self, api_key, lat, lon, local_timezone):
+        self.api_key = api_key
+        self.lat = lat
+        self.lon = lon
+        self.local_timezone = local_timezone
+
+    @abstractmethod
+    def download_data(self):
+        pass
+
+
+class PirateWeather(WeatherProvider):
+    API_URL = "https://api.pirateweather.net/forecast/{apikey}/{lat},{lon}?units=si"
+
+    def download_data(self):
+        url = self.API_URL.format(apikey=self.api_key, lat=self.lat, lon=self.lon)
+        logger.debug("Download weather from: {}".format(url))
+        with requests.get(url) as data:
+            logger.debug(f"Data {data}")
+            columns = [
+                "time",
+                "summary",
+                "precipType",
+                "precipProbability",
+                "precipIntensity",
+                "temperature",
+                "apparentTemperature",
+                "dewPoint",
+                "humidity",
+                "windSpeed",
+                "cloudCover",
+                "visibility",
+                "pressure",
+                "ozone",
+            ]
+            json_data = json.loads(data.text)
+            if "hourly" in json_data and "data" in json_data["hourly"]:
+                raw_data = [
+                    [
+                        (item[column] if column in item.keys() else "none")
+                        for column in columns
+                    ]
+                    for item in json_data["hourly"]["data"]
+                ]
+            else:
+                logger.error(f"KeyError in weather data. Full response: {json_data}")
+                return pd.DataFrame(columns=columns)
+            result = pd.DataFrame(raw_data, columns=columns)
+            # Convert units
+            result["precipProbability"] *= 100
+            result["cloudCover"] *= 100
+            result.time = (
+                result.time.astype("datetime64[s]")
+                .dt.tz_localize("UTC")
+                .dt.tz_convert(self.local_timezone)
+            )
+            return result
+
+
+class VisualCrossing(WeatherProvider):
+    API_URL = "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/{lat},{lon}?unitGroup=metric&key={apikey}&include=hours"
+
+    def download_data(self):
+        url = self.API_URL.format(apikey=self.api_key, lat=self.lat, lon=self.lon)
+        logger.debug("Download weather from: {}".format(url))
+        with requests.get(url) as data:
+            logger.debug(f"Data {data}")
+            json_data = json.loads(data.text)
+
+            if "days" not in json_data:
+                logger.error(f"KeyError 'days' in weather data. Full response: {json_data}")
+                return pd.DataFrame()
+
+            all_hours_data = []
+            for day in json_data['days']:
+                all_hours_data.extend(day['hours'])
+
+            df = pd.DataFrame(all_hours_data)
+
+            # Rename columns to match the standard format
+            rename_map = {
+                'datetimeEpoch': 'time',
+                'conditions': 'summary',
+                'preciptype': 'precipType',
+                'precipprob': 'precipProbability',
+                'precip': 'precipIntensity',
+                'temp': 'temperature',
+                'feelslike': 'apparentTemperature',
+                'dew': 'dewPoint',
+                'humidity': 'humidity',
+                'windspeed': 'windSpeed',
+                'cloudcover': 'cloudCover',
+                'visibility': 'visibility',
+                'pressure': 'pressure',
+                'ozone': 'ozone'
+            }
+            df.rename(columns=rename_map, inplace=True)
+
+            # Convert units and types
+            df['time'] = pd.to_datetime(df['time'], unit='s').dt.tz_localize('UTC').dt.tz_convert(self.local_timezone)
+            if 'precipProbability' in df.columns:
+                 df['precipProbability'] *= 100
+
+            # Ensure all required columns are present
+            required_columns = [
+                "time", "summary", "precipType", "precipProbability", "precipIntensity",
+                "temperature", "apparentTemperature", "dewPoint", "humidity",
+                "windSpeed", "cloudCover", "visibility", "pressure", "ozone"
+            ]
+            for col in required_columns:
+                if col not in df.columns:
+                    df[col] = 'none' # or pd.NA
+
+            return df[required_columns]
+
+
+class OpenWeatherMap(WeatherProvider):
+    API_URL = "https://api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&appid={apikey}&units=metric&exclude=minutely,daily,alerts"
+
+    def download_data(self):
+        url = self.API_URL.format(apikey=self.api_key, lat=self.lat, lon=self.lon)
+        logger.debug("Download weather from: {}".format(url))
+        with requests.get(url) as data:
+            logger.debug(f"Data {data}")
+            json_data = json.loads(data.text)
+
+            if "hourly" not in json_data:
+                logger.error(f"KeyError 'hourly' in weather data. Full response: {json_data}")
+                return pd.DataFrame()
+
+            df = pd.DataFrame(json_data['hourly'])
+
+            # The 'weather' column contains a list with a dictionary, extract the description
+            df['summary'] = df['weather'].apply(lambda x: x[0]['description'] if x else 'none')
+            df['precipType'] = df['weather'].apply(lambda x: x[0]['main'] if x else 'none')
+
+            # Rename columns to match the standard format
+            rename_map = {
+                'dt': 'time',
+                'pop': 'precipProbability',
+                'temp': 'temperature',
+                'feels_like': 'apparentTemperature',
+                'dew_point': 'dewPoint',
+                'humidity': 'humidity',
+                'wind_speed': 'windSpeed',
+                'clouds': 'cloudCover',
+                'visibility': 'visibility',
+                'pressure': 'pressure',
+            }
+            df.rename(columns=rename_map, inplace=True)
+
+            # precipIntensity
+            if 'rain' in df.columns and isinstance(df['rain'].iloc[0], dict):
+                df['precipIntensity'] = df['rain'].apply(lambda x: x.get('1h', 0) if isinstance(x, dict) else 0)
+            elif 'snow' in df.columns and isinstance(df['snow'].iloc[0], dict):
+                df['precipIntensity'] = df['snow'].apply(lambda x: x.get('1h', 0) if isinstance(x, dict) else 0)
+            else:
+                df['precipIntensity'] = 0
+
+            # Convert units and types
+            df['time'] = pd.to_datetime(df['time'], unit='s').dt.tz_localize('UTC').dt.tz_convert(self.local_timezone)
+            if 'precipProbability' in df.columns:
+                df['precipProbability'] *= 100
+
+            if 'humidity' in df.columns:
+                df['humidity'] /= 100
+
+            # Convert wind speed from m/s to km/h
+            if 'windSpeed' in df.columns:
+                df['windSpeed'] *= 3.6
+
+            # Convert visibility from meters to km
+            if 'visibility' in df.columns:
+                df['visibility'] /= 1000
+
+            # Ensure all required columns are present
+            required_columns = [
+                "time", "summary", "precipType", "precipProbability", "precipIntensity",
+                "temperature", "apparentTemperature", "dewPoint", "humidity",
+                "windSpeed", "cloudCover", "visibility", "pressure", "ozone"
+            ]
+            for col in required_columns:
+                if col not in df.columns:
+                    df[col] = 'none'
+
+            return df[required_columns]

--- a/examples/apts.ini
+++ b/examples/apts.ini
@@ -1,5 +1,7 @@
 [weather]
 # Settings for weather API
+# provider can be: pirateweather, visualcrossing, openweathermap
+provider = pirateweather
 api_key = <api_key>
 
 [notification]


### PR DESCRIPTION
The weather feature has been refactored to support multiple weather providers. The hardcoded JSON parsing and API calls have been moved into separate provider classes.

This change introduces a new `apts/weather_providers.py` file which contains a base `WeatherProvider` class and concrete implementations for:
- Pirate Weather (the original provider)
- Visual Crossing
- OpenWeatherMap

The `Weather` class now acts as a factory, selecting the appropriate provider based on the settings in `apts.ini`. The configuration has been updated to include a `provider` key in the `[weather]` section.

The tests have been updated to cover the new provider-based implementation, with mock data for each provider.