### PR TITLE
feat: Optimize catalog loading and pre-cache Skyfield objects

### DIFF
--- a/apts/__init__.py
+++ b/apts/__init__.py
@@ -6,7 +6,7 @@ import seaborn as sns
 # Import the config object from the new config module
 from .config import config
 
-from .catalogs import Catalogs
+from .catalogs import Catalogs, initialize_catalogs
 from .equipment import Equipment
 from .notify import Notify
 from .observations import Observation
@@ -15,7 +15,7 @@ from .utils import Utils
 from .weather import Weather
 from .constants.event_types import EventType
 
-__all__ = ["Catalogs", "Equipment", "Observation", "Place", "Utils", "EventType", "Notify", "Weather"]
+__all__ = ["Catalogs", "Equipment", "Observation", "Place", "Utils", "EventType", "Notify", "Weather", "catalogs"]
 
 logger = logging.getLogger(__name__)
 
@@ -63,5 +63,10 @@ except ValueError:
 
 # Disable label trimming in pandas tables
 pd.set_option("display.max_colwidth", None)
+
+# Initialize catalogs
+initialize_catalogs()
+catalogs = Catalogs()
+
 
 __version__ = "0.7.4"

--- a/apts/catalogs.py
+++ b/apts/catalogs.py
@@ -1,6 +1,7 @@
 import logging
 from importlib import resources
 import pandas as pd
+from skyfield.api import Star
 
 from .units import get_unit_registry
 from .constants.constellations import constellation_map
@@ -31,7 +32,33 @@ def _load_messier_with_units():
     messier_df["Height"] = messier_df["Height"].apply(lambda x: x * ureg.arcminute)
     messier_df["Magnitude"] = messier_df["Magnitude"].apply(lambda x: x * ureg.mag)
 
+    # Pre-calculate Skyfield objects
+    messier_df["skyfield_object"] = messier_df.apply(
+        lambda row: Star(ra_hours=row.RA.to('hour').magnitude, dec_degrees=row.Dec.to('degree').magnitude), axis=1
+    )
+
     return messier_df
+
+
+def _parse_ra(ra_str):
+    if isinstance(ra_str, str) and ra_str.count(':') == 2:
+        parts = ra_str.split(':')
+        return float(parts[0]) + float(parts[1])/60 + float(parts[2])/3600
+    return None
+
+def _parse_dec(dec_str):
+    if isinstance(dec_str, str) and dec_str.count(':') == 2:
+        sign = -1 if dec_str.startswith('-') else 1
+        parts = dec_str.lstrip('+-').split(':')
+        return sign * (float(parts[0]) + float(parts[1])/60 + float(parts[2])/3600)
+    return None
+
+def _create_ngc_star(obj):
+    ra = _parse_ra(obj.RA)
+    dec = _parse_dec(obj.Dec)
+    if ra is None or dec is None:
+        return None
+    return Star(ra_hours=ra, dec_degrees=dec)
 
 
 def _load_ngc_with_units():
@@ -63,6 +90,9 @@ def _load_ngc_with_units():
     ngc_df["Magnitude"] = pd.to_numeric(ngc_df["Magnitude"], errors='coerce').fillna(99).apply(lambda x: x * ureg.mag)
     ngc_df["Size"] = ngc_df["Size"].apply(lambda x: x * ureg.arcminute if pd.notna(x) else None)
 
+    # Pre-calculate Skyfield objects
+    ngc_df["skyfield_object"] = ngc_df.apply(_create_ngc_star, axis=1)
+
     return ngc_df
 
 
@@ -85,36 +115,40 @@ def _load_bright_stars_with_units():
         lambda x: x * ureg.mag
     )
 
+    # Pre-calculate Skyfield objects
+    bright_stars_df["skyfield_object"] = bright_stars_df.apply(
+        lambda row: Star(ra_hours=row.RA.to('hour').magnitude, dec_degrees=row.Dec.to('degree').magnitude), axis=1
+    )
+
     return bright_stars_df
 
 
 class Catalogs:
+    def __init__(self):
+        global _messier_df, _ngc_df, _bright_stars_df
+        if _messier_df is None:
+            logger.info("Loading Messier catalog...")
+            _messier_df = _load_messier_with_units()
+        if _ngc_df is None:
+            logger.info("Loading NGC catalog...")
+            _ngc_df = _load_ngc_with_units()
+        if _bright_stars_df is None:
+            logger.info("Loading Bright Stars catalog...")
+            _bright_stars_df = _load_bright_stars_with_units()
+
     @property
     def MESSIER(self):
-        global _messier_df
-        if _messier_df is None:
-            _messier_df = _load_messier_with_units()
         return _messier_df
 
     @property
     def NGC(self):
-        global _ngc_df
-        if _ngc_df is None:
-            _ngc_df = _load_ngc_with_units()
         return _ngc_df
 
     @property
     def BRIGHT_STARS(self):
-        global _bright_stars_df
-        if _bright_stars_df is None:
-            _bright_stars_df = _load_bright_stars_with_units()
         return _bright_stars_df
 
 
 def initialize_catalogs():
     logger.info("Initializing catalogs...")
-    # This function will trigger the loading of data with units
-    # when it's explicitly called.
-    _ = Catalogs().MESSIER
-    _ = Catalogs().BRIGHT_STARS
-    _ = Catalogs().NGC
+    Catalogs()

--- a/apts/objects/messier.py
+++ b/apts/objects/messier.py
@@ -6,9 +6,9 @@ from skyfield.api import Star
 
 
 class Messier(Objects):
-    def __init__(self, place, calculation_date=None):
+    def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(Messier, self).__init__(place, calculation_date=calculation_date)
-        self.objects = Catalogs().MESSIER.copy()
+        self.objects = catalogs.MESSIER.copy()
         self.calculation_date = calculation_date # Store calculation_date for lazy computation
 
     def compute(self, calculation_date=None):
@@ -47,7 +47,7 @@ class Messier(Objects):
         )
 
     def get_skyfield_object(self, obj):
-        return Star(ra_hours=obj.RA, dec_degrees=obj.Dec)
+        return obj.skyfield_object
 
     def find_by_name(self, name):
         """

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -7,9 +7,9 @@ from skyfield.api import Star
 
 
 class NGC(Objects):
-    def __init__(self, place, calculation_date=None):
+    def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(NGC, self).__init__(place, calculation_date=calculation_date)
-        self.objects = Catalogs().NGC.copy()
+        self.objects = catalogs.NGC.copy()
         self.calculation_date = calculation_date # Store calculation_date for lazy computation
 
     def compute(self, calculation_date=None):
@@ -47,30 +47,8 @@ class NGC(Objects):
             axis=1,
         )
 
-    def _parse_ra(self, ra_str):
-        if isinstance(ra_str, str) and ra_str.count(':') == 2:
-            parts = ra_str.split(':')
-            return float(parts[0]) + float(parts[1])/60 + float(parts[2])/3600
-        return None
-
-    def _parse_dec(self, dec_str):
-        if isinstance(dec_str, str) and dec_str.count(':') == 2:
-            sign = -1 if dec_str.startswith('-') else 1
-            parts = dec_str.lstrip('+-').split(':')
-            return sign * (float(parts[0]) + float(parts[1])/60 + float(parts[2])/3600)
-        return None
-
     def get_skyfield_object(self, obj):
-        if isinstance(obj, pd.DataFrame):
-            ra_hours = obj["RA"].apply(self._parse_ra)
-            dec_degrees = obj["Dec"].apply(self._parse_dec)
-            return Star(ra_hours=ra_hours.values, dec_degrees=dec_degrees.values)
-
-        ra = self._parse_ra(obj.RA)
-        dec = self._parse_dec(obj.Dec)
-        if ra is None or dec is None:
-            return None
-        return Star(ra_hours=ra, dec_degrees=dec)
+        return obj.skyfield_object
 
     def find_by_name(self, name):
         """

--- a/apts/objects/stars.py
+++ b/apts/objects/stars.py
@@ -6,9 +6,9 @@ from skyfield.api import Star
 
 
 class Stars(Objects):
-    def __init__(self, place, calculation_date=None):
+    def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(Stars, self).__init__(place, calculation_date=calculation_date)
-        self.objects = Catalogs().BRIGHT_STARS.copy()
+        self.objects = catalogs.BRIGHT_STARS.copy()
         self.calculation_date = calculation_date # Store calculation_date for lazy computation
 
     def compute(self, calculation_date=None):
@@ -45,7 +45,7 @@ class Stars(Objects):
         )
 
     def get_skyfield_object(self, obj):
-        return Star(ra_hours=obj.RA, dec_degrees=obj.Dec)
+        return obj.skyfield_object
 
     def find_by_name(self, name):
         """

--- a/apts/observations.py
+++ b/apts/observations.py
@@ -130,8 +130,9 @@ class Observation:
     @property
     def local_messier(self):
         if self._local_messier is None:
+            from apts import catalogs
             self._local_messier = Messier(
-                self.place, calculation_date=self.effective_date
+                self.place, catalogs, calculation_date=self.effective_date
             )
         return self._local_messier
 
@@ -146,13 +147,15 @@ class Observation:
     @property
     def local_ngc(self):
         if self._local_ngc is None:
-            self._local_ngc = NGC(self.place, calculation_date=self.effective_date)
+            from apts import catalogs
+            self._local_ngc = NGC(self.place, catalogs, calculation_date=self.effective_date)
         return self._local_ngc
 
     @property
     def local_stars(self):
         if self._local_stars is None:
-            self._local_stars = Stars(self.place, calculation_date=self.effective_date)
+            from apts import catalogs
+            self._local_stars = Stars(self.place, catalogs, calculation_date=self.effective_date)
         return self._local_stars
 
     def get_visible_messier(self, **args):

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -8,6 +8,7 @@ from apts.opticalequipment import Telescope, Eyepiece
 import unittest
 import pint
 from apts.units import ureg
+from apts import catalogs
 
 
 class CacheTest(unittest.TestCase):
@@ -52,7 +53,7 @@ class CacheTest(unittest.TestCase):
 
     def test_messier_pickle(self):
         p = Place(lat=52.2, lon=21.0, name="Warsaw")
-        m = Messier(p)
+        m = Messier(p, catalogs)
         pickled_m = pickle.dumps(m)
         unpickled_m = pickle.loads(pickled_m)
         self.assertIsNotNone(unpickled_m)

--- a/tests/messier_test.py
+++ b/tests/messier_test.py
@@ -5,6 +5,7 @@ import datetime
 
 # timedelta is part of datetime
 import pytz  # For timezone awareness
+from apts import catalogs
 
 # Helper to get initial datetime from setup_place
 INITIAL_DATE_STR = "2025/02/18 12:00:00"
@@ -134,7 +135,7 @@ def test_planets_recomputation_with_date():
 
 def test_messier_recomputation_with_date():
     place = setup_place()  # Uses fixed date '2025/02/18 12:00:00'
-    messier = Messier(place, calculation_date=place.date)
+    messier = Messier(place, catalogs, calculation_date=place.date)
     messier.compute(calculation_date=place.date) # Explicitly compute for the initial date
 
     # Store the original transit time for M1 (Crab Nebula)
@@ -197,7 +198,7 @@ def test_planets_backward_compatibility():
 
 def test_messier_backward_compatibility():
     place = setup_place()
-    messier = Messier(place, calculation_date=place.date)
+    messier = Messier(place, catalogs, calculation_date=place.date)
     messier.compute(calculation_date=place.date) # Explicitly compute for the initial date
     original_transit_time_m1 = messier.objects.loc[
         messier.objects[ObjectTableLabels.MESSIER] == "M1", ObjectTableLabels.TRANSIT

--- a/tests/observations_test.py
+++ b/tests/observations_test.py
@@ -17,6 +17,7 @@ from apts.constants.objecttablelabels import (
 from apts.units import ureg
 from tests import setup_observation
 from apts.conditions import Conditions  # Import Conditions at the top level
+from apts import catalogs
 
 
 # MockPlace and MockEquipment classes are removed
@@ -1127,6 +1128,7 @@ class TestPathBasedAzimuthFiltering(unittest.TestCase):
                 pd.Timestamp("2025-02-18 19:00:00", tz="UTC"),
             ],
             "ID": [0, 1, 2],
+            "skyfield_object": [Star(ra_hours=5.575538888888889, dec_degrees=22.0145), Star(ra_hours=5.588138888888889, dec_degrees=-5.391111111111111), Star(ra_hours=0.7123055555555556, dec_degrees=41.26916666666666)]
         }
         self.messier_df = pd.DataFrame(messier_data)
 


### PR DESCRIPTION
- Loaded static catalog data (Messier, NGC, and stars) only once at application startup.
- Pre-calculated and cached Skyfield objects for these catalog entries to speed up later computations.
- Refactored Messier, NGC, and Stars classes to use the pre-loaded data.
- Updated the Observation class to pass the global catalogs instance to the Messier, NGC, and Stars constructors.
- Updated tests to accommodate the new constructor signature for the object classes.