### PR TITLE
🔭 Stellar: Added Alt-Az field rotation calculations

### DIFF
--- a/apts/optics.py
+++ b/apts/optics.py
@@ -778,6 +778,69 @@ class OpticalPath:
 
         return float(angular_diameter / p_scale.magnitude)
 
+    def field_rotation_rate(
+        self, latitude_degrees: float, azimuth_degrees: float, altitude_degrees: float
+    ) -> Any | None:
+        """
+        Calculates the field rotation rate for an Alt-Az mount in arcseconds per second.
+        Formula: omega_rot = omega_e * cos(phi) * cos(Az) / cos(Alt)
+        Where omega_e is the sidereal rotation rate (15.041067"/s).
+        Source: "Field Rotation" by Bill Keel
+        """
+        # Sidereal rate in arcseconds per second
+        omega_e = 15.041067
+
+        phi = numpy.radians(latitude_degrees)
+        az = numpy.radians(azimuth_degrees)
+        alt = numpy.radians(min(altitude_degrees, 89.99))  # Avoid zenith singularity
+
+        rate = omega_e * numpy.cos(phi) * numpy.cos(az) / numpy.cos(alt)
+        return rate * (get_unit_registry().arcsecond / get_unit_registry().second)
+
+    def max_exposure_alt_az(
+        self,
+        latitude_degrees: float,
+        azimuth_degrees: float,
+        altitude_degrees: float,
+        tolerance_pixels: float = 1.0,
+    ) -> Any | None:
+        """
+        Calculates the maximum exposure time for an Alt-Az mount to avoid field rotation trailing.
+        The trailing is measured at the corner of the sensor.
+        Formula: t = tol / (R_pixels * omega_rot_rad_s)
+        Where R_pixels is the distance from the center to the corner in pixels.
+        """
+        from .opticalequipment.camera import Camera
+        from .opticalequipment.smart_telescope import SmartTelescope
+
+        if not isinstance(self.output, (Camera, SmartTelescope)):
+            return None
+
+        # Field rotation rate in arcsec/s
+        rate_q = self.field_rotation_rate(
+            latitude_degrees, azimuth_degrees, altitude_degrees
+        )
+        if rate_q is None:
+            return None
+
+        rate_arcsec_s = abs(rate_q.magnitude)
+        if rate_arcsec_s < 1e-10:
+            return 3600 * get_unit_registry().second
+
+        # Rotation rate in radians per second
+        rate_rad_s = rate_arcsec_s / 206265.0
+
+        # Distance from center to corner in pixels
+        w = self.output.width
+        h = self.output.height
+        r_pixels = numpy.sqrt((w / 2.0) ** 2 + (h / 2.0) ** 2)
+
+        if r_pixels == 0:
+            return 3600 * get_unit_registry().second
+
+        t = tolerance_pixels / (r_pixels * rate_rad_s)
+        return t * get_unit_registry().second
+
     def rule_of_500(self):
         """
         Calculates the maximum exposure time to avoid star trailing using the classic Rule of 500.

--- a/tests/unit/test_field_rotation.py
+++ b/tests/unit/test_field_rotation.py
@@ -1,0 +1,67 @@
+import unittest
+from typing import Any, cast
+from unittest.mock import MagicMock
+import numpy as np
+from apts.optics import OpticalPath
+from apts.units import get_unit_registry
+from apts.opticalequipment.telescope import Telescope
+from apts.opticalequipment.camera import Camera
+
+class TestFieldRotation(unittest.TestCase):
+    def setUp(self):
+        self.ureg = get_unit_registry()
+
+    def test_field_rotation_rate(self):
+        t = MagicMock(spec=Telescope)
+        path = OpticalPath(t, [], [], [], [], MagicMock())
+
+        # Test at equator (lat 0), North (az 0), 45 deg altitude
+        # rate = 15.041067 * cos(0) * cos(0) / cos(45) = 15.041067 / (1/sqrt(2)) = 15.041067 * sqrt(2) approx 21.271
+        rate = path.field_rotation_rate(0, 0, 45)
+        self.assertAlmostEqual(cast(Any, rate).magnitude, 15.041067 * np.sqrt(2), places=3)
+        self.assertEqual(cast(Any, rate).units, self.ureg.arcsecond / self.ureg.second)
+
+        # Test at Pole (lat 90)
+        # rate = 15.041067 * cos(90) * cos(0) / cos(45) = 0
+        rate_pole = path.field_rotation_rate(90, 0, 45)
+        self.assertAlmostEqual(cast(Any, rate_pole).magnitude, 0.0, places=3)
+
+        # Test at zenith (alt 90) - should be capped by 89.99
+        # rate approx 15.041067 * cos(lat) * cos(az) / cos(89.99)
+        rate_zenith = path.field_rotation_rate(45, 0, 90)
+        # cos(89.99) is very small, so rate should be large but finite
+        self.assertTrue(cast(Any, rate_zenith).magnitude > 1000)
+
+    def test_max_exposure_alt_az(self):
+        t = MagicMock(spec=Telescope)
+
+        c = MagicMock(spec=Camera)
+        # ZWO ASI1600: 4656 x 3520
+        c.width = 4656
+        c.height = 3520
+
+        path = OpticalPath(t, [], [], [], [], c)
+
+        # Distance to corner: sqrt((4656/2)^2 + (3520/2)^2) = sqrt(2328^2 + 1760^2) approx 2918.4 pixels
+        # At lat 45, az 0, alt 45:
+        # rate = 15.041067 * cos(45) * cos(0) / cos(45) = 15.041067 arcsec/s
+        # rate_rad_s = 15.041067 / 206265 approx 7.292e-5 rad/s
+        # max_exp = 1.0 / (2918.4 * 7.292e-5) approx 4.70 seconds
+
+        max_exp = path.max_exposure_alt_az(45, 0, 45, tolerance_pixels=1.0)
+
+        r_pixels = np.sqrt((4656/2.0)**2 + (3520/2.0)**2)
+        rate_arcsec_s = 15.041067 * np.cos(np.radians(45)) * np.cos(np.radians(0)) / np.cos(np.radians(45))
+        rate_rad_s = rate_arcsec_s / 206265.0
+        expected = 1.0 / (r_pixels * rate_rad_s)
+
+        self.assertAlmostEqual(cast(Any, max_exp).magnitude, expected, places=2)
+        self.assertEqual(cast(Any, max_exp).units, self.ureg.second)
+
+    def test_max_exposure_non_camera(self):
+        t = MagicMock(spec=Telescope)
+        path = OpticalPath(t, [], [], [], [], MagicMock()) # Not a Camera
+        self.assertIsNone(path.max_exposure_alt_az(45, 0, 45))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented high-precision field rotation rate and maximum exposure time calculations for Alt-Az mounts. These features help users of smart telescopes and traditional Alt-Az setups optimize their sub-exposure times to avoid field rotation trailing at the sensor corners. Added comprehensive unit tests to verify the math against known scenarios and ensure robustness near the zenith singularity.

---
*PR created automatically by Jules for task [11888740009770774136](https://jules.google.com/task/11888740009770774136) started by @pozar87*