### PR TITLE
feat: Use general meteoblue package

### DIFF
--- a/apts/weather_providers.py
+++ b/apts/weather_providers.py
@@ -126,7 +126,7 @@ class VisualCrossing(WeatherProvider):
 
 
 class Meteoblue(WeatherProvider):
-    API_URL = "https://my.meteoblue.com/packages/basic-1h_clouds-1h?lat={lat}&lon={lon}&apikey={apikey}&format=json"
+    API_URL = "https://my.meteoblue.com/packages/basic-1h?lat={lat}&lon={lon}&apikey={apikey}&format=json"
 
     def download_data(self):
         url = self.API_URL.format(apikey=self.api_key, lat=self.lat, lon=self.lon)


### PR DESCRIPTION
This change modifies the Meteoblue weather provider to use the `basic-1h` data package instead of `basic-1h_clouds-1h`.

The `basic-1h_clouds-1h` package may not be available to all users, which could prevent the visibility plot from being displayed. The `basic-1h` package is more general and more likely to be available to all users, which should make the visibility plot more reliable for Meteoblue users.

The other weather providers (`PirateWeather`, `VisualCrossing`, and `OpenWeatherMap`) already have the correct implementation to fetch visibility data, but their APIs may not be returning it consistently. This change does not affect those providers.