### PR TITLE
Fix crash when max_return is None

### DIFF
--- a/apts/observations.py
+++ b/apts/observations.py
@@ -118,20 +118,20 @@ class Observation:
 
         # Compute time limit for observation
         if self.start is not None:
-            max_return_values = [
-                int(value) for value in self.conditions.max_return.split(":")
-            ]
-            time_limit_dt = self.start.replace(
-                hour=max_return_values[0],
-                minute=max_return_values[1],
-                second=max_return_values[2],
-            )
-            # Ensure time_limit is after self.start, if it's on the same day but earlier, add a day
-            self.time_limit = (
-                time_limit_dt
-                if time_limit_dt > self.start
-                else time_limit_dt + timedelta(days=1)
-            )
+            if self.conditions.max_return:
+                h, m, s = (
+                    int(value) for value in self.conditions.max_return.split(":")
+                )
+                self.time_limit = self.start.replace(
+                    hour=h, minute=m, second=s, microsecond=0
+                )
+                # Adjust for overnight observations if necessary.
+                if self.time_limit < self.start:
+                    self.time_limit += timedelta(days=1)
+            else:
+                # If max_return is None, default time_limit to None so the
+                # observation ends at dawn.
+                self.time_limit = None
         # If self.start is None, self.time_limit remains None.
 
     @property

--- a/tests/observations_test.py
+++ b/tests/observations_test.py
@@ -139,6 +139,25 @@ class TestObservationInitialization(unittest.TestCase):
         self.assertIsNone(observation.stop)
         self.place.sunrise_time.assert_not_called()
 
+    def test_max_return_none(self):
+        """Test that observation initialization handles max_return=None gracefully."""
+        # Arrange
+        self.place.sunset_time.return_value = pd.Timestamp("2025-02-18 18:30:00", tz="UTC")
+        self.place.sunrise_time.return_value = pd.Timestamp("2025-02-19 05:30:00", tz="UTC")
+        conditions = Conditions(max_return=None)
+
+        # Act
+        observation = Observation(
+            place=self.place,
+            equipment=self.equipment,
+            conditions=conditions,
+            target_date=self.target_date,
+            sun_observation=False,
+        )
+
+        # Assert
+        self.assertIsNone(observation.time_limit)
+
 
 class TestObservationTemplate(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This commit addresses an `AttributeError` in `apts.observations.Observation` that occurred when `conditions.max_return` was `None`. The `__init__` method now gracefully handles the `None` case by setting `self.time_limit` to `None`, which allows the observation to default to ending at dawn.

Additionally, a new test case has been added to `tests/observations_test.py` to ensure this scenario is covered and prevent future regressions.