### PR TITLE
feat: Add bright ISS flyby calculation to events

### DIFF
--- a/apts/constants/event_types.py
+++ b/apts/constants/event_types.py
@@ -18,6 +18,7 @@ class EventType(str, Enum):
     MOON_MESSIER_CONJUNCTIONS = "moon_messier_conjunctions"
     SPACE_LAUNCHES = "space_launches"
     SPACE_EVENTS = "space_events"
+    ISS_FLYBYS = "iss_flybys"
 
     def __str__(self):
         return self.value

--- a/apts/events.py
+++ b/apts/events.py
@@ -88,6 +88,8 @@ class AstronomicalEvents:
             futures.append(executor.submit(self.calculate_space_launches))
         if self.event_settings.get("space_events", False):
             futures.append(executor.submit(self.calculate_space_events))
+        if self.event_settings.get("iss_flybys", False):
+            futures.append(executor.submit(self.calculate_iss_flybys))
 
         for future in as_completed(futures):
             self.events.extend(future.result())
@@ -141,6 +143,14 @@ class AstronomicalEvents:
         except requests.exceptions.RequestException as e:
             logger.error(f"Error fetching space events: {e}")
         logger.debug(f"--- calculate_space_events: {time.time() - start_time}s")
+        return events
+
+    def calculate_iss_flybys(self):
+        start_time = time.time()
+        events = skyfield_searches.find_iss_flybys(
+            self.observer, self.start_date, self.end_date
+        )
+        logger.debug(f"--- calculate_iss_flybys: {time.time() - start_time}s")
         return events
 
     def calculate_moon_phases(self):

--- a/examples/apts.ini
+++ b/examples/apts.ini
@@ -41,3 +41,4 @@ aphelion_perihelion = true
 moon_apogee_perigee = true
 mercury_inferior_conjunctions = true
 moon_messier_conjunctions = true
+iss_flybys = true


### PR DESCRIPTION
This change adds a new feature to calculate bright flybys of the International Space Station (ISS).

A new event type, `ISS_FLYBYS`, has been added to the `EventType` enum.

The main calculation logic is implemented in the new `find_iss_flybys` function in `apts/skyfield_searches.py`. This function:
- Fetches the latest ISS TLE data from CelesTrak using `skyfield.api.load.tle_file`.
- Finds all rise, culmination, and set events for the ISS over the observer's location.
- Filters these events to find "bright" flybys, defined as passes where:
  - The sun is at least 18 degrees below the horizon at the peak of the pass.
  - The ISS's magnitude is brighter than -1.5.
  - The peak altitude of the pass is above 40 degrees.

The new feature is integrated into the `AstronomicalEvents` class with a new `calculate_iss_flybys` method. This method is called from `get_events` if the `iss_flybys` setting is enabled in the configuration.

The example configuration file `examples/apts.ini` has been updated to include and enable the `iss_flybys` event by default.

A new unit test, `test_calculate_iss_flybys`, has been added to `tests/events_test.py`. This test uses `unittest.mock.patch` to mock the `find_iss_flybys` function, ensuring that the new logic is tested in isolation without making external network requests.

The dependency management and testing process were also improved by installing the system dependency `libcairo2-dev` and using `python -m pytest` to ensure the test suite runs correctly.