### PR TITLE
feat: Implement search for solar and lunar eclipses

### DIFF
--- a/apts/constants/event_types.py
+++ b/apts/constants/event_types.py
@@ -16,6 +16,8 @@ class EventType(str, Enum):
     MOON_APOGEE_PERIGEE = "moon_apogee_perigee"
     MERCURY_INFERIOR_CONJUNCTIONS = "mercury_inferior_conjunctions"
     MOON_MESSIER_CONJUNCTIONS = "moon_messier_conjunctions"
+    SOLAR_ECLIPSES = "solar_eclipses"
+    LUNAR_ECLIPSES = "lunar_eclipses"
     SPACE_LAUNCHES = "space_launches"
     SPACE_EVENTS = "space_events"
     ISS_FLYBYS = "iss_flybys"

--- a/apts/events.py
+++ b/apts/events.py
@@ -93,6 +93,10 @@ class AstronomicalEvents:
             futures.append(executor.submit(self.calculate_space_events))
         if self.event_settings.get("iss_flybys", False):
             futures.append(executor.submit(self.calculate_iss_flybys))
+        if self.event_settings.get("solar_eclipses", False):
+            futures.append(executor.submit(self.calculate_solar_eclipses))
+        if self.event_settings.get("lunar_eclipses", False):
+            futures.append(executor.submit(self.calculate_lunar_eclipses))
 
         for future in as_completed(futures):
             self.events.extend(future.result())
@@ -160,6 +164,26 @@ class AstronomicalEvents:
             topos_observer, self.observer, self.start_date, self.end_date
         )
         logger.debug(f"--- calculate_iss_flybys: {time.time() - start_time}s")
+        return events
+
+    def calculate_solar_eclipses(self):
+        start_time = time.time()
+        events = skyfield_searches.find_solar_eclipses(
+            self.observer, self.eph, self.start_date, self.end_date
+        )
+        for event in events:
+            event["event"] = "Solar Eclipse"
+        logger.debug(f"--- calculate_solar_eclipses: {time.time() - start_time}s")
+        return events
+
+    def calculate_lunar_eclipses(self):
+        start_time = time.time()
+        events = skyfield_searches.find_lunar_eclipses(
+            self.eph, self.start_date, self.end_date
+        )
+        for event in events:
+            event["event"] = f"Lunar Eclipse: {event['type']}"
+        logger.debug(f"--- calculate_lunar_eclipses: {time.time() - start_time}s")
         return events
 
     def calculate_moon_phases(self):

--- a/apts/events.py
+++ b/apts/events.py
@@ -182,7 +182,9 @@ class AstronomicalEvents:
             self.eph, self.start_date, self.end_date
         )
         for event in events:
-            event["event"] = f"Lunar Eclipse: {event['type']}"
+            event[
+                "event"
+            ] = f"Lunar Eclipse: {event['type']} (Penumbral Magnitude: {event['penumbral_magnitude']:.2f}, Umbral Magnitude: {event['umbral_magnitude']:.2f})"
         logger.debug(f"--- calculate_lunar_eclipses: {time.time() - start_time}s")
         return events
 

--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -3,6 +3,9 @@ from skyfield import eclipselib
 from skyfield.searchlib import find_maxima, find_minima
 import numpy as np
 import pandas as pd
+from datetime import timedelta
+from skyfield.constants import ERAD
+from skyfield.functions import angle_between, length_of
 from .cache import get_timescale, get_ephemeris
 
 
@@ -364,8 +367,15 @@ def find_lunar_eclipses(eph, start_date, end_date):
     t1 = ts.utc(end_date)
     t, y, details = eclipselib.lunar_eclipses(t0, t1, eph)
     events = []
-    for ti, yi in zip(t, y):
-        events.append({"date": ti.utc_datetime(), "type": eclipselib.LUNAR_ECLIPSES[yi]})
+    for i, (ti, yi) in enumerate(zip(t, y)):
+        events.append(
+            {
+                "date": ti.utc_datetime(),
+                "type": eclipselib.LUNAR_ECLIPSES[yi],
+                "penumbral_magnitude": details["penumbral_magnitude"][i],
+                "umbral_magnitude": details["umbral_magnitude"][i],
+            }
+        )
     return events
 
 

--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -1,4 +1,5 @@
 from skyfield.api import load
+from skyfield import eclipselib
 from skyfield.searchlib import find_maxima, find_minima
 import numpy as np
 import pandas as pd
@@ -355,3 +356,46 @@ def find_iss_flybys(
         )
 
     return events_list
+
+
+def find_lunar_eclipses(eph, start_date, end_date):
+    ts = get_timescale()
+    t0 = ts.utc(start_date)
+    t1 = ts.utc(end_date)
+    t, y, details = eclipselib.lunar_eclipses(t0, t1, eph)
+    events = []
+    for ti, yi in zip(t, y):
+        events.append({"date": ti.utc_datetime(), "type": eclipselib.LUNAR_ECLIPSES[yi]})
+    return events
+
+
+def find_solar_eclipses(observer, eph, start_date, end_date):
+    ts = get_timescale()
+    t0 = ts.utc(start_date)
+    t1 = ts.utc(end_date)
+    sun = eph["sun"]
+    moon = eph["moon"]
+
+    earth = eph["earth"]
+    Rs = 695700  # km
+    rm = 1737.4  # km
+    re = 6378  # km
+
+    def eclipse_separation(t):
+        s = earth.at(t).observe(sun)
+        m = earth.at(t).observe(moon)
+        Ds = s.distance().km
+        dm = m.distance().km
+        mu = s.separation_from(m).radians
+        threshold = np.arcsin((rm + re) / dm) + np.arcsin((Rs - re) / Ds)
+        return mu - threshold
+
+    eclipse_separation.step_days = 0.1
+    times, separations = find_minima(t0, t1, eclipse_separation)
+    events = []
+    for t, sep in zip(times, separations):
+        if sep < 0:
+            events.append(
+                {"date": t.utc_datetime(), "type": "Solar", "separation": sep}
+            )
+    return events

--- a/tests/skyfield_searches_test.py
+++ b/tests/skyfield_searches_test.py
@@ -294,9 +294,13 @@ class SkyfieldSearchesTest(unittest.TestCase):
         self.assertEqual(events[0]["type"], "Penumbral")
         self.assertEqual(events[0]["date"].day, 5)
         self.assertEqual(events[0]["date"].month, 5)
+        self.assertIn("penumbral_magnitude", events[0])
+        self.assertIn("umbral_magnitude", events[0])
         self.assertEqual(events[1]["type"], "Partial")
         self.assertEqual(events[1]["date"].day, 28)
         self.assertEqual(events[1]["date"].month, 10)
+        self.assertIn("penumbral_magnitude", events[1])
+        self.assertIn("umbral_magnitude", events[1])
 
     def test_find_solar_eclipses(self):
         start_date = datetime(2023, 1, 1, tzinfo=utc)

--- a/tests/skyfield_searches_test.py
+++ b/tests/skyfield_searches_test.py
@@ -284,6 +284,33 @@ class SkyfieldSearchesTest(unittest.TestCase):
 
             self.assertIsInstance(events, list)
 
+    def test_find_lunar_eclipses(self):
+        start_date = datetime(2023, 1, 1, tzinfo=utc)
+        end_date = datetime(2023, 12, 31, tzinfo=utc)
+        events = skyfield_searches.find_lunar_eclipses(self.eph, start_date, end_date)
+        self.assertIsInstance(events, list)
+        # There are two lunar eclipses in 2023
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["type"], "Penumbral")
+        self.assertEqual(events[0]["date"].day, 5)
+        self.assertEqual(events[0]["date"].month, 5)
+        self.assertEqual(events[1]["type"], "Partial")
+        self.assertEqual(events[1]["date"].day, 28)
+        self.assertEqual(events[1]["date"].month, 10)
+
+    def test_find_solar_eclipses(self):
+        start_date = datetime(2023, 1, 1, tzinfo=utc)
+        end_date = datetime(2023, 12, 31, tzinfo=utc)
+        events = skyfield_searches.find_solar_eclipses(
+            self.observer, self.eph, start_date, end_date
+        )
+        self.assertIsInstance(events, list)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["date"].day, 20)
+        self.assertEqual(events[0]["date"].month, 4)
+        self.assertEqual(events[1]["date"].day, 14)
+        self.assertEqual(events[1]["date"].month, 10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit implements the ability to search for solar and lunar eclipses.

- Adds `SOLAR_ECLIPSES` and `LUNAR_ECLIPSES` to the `EventType` enum.
- Implements `find_solar_eclipses` and `find_lunar_eclipses` in `apts/skyfield_searches.py` to perform the eclipse calculations.
- Integrates the new eclipse searches into the `AstronomicalEvents` class in `apts/events.py`.
- Adds unit tests for the new eclipse search functions.