### PR TITLE
feat: Add support for Tiangong (Tianhe) pass prediction

### DIFF
--- a/apts/constants/event_types.py
+++ b/apts/constants/event_types.py
@@ -21,6 +21,7 @@ class EventType(str, Enum):
     SPACE_LAUNCHES = "space_launches"
     SPACE_EVENTS = "space_events"
     ISS_FLYBYS = "iss_flybys"
+    TIANGONG_FLYBYS = "tiangong_flybys"
 
     def __str__(self):
         return self.value

--- a/apts/events.py
+++ b/apts/events.py
@@ -93,6 +93,8 @@ class AstronomicalEvents:
             futures.append(executor.submit(self.calculate_space_events))
         if self.event_settings.get("iss_flybys", False):
             futures.append(executor.submit(self.calculate_iss_flybys))
+        if self.event_settings.get("tiangong_flybys", False):
+            futures.append(executor.submit(self.calculate_tiangong_flybys))
         if self.event_settings.get("solar_eclipses", False):
             futures.append(executor.submit(self.calculate_solar_eclipses))
         if self.event_settings.get("lunar_eclipses", False):
@@ -164,6 +166,20 @@ class AstronomicalEvents:
             topos_observer, self.observer, self.start_date, self.end_date
         )
         logger.debug(f"--- calculate_iss_flybys: {time.time() - start_time}s")
+        return events
+
+    def calculate_tiangong_flybys(self):
+        start_time = time.time()
+        # Create the Topos object directly from place attributes
+        topos_observer = Topos(
+            latitude_degrees=self.place.lat_decimal,
+            longitude_degrees=self.place.lon_decimal,
+            elevation_m=self.place.elevation,
+        )
+        events = skyfield_searches.find_tiangong_flybys(
+            topos_observer, self.observer, self.start_date, self.end_date
+        )
+        logger.debug(f"--- calculate_tiangong_flybys: {time.time() - start_time}s")
         return events
 
     def calculate_solar_eclipses(self):

--- a/tests/tiangong_flybys_integration_test.py
+++ b/tests/tiangong_flybys_integration_test.py
@@ -1,0 +1,211 @@
+import unittest
+from datetime import datetime
+from skyfield.api import load, Topos, utc
+from unittest.mock import patch, MagicMock
+from apts import skyfield_searches
+
+
+class TiangongFlybysIntegrationTest(unittest.TestCase):
+    """Integration tests for Tiangong flyby detection functionality"""
+
+    def setUp(self):
+        self.ts = load.timescale()
+        self.eph = load("de421.bsp")
+        self.topos_observer = Topos(latitude_degrees=52.2, longitude_degrees=21.0)
+        self.vector_observer = self.eph["earth"] + self.topos_observer
+        self.start_date = datetime(2023, 6, 1, tzinfo=utc)
+        self.end_date = datetime(2023, 6, 2, tzinfo=utc)
+
+    def test_tle_load_network_error(self):
+        """Test graceful handling of network errors when loading TLE"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_tle.side_effect = Exception("Network connection failed")
+
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            self.assertEqual(events, [])
+
+    def test_no_tiangong_in_tle_file(self):
+        """Test graceful handling when Tiangong is not found in TLE file"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            # Mock TLE file with other satellites but no Tiangong
+            mock_other_sat = MagicMock()
+            mock_other_sat.name = "HUBBLE SPACE TELESCOPE"
+            mock_tle.return_value = [mock_other_sat]
+
+            # This should raise StopIteration when looking for Tiangong
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            self.assertEqual(len(events), 0)
+
+    def test_empty_events_from_find_events(self):
+        """Test handling when find_events returns no events"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])  # No events
+            mock_tle.return_value = [mock_satellite]
+
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            self.assertEqual(len(events), 0)
+
+    def test_function_parameters_and_defaults(self):
+        """Test that the function accepts all expected parameters"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])
+            mock_tle.return_value = [mock_satellite]
+
+            # Test with custom parameters
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+                peak_altitude_threshold=30,
+                rise_altitude_threshold=5,
+            )
+
+            self.assertIsInstance(events, list)
+            self.assertEqual(len(events), 0)
+
+    def test_basic_function_signature(self):
+        """Test that the function has the correct signature and returns a list"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])
+            mock_tle.return_value = [mock_satellite]
+
+            # Test basic call
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            self.assertIsInstance(events, list)
+
+    def test_tle_url_is_correct(self):
+        """Test that the correct TLE URL is used"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])
+            mock_tle.return_value = [mock_satellite]
+
+            skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            # Verify the correct URL was called
+            mock_tle.assert_called_once_with(
+                "https://celestrak.org/NORAD/elements/stations.txt"
+            )
+
+    def test_tiangong_name_search(self):
+        """Test that the function looks for Tiangong with correct name"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            # Create multiple satellites with different names
+            mock_sat1 = MagicMock()
+            mock_sat1.name = "HUBBLE SPACE TELESCOPE"
+            mock_sat2 = MagicMock()
+            mock_sat2.name = "CSS (TIANHE)"
+            mock_sat2.find_events.return_value = ([], [])
+            mock_sat3 = MagicMock()
+            mock_sat3.name = "ISS (ZARYA)"
+
+            mock_tle.return_value = [mock_sat1, mock_sat2, mock_sat3]
+
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            # Should find Tiangong and call find_events on it
+            mock_sat2.find_events.assert_called_once()
+            self.assertIsInstance(events, list)
+
+    def test_return_structure_when_no_events(self):
+        """Test that function returns proper structure even with no events"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])
+            mock_tle.return_value = [mock_satellite]
+
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            self.assertIsInstance(events, list)
+            self.assertEqual(len(events), 0)
+
+    def test_time_conversion_handling(self):
+        """Test that the function properly handles time conversions"""
+
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            mock_satellite = MagicMock()
+            mock_satellite.name = "CSS (TIANHE)"
+            mock_satellite.find_events.return_value = ([], [])
+            mock_tle.return_value = [mock_satellite]
+
+            # Test with different date formats
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                datetime(2023, 1, 1, tzinfo=utc),
+                datetime(2023, 1, 2, tzinfo=utc),
+            )
+
+            # Should not raise any time conversion errors
+            self.assertIsInstance(events, list)
+
+    def test_exception_handling_during_processing(self):
+        """Test exception handling during Tiangong search and processing"""
+        with patch("skyfield.api.load.tle_file") as mock_tle:
+            # Simulate an error during satellite search
+            def bad_generator():
+                raise StopIteration("Tiangong not found")
+
+            mock_tle.side_effect = lambda *args, **kwargs: bad_generator()
+
+            events = skyfield_searches.find_tiangong_flybys(
+                self.topos_observer,
+                self.vector_observer,
+                self.start_date,
+                self.end_date,
+            )
+
+            # Should handle the exception gracefully
+            self.assertEqual(events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit introduces the functionality to predict flyby events for the Tiangong (Tianhe) space station.

The implementation includes:
- A new event type for Tiangong flybys.
- A new function to calculate Tiangong flybys, which is refactored from the existing ISS flyby logic to be more generic.
- A new integration test file for Tiangong flybys.

The code has been refactored to use a common private function for both ISS and Tiangong flybys, reducing code duplication and making it easier to add more satellites in the future.

The apparent magnitude for Tiangong is not calculated as it is not readily available in Skyfield. The TLE file from Celestrak is cached by default by the Skyfield library.