### PR TITLE
🧪 Q: Improved type safety and test coverage in optics and equipment

### DIFF
--- a/apts/opticalequipment/abstract.py
+++ b/apts/opticalequipment/abstract.py
@@ -190,6 +190,10 @@ class OutputOpticalEquipment(OpticalEquipment):
         """Indicates if the output is primarily for visual observation."""
         return True  # Default for eyepieces etc.
 
+    def field_of_view(self, telescope, zoom, barlow_magnification):
+        """Calculates field of view."""
+        raise NotImplementedError("Subclasses must implement field_of_view")
+
     def field_of_view_width(self, telescope, zoom, barlow_magnification):
         """Calculates horizontal field of view."""
         return self.field_of_view(telescope, zoom, barlow_magnification)

--- a/apts/opticalequipment/binoculars.py
+++ b/apts/opticalequipment/binoculars.py
@@ -55,7 +55,7 @@ class Binoculars(OutputOpticalEquipment):
         # True Field of View = Apparent FOV / Magnification
         return self.apparent_fov_deg / self.magnification
 
-    def exit_pupil(self):
+    def exit_pupil(self, telescope=None, zoom=None):
         return self.objective_diameter / self.magnification
 
     def dawes_limit(self):
@@ -93,7 +93,7 @@ class Binoculars(OutputOpticalEquipment):
 
         return 7.7 + 5 * numpy.log10(self.objective_diameter.to("cm").magnitude)
 
-    def brightness(self):
+    def brightness(self, telescope=None, zoom=None):
         # Relative brightness: (Exit Pupil (mm) / 7mm)^2 * 100
         # Assuming 7mm is the max human eye pupil diameter
         return (self.exit_pupil().to("mm").magnitude / 7) ** 2 * 100

--- a/apts/opticalequipment/naked_eye.py
+++ b/apts/opticalequipment/naked_eye.py
@@ -38,7 +38,7 @@ class NakedEye(OutputOpticalEquipment):
     def fov(self):
         return self.apparent_fov_deg / self.magnification
 
-    def exit_pupil(self):
+    def exit_pupil(self, telescope=None, zoom=None):
         return self.objective_diameter / self.magnification
 
     def dawes_limit(self):
@@ -60,7 +60,7 @@ class NakedEye(OutputOpticalEquipment):
 
         return 7.7 + 5 * numpy.log10(self.objective_diameter.to("cm").magnitude)  # pyright: ignore
 
-    def brightness(self):
+    def brightness(self, telescope=None, zoom=None):
         return (self.exit_pupil().to("mm").magnitude / 7) ** 2 * 100  # pyright: ignore
 
     def register(self, equipment):

--- a/tests/unit/test_jovian_moon_events.py
+++ b/tests/unit/test_jovian_moon_events.py
@@ -5,7 +5,6 @@ from apts.cache import get_timescale
 from apts.constants.event_types import EventType
 from apts.events import AstronomicalEvents
 from apts.place import Place
-from unittest.mock import patch
 from apts.skyfield_searches import find_jovian_moon_events, find_solar_longitude_time
 
 utc = timezone.utc

--- a/tests/unit/test_optics.py
+++ b/tests/unit/test_optics.py
@@ -249,6 +249,34 @@ class TestOptics(unittest.TestCase):
         c.pixel_size.return_value = None
         self.assertIsNone(path.ideal_planetary_focal_ratio())
 
+    def test_required_subs_for_snr(self):
+        t = MagicMock(spec=Telescope)
+        c = MagicMock(spec=Camera)
+        path = OpticalPath(t, [], [], [], [], c)
+
+        # Mock object_flux and sky_flux
+        # If signal s=10, background b=5, read noise squared r=4
+        # target_snr = 5
+        # n_required = 5^2 * (10 + 5 + 4) / 10^2 = 25 * 19 / 100 = 4.75 -> ceil -> 5
+        path.object_flux = MagicMock(return_value=1.0)  # e-/s
+        path.sky_flux = MagicMock(return_value=0.5)  # e-/s/pixel
+        c.read_noise = 2.0  # e- (r = 4)
+
+        exposure_time = 10.0
+        # s = 1.0 * 10.0 = 10.0
+        # b = 0.5 * 10.0 * 1 = 5.0 (n_pix=1)
+        # r = 2.0^2 * 1 = 4.0 (n_pix=1)
+
+        n_subs = path.required_subs_for_snr(
+            target_snr=5.0,
+            magnitude=10.0,
+            sqm=21.0,
+            exposure_time=exposure_time,
+            n_pix=1
+        )
+
+        self.assertEqual(n_subs, 5.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR addresses several quality issues identified during a static analysis and coverage audit:

1.  **Interface Consistency & Type Safety:** The `OutputOpticalEquipment` base class was missing the `field_of_view` method, despite it being called by its own derived methods (like `field_of_view_width`). This caused Pyright errors. I added the abstract method and updated `Binoculars` and `NakedEye` to have compatible signatures for `exit_pupil` and `brightness`.
2.  **Linting:** Fixed an unused import in the test suite discovered by Ruff.
3.  **Testing:** Added a comprehensive unit test for `required_subs_for_snr` in `apts/optics.py`, which was previously lacking specific coverage for its ceiling logic and signal/noise integration.

Verified with `pyright apts/opticalequipment` and `PYTHONPATH=. python3 tests/unit/test_optics.py`.

---
*PR created automatically by Jules for task [17868960516000691041](https://jules.google.com/task/17868960516000691041) started by @pozar87*