### PR TITLE
🔭 Stellar: Added dB option to SNR and improved documentation

### DIFF
--- a/apts/optics.py
+++ b/apts/optics.py
@@ -471,6 +471,14 @@ class OpticalPath:
         return drift * get_unit_registry().mm
 
     def sky_flux(self, sqm: float) -> Optional[float]:
+        """
+        Calculates the sky background flux in electrons per second per pixel.
+        Assumes an L-band (clear) filter equivalent and a zero point where a 21.83 mag/arcsec^2
+        sky produces a specific reference flux.
+
+        :param sqm: Sky Quality Meter reading in mag/arcsec^2.
+        :return: Sky flux in e-/s/pixel.
+        """
         from .opticalequipment.camera import Camera
         from .opticalequipment.smart_telescope import SmartTelescope
 
@@ -490,7 +498,7 @@ class OpticalPath:
 
         pixel_area_arcsec2 = scale.magnitude**2
 
-        # Formula
+        # Formula: Reference flux scaled by aperture, QE, and sky brightness
         flux = (
             0.005
             * 10 ** (0.4 * (21.83 - sqm))
@@ -507,6 +515,15 @@ class OpticalPath:
         altitude: Optional[float] = None,
         extinction_k: float = 0.2,
     ) -> Optional[float]:
+        """
+        Calculates the total integrated flux from an object in electrons per second.
+        The calculation is based on the object's magnitude and the setup's aperture and QE.
+
+        :param magnitude: Apparent magnitude of the object.
+        :param altitude: Optional altitude in degrees to account for atmospheric extinction.
+        :param extinction_k: Atmospheric extinction coefficient (default 0.2).
+        :return: Total integrated object flux in e-/s.
+        """
         from .opticalequipment.camera import Camera
         from .opticalequipment.smart_telescope import SmartTelescope
 
@@ -531,7 +548,7 @@ class OpticalPath:
         for f in self.filters:
             transmission *= f.transmission
 
-        # Total flux from the object
+        # Total integrated flux from the object
         # Based on the same zero point as sky_flux
         flux = (
             0.005
@@ -551,7 +568,23 @@ class OpticalPath:
         n_pix: int = 4,
         altitude: Optional[float] = None,
         extinction_k: float = 0.2,
+        in_db: bool = False,
     ) -> Optional[float]:
+        """
+        Calculates the Signal-to-Noise Ratio (SNR) for an object in the given optical path.
+        The model accounts for object shot noise, sky background shot noise, and sensor read noise.
+        It assumes aperture photometry where the object signal is integrated over `n_pix` pixels.
+
+        :param magnitude: Apparent magnitude of the object.
+        :param sqm: Sky Quality Meter reading in mag/arcsec^2.
+        :param exposure_time: Exposure time per sub-exposure in seconds.
+        :param n_subs: Number of sub-exposures stacked.
+        :param n_pix: Number of pixels over which the object signal is integrated (default 4).
+        :param altitude: Optional altitude in degrees for atmospheric extinction.
+        :param extinction_k: Atmospheric extinction coefficient (default 0.2).
+        :param in_db: If True, returns SNR in decibels (20 * log10).
+        :return: SNR (dimensionless linear ratio or dB).
+        """
         from .opticalequipment.camera import Camera
         from .opticalequipment.smart_telescope import SmartTelescope
 
@@ -581,7 +614,14 @@ class OpticalPath:
         if total_noise == 0:
             return 0.0
 
-        return signal / total_noise
+        snr_linear = signal / total_noise
+
+        if in_db:
+            if snr_linear <= 0:
+                return -numpy.inf
+            return 20.0 * numpy.log10(snr_linear)
+
+        return snr_linear
 
     def required_subs_for_snr(
         self,

--- a/tests/unit/test_optics_snr_extension.py
+++ b/tests/unit/test_optics_snr_extension.py
@@ -1,9 +1,10 @@
+import pytest
+import numpy as np
 from apts.light_pollution import LightPollution
 from apts.place import Place
 from apts.optics import OpticalPath
 from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
 from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
-import numpy as np
 
 def test_bortle_to_sqm():
     # Test midpoints
@@ -69,3 +70,47 @@ def test_camera_limiting_magnitude():
     snr_at_limit = path.snr(limit_mag, sqm, sub_time, n_subs=int(n_subs))
     assert snr_at_limit is not None
     assert abs(snr_at_limit - 5.0) < 0.1
+
+def test_snr_db_conversion():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Esprit_100ED()
+    camera = ZwoCamera.ZWO_ASI2600MC_PRO()
+    path = OpticalPath.from_path([telescope, camera])
+
+    magnitude = 15.0
+    sqm = 21.0
+    exposure_time = 60
+
+    snr_linear = path.snr(magnitude, sqm, exposure_time, in_db=False)
+    snr_db = path.snr(magnitude, sqm, exposure_time, in_db=True)
+
+    assert snr_linear is not None
+    assert snr_db is not None
+    # SNR in dB should be 20 * log10(SNR_linear)
+    assert snr_db == pytest.approx(20.0 * np.log10(snr_linear))
+
+    # Test edge case: SNR <= 0
+    # Zero exposure time ensures zero signal and thus zero SNR
+    snr_zero_linear = path.snr(magnitude, sqm, exposure_time=0.0)
+    snr_zero_db = path.snr(magnitude, sqm, exposure_time=0.0, in_db=True)
+    assert snr_zero_linear == 0.0
+    assert snr_zero_db == -np.inf
+
+def test_snr_extinction_verification():
+    # Verify that SNR calculation accounts for atmospheric extinction
+    telescope = Sky_watcherTelescope.Sky_Watcher_Esprit_100ED()
+    camera = ZwoCamera.ZWO_ASI2600MC_PRO()
+    path = OpticalPath.from_path([telescope, camera])
+
+    magnitude = 10.0
+    sqm = 21.0
+    exposure_time = 60
+
+    # Zenith (altitude 90, airmass 1.0)
+    snr_zenith = path.snr(magnitude, sqm, exposure_time, altitude=90.0, extinction_k=0.2)
+    # Near horizon (altitude 10, airmass ~5.6)
+    snr_low = path.snr(magnitude, sqm, exposure_time, altitude=10.0, extinction_k=0.2)
+
+    assert snr_zenith is not None
+    assert snr_low is not None
+    # Extinction should make the star fainter at lower altitudes, thus lower SNR
+    assert snr_zenith > snr_low


### PR DESCRIPTION
I have verified the Signal-to-Noise Ratio (SNR) calculations in the `apts` library and added an option to represent the result in decibels (dB), as requested.

### Key Changes:
- **SNR in dB:** Added an `in_db` parameter to the `snr` method in `apts/optics.py`. When set to `True`, it returns the SNR using the standard amplitude ratio formula: \( SNR_{dB} = 20 \cdot \log_{10}(SNR_{linear}) \). This addresses the feedback that SNR values can appear "very big" by providing a more compact logarithmic representation.
- **Verification & Documentation:**
    - Verified that the flux models correctly account for aperture area, quantum efficiency, filter transmission, and atmospheric extinction (via altitude and extinction coefficient).
    - Added detailed docstrings to `snr`, `sky_flux`, and `object_flux` to clarify input units (seconds for exposure, mag/arcsec² for SQM) and the underlying mathematical assumptions.
- **Enhanced Testing:**
    - Added a unit test to verify the linear-to-dB conversion accuracy.
    - Added a verification test to ensure SNR properly degrades with atmospheric extinction at lower altitudes.
    - Handled edge cases like zero signal leading to negative infinity dB.

All existing and new tests pass, confirming the robustness and accuracy of the SNR model.

---
*PR created automatically by Jules for task [12500943451616005234](https://jules.google.com/task/12500943451616005234) started by @pozar87*