### PR TITLE
Fix FutureWarning in decdeg2dms function

### DIFF
--- a/apts/utils/__init__.py
+++ b/apts/utils/__init__.py
@@ -54,6 +54,10 @@ class Utils:
         mnt, sec = divmod(dd * 3600, 60)
         deg, mnt = divmod(mnt, 60)
         if pretty:
+            if hasattr(deg, "iloc"):
+                deg = deg.iloc[0]
+                mnt = mnt.iloc[0]
+                sec = sec.iloc[0]
             return "{}°{}'{}\"".format(int(deg), int(mnt), int(sec))
         else:
             return deg, mnt, sec


### PR DESCRIPTION
The `decdeg2dms` function in `apts/utils/__init__.py` was causing a `FutureWarning` when passed a pandas Series object. This was because `int()` was being called directly on a single-element Series, which is deprecated.

This commit fixes the warning by checking if the input has an `iloc` attribute and, if so, using `iloc[0]` to extract the value before casting it to an integer.

The `DeprecationWarning` related to `openid` was investigated but found to be originating from an external project and could not be reproduced or fixed within this repository.