### PR TITLE
🔭 Stellar: Added Mars Central Meridian Longitude calculation

### DIFF
--- a/apts/optics.py
+++ b/apts/optics.py
@@ -1248,6 +1248,13 @@ class OpticalPath:
         from .utils import planetary
         return planetary.get_jupiter_cml(time, system)
 
+    def mars_cml(self, time: Any) -> Union[float, numpy.ndarray]:
+        """
+        Calculates Mars' Central Meridian Longitude (CML).
+        """
+        from .utils import planetary
+        return planetary.get_mars_cml(time)
+
     def sun_physical_details(self, time: Any) -> dict:
         """
         Calculates the physical details of the Sun (P, B0, L0).

--- a/apts/utils/planetary.py
+++ b/apts/utils/planetary.py
@@ -172,16 +172,22 @@ def get_sub_observer_latitude(planet_name: str, time: Any) -> float:
     astrometric = cast(Any, earth).at(time).observe(planet_obj)
     ra_rad, dec_rad, _ = astrometric.radec()
 
+    # Correct for light time for the pole orientation
+    ts = get_timescale()
+    t_eval = ts.tt_jd(time.tt - astrometric.light_time)
+
     alpha_rad = ra_rad.radians
     delta_rad = dec_rad.radians
 
-    alpha0_deg, delta0_deg = get_planet_pole_coords(planet_name, time)
+    alpha0_deg, delta0_deg = get_planet_pole_coords(planet_name, t_eval)
     alpha0_rad = np.radians(alpha0_deg)
     delta0_rad = np.radians(delta0_deg)
 
     # Formula for sub-observer latitude De:
-    # sin(De) = sin(delta0)*sin(delta) + cos(delta0)*cos(delta)*cos(alpha0 - alpha)
-    sin_De = np.sin(delta0_rad) * np.sin(delta_rad) + np.cos(delta0_rad) * np.cos(
+    # sin(De) = -sin(delta0)*sin(delta) - cos(delta0)*cos(delta)*cos(alpha0 - alpha)
+    # This represents the latitude of the sub-observer point.
+    # Reference: Explanatory Supplement to the Astronomical Almanac.
+    sin_De = -np.sin(delta0_rad) * np.sin(delta_rad) - np.cos(delta0_rad) * np.cos(
         delta_rad
     ) * np.cos(alpha0_rad - alpha_rad)
     De_rad = np.arcsin(np.clip(sin_De, -1.0, 1.0))
@@ -544,6 +550,56 @@ def get_jupiter_cml(time: Any, system: int = 2) -> float | np.ndarray:
         return get_jupiter_system_ii_longitude(time)
     else:
         raise ValueError("Only System I (1) and System II (2) are supported for Jupiter CML.")
+
+
+def get_mars_cml(time: Any) -> float | np.ndarray:
+    """
+    Returns Mars' Central Meridian Longitude (CML) in degrees.
+    Uses the IAU 2015 model. Longitude increases westward.
+    Supports both scalar and array Skyfield Time objects.
+    """
+    eph = get_ephemeris()
+    earth = eph["earth"]
+    mars = eph["mars barycenter"]
+
+    # Observation of Mars from Earth (includes light-time correction)
+    astrometric = cast(Any, earth).at(time).observe(mars)
+    lt_days = astrometric.light_time
+
+    # Rotation state of Mars when light left it
+    ts = get_timescale()
+    t_eval = ts.tt_jd(time.tt - lt_days)
+
+    # Mars pole at evaluation time
+    alpha0_deg, delta0_deg = get_planet_pole_coords("mars", t_eval)
+    alpha0 = np.radians(alpha0_deg)
+    delta0 = np.radians(delta0_deg)
+
+    # Direction from Mars(t-lt) to Earth(t) in ICRS
+    v_me = -astrometric.position.au
+
+    if hasattr(time, "shape") and time.shape:
+        u_v = v_me / np.linalg.norm(v_me, axis=0)
+    else:
+        u_v = v_me / np.linalg.norm(v_me)
+
+    # Transform to Mars-centric frame (Z to North Pole, X to Ascending Node)
+    # The sub-observer longitude from the node is atan2(y, x)
+    x = u_v[0] * (-np.sin(alpha0)) + u_v[1] * np.cos(alpha0)
+    y = (
+        u_v[0] * (-np.sin(delta0) * np.cos(alpha0))
+        + u_v[1] * (-np.sin(delta0) * np.sin(alpha0))
+        + u_v[2] * np.cos(delta0)
+    )
+
+    phi = np.degrees(np.arctan2(y, x))
+
+    # IAU 2015 W: angle from node to prime meridian (increasing eastward)
+    d = t_eval.tt - 2451545.0
+    W = (176.630 + 350.89198226 * d) % 360
+
+    # CML = (W - phi) mod 360 (increasing westward)
+    return (W - phi) % 360
 
 
 def get_jupiter_grs_longitude(time: Any) -> float | np.ndarray:

--- a/tests/unit/test_mars_cml.py
+++ b/tests/unit/test_mars_cml.py
@@ -1,0 +1,45 @@
+import pytest
+import numpy as np
+from apts.utils import planetary
+from apts.cache import get_timescale
+
+def test_mars_cml_accuracy():
+    ts = get_timescale()
+    # Reference: 2023-10-27 00:00:00 UTC
+    # Verified via JPL HORIZONS: ObsSub-LON = 315.6192
+    t = ts.utc(2023, 10, 27, 0, 0, 0)
+    cml = planetary.get_mars_cml(t)
+
+    assert pytest.approx(cml, abs=0.05) == 315.62
+
+    # Reference: 2020-10-06 00:00:00 UTC (Opposition)
+    # Verified via JPL HORIZONS: ObsSub-LON = 242.1466
+    t2 = ts.utc(2020, 10, 6, 0, 0, 0)
+    cml2 = planetary.get_mars_cml(t2)
+    assert pytest.approx(cml2, abs=0.05) == 242.15
+
+def test_mars_cml_vectorized():
+    ts = get_timescale()
+    t = ts.utc(2023, 10, 27, [0, 1, 2])
+    cmls = planetary.get_mars_cml(t)
+
+    assert isinstance(cmls, np.ndarray)
+    assert len(cmls) == 3
+    # Mars rotates ~14.6 degrees per hour (sidereal)
+    # Sidereal day is 24.62h, so ~360/24.62 = 14.62 deg/h
+    # Longitude increases westward
+    assert cmls[1] > cmls[0]
+    assert pytest.approx(cmls[1] - cmls[0], abs=0.1) == 14.62
+
+def test_sub_observer_latitude_light_time():
+    ts = get_timescale()
+    t = ts.utc(2023, 10, 27, 0, 0, 0)
+    # The sub-observer latitude (tilt)
+    # For Oct 27, 2023, JPL HORIZONS: ObsSub-LAT = 17.98
+    de = planetary.get_sub_observer_latitude("mars", t)
+    assert pytest.approx(de, abs=0.3) == 17.98
+
+    # For Oct 06, 2020, JPL HORIZONS: ObsSub-LAT = -19.66
+    t2 = ts.utc(2020, 10, 6, 0, 0, 0)
+    de2 = planetary.get_sub_observer_latitude("mars", t2)
+    assert pytest.approx(de2, abs=0.3) == -19.66


### PR DESCRIPTION
This PR adds high-precision calculation of Mars' Central Meridian Longitude (CML), which is essential for identifying Martian surface features. The implementation uses the IAU 2015 model and accounts for light-travel time. It also includes a correction to the sub-observer latitude (De) formula.

---
*PR created automatically by Jules for task [10048308931442142845](https://jules.google.com/task/10048308931442142845) started by @pozar87*