### PR TITLE
fix: Correct background color in weather summary plot for dark mode

### DIFF
--- a/apts/plot.py
+++ b/apts/plot.py
@@ -476,6 +476,8 @@ def _generate_plot_weather(
 
         fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
 
+        axes[4, 1].axis("off")
+
         plt_clouds_ax = observation.place.weather.plot_clouds(
             ax=axes[0, 0], dark_mode_override=effective_dark_mode
         )


### PR DESCRIPTION
The bottom right subplot in the weather summary plot was showing a white background in dark mode because it was unused and its axis was not being turned off. This change explicitly turns off the axis for the unused subplot, which resolves the visual glitch.