### PR TITLE
fix(place): Correct sun observation start/end time calculation

### DIFF
--- a/apts/place.py
+++ b/apts/place.py
@@ -98,9 +98,11 @@ class Place:
         if start_search_from:
             start_date = start_search_from
         elif target_date:
-            start_date = datetime.datetime.combine(
-                target_date, datetime.time(12, 0, 0, tzinfo=datetime.timezone.utc)
-            )
+            # Create datetime at the beginning of the day in the local timezone, then convert to UTC
+            local_start_of_day = datetime.datetime.combine(
+                target_date, datetime.time.min
+            ).replace(tzinfo=self.local_timezone)
+            start_date = local_start_of_day.astimezone(datetime.timezone.utc)
         else:
             start_date = self.date.utc_datetime()
         return self._next_setting_time(self.sun, start=start_date)
@@ -111,9 +113,11 @@ class Place:
         if start_search_from:
             start_date = start_search_from
         elif target_date:
-            start_date = datetime.datetime.combine(
-                target_date, datetime.time(12, 0, 0, tzinfo=datetime.timezone.utc)
-            )
+            # Create datetime at the beginning of the day in the local timezone, then convert to UTC
+            local_start_of_day = datetime.datetime.combine(
+                target_date, datetime.time.min
+            ).replace(tzinfo=self.local_timezone)
+            start_date = local_start_of_day.astimezone(datetime.timezone.utc)
         else:
             start_date = self.date.utc_datetime()
         return self._next_rising_time(self.sun, start=start_date)


### PR DESCRIPTION
When creating a sun observation with a `target_date`, the start and end times could be calculated for the wrong day. This was because the search for the sunrise or sunset event started at a fixed time (12:00 UTC) on the target date.

For timezones west of UTC, this could mean the search started after that day's sunrise had already occurred, causing the next day's sunrise to be found instead.

The fix is to start the search at the beginning of the `target_date` in the observation location's local timezone. This is achieved by creating a timezone-aware datetime for the start of the day locally and converting it to UTC before passing it to the search function. This ensures the correct day's events are always found.