### PR TITLE
For dwarf planets like Ceres and Eris, the magnitude, size, and phase…

### DIFF
--- a/apts/objects/solar_objects.py
+++ b/apts/objects/solar_objects.py
@@ -128,7 +128,7 @@ class SolarObjects(Objects):
             object_name = row[ObjectTableLabels.NAME]
             if object_name in self.minor_planet_names:
                 # For minor planets, we'll use a placeholder for magnitude, size, and phase for now
-                return pd.Series([10.0, 0, 0])
+                return pd.Series([pd.NA, pd.NA, pd.NA])
             else:
                 ephem_obj_constructor = ephem_object_map.get(object_name)
                 if ephem_obj_constructor:


### PR DESCRIPTION
… properties cannot be calculated. This commit updates the planet table to use `pd.NA` for these fields. This is a more appropriate way to represent missing numerical data in pandas than using a string like 'n/a', as it preserves the numeric data type of the columns.