### PR TITLE
feat: Add caching for stations.txt

### DIFF
--- a/apts/events.py
+++ b/apts/events.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import List, Optional
 import requests
+import requests_cache
 from dateutil.parser import parse as parse_date
 from .config import get_event_settings
 from .constants.event_types import EventType
@@ -14,6 +15,7 @@ from .utils import planetary
 
 logger = logging.getLogger(__name__)
 
+requests_cache.install_cache("apts_cache", backend="memory", expire_after=300)
 
 utc = timezone.utc
 from . import skyfield_searches

--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -290,7 +290,7 @@ def find_iss_flybys(
     try:
         stations_url = "https://celestrak.org/NORAD/elements/stations.txt"
         # Load TLE file - no ephemeris needed for satellite data
-        satellites = load.tle_file(stations_url, reload=True)
+        satellites = load.tle_file(stations_url)
         iss = next(s for s in satellites if s.name == "ISS (ZARYA)")
     except Exception as e:
         # Could be network error, or ISS not in file

--- a/tests/iss_flybys_integration_test.py
+++ b/tests/iss_flybys_integration_test.py
@@ -122,7 +122,7 @@ class ISSFlybysIntegrationTest(unittest.TestCase):
 
             # Verify the correct URL was called
             mock_tle.assert_called_once_with(
-                "https://celestrak.org/NORAD/elements/stations.txt", reload=True
+                "https://celestrak.org/NORAD/elements/stations.txt"
             )
 
     def test_iss_name_search(self):


### PR DESCRIPTION
Adds caching for the `stations.txt` file download, similar to the existing caching for weather data.

This is achieved by:
- Removing the `reload=True` parameter from the `skyfield.api.load.tle_file` call in `apts/skyfield_searches.py`.
- Adding `requests_cache.install_cache` to `apts/events.py` to enable caching for all requests made with the `requests` library in that module.
- Updating the test in `tests/iss_flybys_integration_test.py` to reflect the change in the `load.tle_file` call.