### PR TITLE
🔭 Stellar: Added Planetary Angular Size and Sensor Projection calculations

### DIFF
--- a/.jules/stellar.md
+++ b/.jules/stellar.md
@@ -51,3 +51,24 @@
 - Updated `apts/opticalequipment/camera/vendors/player_one.py` with the accurate data.
 - Added `tests/unit/test_player_one_specs.py` to ensure data integrity.
 - Verified with `pytest`.
+
+## 2025-05-16 - Planetary Angular Size and Projection
+
+### Observe
+- Users need to know how large a planet will appear on their sensor to choose the right focal length/Barlow.
+- The library was missing physical radius data for major planets and the Moon, as well as functions to calculate apparent angular diameter.
+
+### Target
+- Priority 3: Implement a new utility function.
+- Added planetary size projection in pixels for imaging setups.
+
+### Calibrate
+- Radius data source: IAU 2015 Standards (already in `apts/constants/astronomy.py`, but not fully mapped).
+- Angular diameter formula: $\delta = 2 \arcsin(R/D)$ where R is radius and D is geocentric distance.
+- Integrated `planetary_size_in_pixels` into `OpticalPath`.
+
+### Develop
+- Mapped `PLANET_RADII_KM` in `apts/utils/planetary.py`.
+- Implemented `get_planet_angular_diameter` and `planetary_size_in_pixels`.
+- Conducted data audit for ZWO ASI224MC and updated its specs in `zwo.py` to resolve heuristic inaccuracies.
+- Verified with `tests/unit/test_stellar_v5.py` and regression tests.

--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -744,13 +744,21 @@ class ZwoCamera(Camera):
                    'brand': 'ZWO',
                    'cside_gender': '',
                    'cside_thread': '',
+                   'full_well_e': 19200,
+                   'height': 976,
                    'mass': 60,
                    'name': 'ASI224MC',
                    'optical_length': 12.5,
+                   'pixel_size_um': 3.75,
+                   'quantum_efficiency_pct': 80,
+                   'read_noise_e': 0.75,
                    'reversible': False,
+                   'sensor_height_mm': 3.6,
+                   'sensor_width_mm': 4.8,
                    'tside_gender': 'Female',
                    'tside_thread': 'CS',
-                   'type': 'type_camera'},
+                   'type': 'type_camera',
+                   'width': 1304},
  'ZWO_ASI_2400MC_Pro': {'bf_role': 'end',
                         'brand': 'ZWO',
                         'cside_gender': '',
@@ -2319,7 +2327,11 @@ class ZwoCamera(Camera):
 
     @classmethod
     def ZWO_ASI_224MC(cls):
-        return cls.from_database(cls._DATABASE['ZWO_ASI_224MC'])
+        """
+        Factory method for ZWO ASI224MC camera.
+        Sensor: Sony IMX224 (1/3")
+        """
+        return cls.from_database(cls._DATABASE["ZWO_ASI_224MC"])
 
     @classmethod
     def ZWO_ASI_290MM_Mini(cls):

--- a/apts/optics.py
+++ b/apts/optics.py
@@ -763,6 +763,21 @@ class OpticalPath:
         p_size = p_size_q.to("micrometer").magnitude
         return k * p_size
 
+    def planetary_size_in_pixels(self, planet_name: str, time: Any) -> float | None:
+        """
+        Calculates the projected size of a planet on the sensor in pixels.
+        Uses the planet's angular diameter and the setup's pixel scale.
+        """
+        from .utils import planetary
+
+        angular_diameter = planetary.get_planet_angular_diameter(planet_name, time)
+        p_scale = self.pixel_scale()
+
+        if p_scale is None or p_scale.magnitude == 0:
+            return None
+
+        return float(angular_diameter / p_scale.magnitude)
+
     def rule_of_500(self):
         """
         Calculates the maximum exposure time to avoid star trailing using the classic Rule of 500.

--- a/apts/utils/planetary.py
+++ b/apts/utils/planetary.py
@@ -11,6 +11,7 @@ from skyfield import almanac
 
 from apts.cache import get_ephemeris, get_mpcorb_data, get_timescale
 from apts.i18n import language_context, gettext_
+from apts.constants import astronomy
 
 MINOR_PLANET_NAMES = {
     "ceres": "(1) Ceres",
@@ -77,6 +78,58 @@ APHELION_PERIHELION_PLANETS = [
     "makemake",
     "eris",
 ]
+
+PLANET_RADII_KM = {
+    "mercury": astronomy.MERCURY_RADIUS_KM,
+    "venus": astronomy.VENUS_RADIUS_KM,
+    "earth": astronomy.EARTH_RADIUS_KM,
+    "mars": astronomy.MARS_RADIUS_KM,
+    "jupiter": astronomy.JUPITER_RADIUS_KM,
+    "saturn": astronomy.SATURN_RADIUS_KM,
+    "uranus": astronomy.URANUS_RADIUS_KM,
+    "neptune": astronomy.NEPTUNE_RADIUS_KM,
+    "pluto": astronomy.PLUTO_RADIUS_KM,
+    "moon": astronomy.MOON_RADIUS_KM,
+    "sun": astronomy.SUN_RADIUS_KM,
+}
+
+
+def get_planet_radius_km(planet_name: str) -> float:
+    """
+    Returns the equatorial radius of a planet in km.
+    """
+    # Normalize name to simple name
+    simple_name = get_simple_name(planet_name).lower()
+    radius = PLANET_RADII_KM.get(simple_name)
+    if radius is None:
+        raise ValueError(f"Radius for object '{planet_name}' not found.")
+    return radius
+
+
+def get_planet_distance_km(planet_name: str, time: Any) -> float:
+    """
+    Returns the geocentric distance to the planet in km.
+    """
+    eph = get_ephemeris()
+    earth = eph["earth"]
+    planet_obj = get_skyfield_obj(planet_name)
+    return cast(Any, earth).at(time).observe(planet_obj).distance().km
+
+
+def get_planet_angular_diameter(planet_name: str, time: Any) -> float:
+    """
+    Returns the apparent angular diameter of the planet in arcseconds.
+    Formula: diameter = 2 * arcsin(Radius / Distance)
+    """
+    radius = get_planet_radius_km(planet_name)
+    distance = get_planet_distance_km(planet_name, time)
+
+    # Angular diameter in radians
+    # Using arcsin(R/D) gives the angular radius, so multiply by 2 for diameter.
+    alpha_rad = 2 * np.arcsin(radius / distance)
+
+    # Convert to arcseconds
+    return float(np.degrees(alpha_rad) * 3600.0)
 
 
 def get_simple_name(technical_name: str) -> str:

--- a/tests/unit/test_stellar_v5.py
+++ b/tests/unit/test_stellar_v5.py
@@ -1,0 +1,53 @@
+import pytest
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from apts.cache import get_timescale
+from apts.optics import OpticalPath
+from apts.opticalequipment.telescope.base import Telescope
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils import planetary
+
+def test_jupiter_angular_diameter():
+    ts = get_timescale()
+    # Jupiter opposition was around 2023-11-03
+    t = ts.utc(2023, 11, 3, 12, 0)
+
+    # Expected angular diameter for Jupiter at opposition is ~49 arcseconds
+    diam = planetary.get_planet_angular_diameter("Jupiter", t)
+    assert diam == pytest.approx(49.5, abs=1.0)
+
+def test_planetary_projection_size():
+    ts = get_timescale()
+    t = ts.utc(2023, 11, 3, 12, 0)
+
+    # Setup: C8 (2032mm focal length) with ASI224MC (3.75um pixels)
+    # Using a 2x Barlow (effective FL = 4064mm)
+    scope = Telescope(203, 2032, vendor="C8")
+    camera = cast(Any, ZwoCamera).ZWO_ASI_224MC()
+
+    from apts.opticalequipment.barlow import Barlow
+    barlow = Barlow(2.0, "2x Barlow")
+
+    path = OpticalPath(scope, [barlow], [], [], [], camera)
+
+    # Pixel scale: (3.75 / 4064) * 206265 = 0.19 arcsec/pixel
+    scale = path.pixel_scale()
+    assert scale.magnitude == pytest.approx(0.19, abs=0.01)
+
+    # Jupiter size in pixels: 49.5 / 0.19 = ~260 pixels
+    size_px = path.planetary_size_in_pixels("Jupiter", t)
+    assert size_px == pytest.approx(260, abs=10)
+
+def test_planet_radius_lookup():
+    assert planetary.get_planet_radius_km("Mars") == pytest.approx(3396.2)
+    assert planetary.get_planet_radius_km("Jupiter") == pytest.approx(71492.0)
+    with pytest.raises(ValueError):
+        planetary.get_planet_radius_km("UnknownBody")
+
+def test_planet_distance():
+    ts = get_timescale()
+    t = ts.utc(2023, 11, 3, 12, 0)
+    # Geocentric distance to Jupiter at opposition is roughly 4 AU
+    dist = planetary.get_planet_distance_km("Jupiter", t)
+    assert dist / 149597870.7 == pytest.approx(3.98, abs=0.1)


### PR DESCRIPTION
Added planetary size projection in pixels and angular diameter calculations to the `apts` library.

💡 What:
- Implemented `get_planet_angular_diameter` in `apts/utils/planetary.py` using the high-precision formula δ = 2 ⋅ arcsin(R/D).
- Added `planetary_size_in_pixels` to the `OpticalPath` class in `apts/optics.py`.
- Conducted a data audit and updated the `ZWO ASI224MC` specifications with manufacturer-verified data (IMX224 sensor, 3.75µm pixels, 19.2ke- full well).
- Mapped `PLANET_RADII_KM` using IAU 2015 Standards.

🎯 Why:
Astrophotographers need to know how large a planet will appear on their sensor to select the optimal focal length and Barlow lens. These additions provide precise projection data based on the real-time distance to the target.

📚 Source:
- Formula: Guy Ottewell, 'Astronomical Companion'.
- Data: IAU 2015 Resolution B3 on recommended nominal constants for fundamental astronomy.

---
*PR created automatically by Jules for task [11398918904001804077](https://jules.google.com/task/11398918904001804077) started by @pozar87*