### PR TITLE
🧪 Q: Fix type errors, add planetary geometry tests, and clean up imports

### DIFF
--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -194,7 +194,7 @@ def find_golden_blue_hours(observer, start_date, end_date):
     return events
 
 
-def find_venus_greatest_brilliancy(observer, start_date, end_date):
+def find_venus_greatest_brilliancy(observer: Any, start_date: Any, end_date: Any):
     """
     Finds when Venus reaches its greatest brilliancy (minimum apparent magnitude).
     """
@@ -206,7 +206,7 @@ def find_venus_greatest_brilliancy(observer, start_date, end_date):
 
     # For planetary magnitude, we use geocentric position (earth.at(t))
     # to match standard almanac definitions for greatest brilliancy.
-    earth = get_ephemeris()["earth"]
+    earth = cast(Any, get_ephemeris()["earth"])
 
     def magnitude(t):
         astrometric = earth.at(t).observe(venus)

--- a/tests/unit/test_planetary_geometry.py
+++ b/tests/unit/test_planetary_geometry.py
@@ -1,5 +1,3 @@
-import pytest
-import numpy as np
 from skyfield.api import load
 from apts.utils import planetary
 from apts.optics import OpticalPath
@@ -58,3 +56,25 @@ def test_sub_observer_latitude_range():
     lat = planetary.get_sub_observer_latitude("Saturn", t)
     # Saturn's rings are currently closing but tilt is still non-zero
     assert -30 <= lat <= 30
+
+def test_planetary_geometry_apparent_polar_coverage():
+    ts = load.timescale()
+    # Test Saturn when tilt is significant (e.g., 2017)
+    t = ts.utc(2017, 6, 15)
+
+    d_eq = planetary.get_planet_angular_diameter("Saturn", t, which="equatorial")
+    d_pol = planetary.get_planet_angular_diameter("Saturn", t, which="polar")
+    d_app = planetary.get_planet_angular_diameter("Saturn", t, which="apparent_polar")
+
+    # In 2017, Saturn's tilt was near maximum (~27°).
+    # d_app = d_eq * sqrt(1 - (2f - f^2) * cos^2(tilt))
+    # As tilt increases (away from 0), d_app should increase from d_pol towards d_eq.
+    assert d_pol < d_app < d_eq
+
+    # Test Mars (oblate)
+    d_eq_m = planetary.get_planet_angular_diameter("Mars", t, which="equatorial")
+    d_pol_m = planetary.get_planet_angular_diameter("Mars", t, which="polar")
+    d_app_m = planetary.get_planet_angular_diameter("Mars", t, which="apparent_polar")
+
+    assert d_eq_m > d_pol_m
+    assert d_pol_m <= d_app_m <= d_eq_m

--- a/tests/unit/test_sharpstar_specs.py
+++ b/tests/unit/test_sharpstar_specs.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.telescope.vendors.sharpstar import SharpstarTelescope
 
 def test_sharpstar_61edph_ii():

--- a/tests/unit/test_stellar_v10.py
+++ b/tests/unit/test_stellar_v10.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from apts.optics import OpticalPath
 from apts.opticalequipment.telescope.vendors.askar import AskarTelescope
 from apts.opticalequipment.camera.vendors.zwo import ZwoCamera

--- a/tests/unit/test_svbony_122_specs.py
+++ b/tests/unit/test_svbony_122_specs.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.telescope.vendors.svbony import SvbonyTelescope
 from apts.units import get_unit_registry
 


### PR DESCRIPTION
This PR improves the overall health of the codebase by addressing type-checking errors, adding missing test coverage for critical planetary calculations, and cleaning up linting violations.

Specifically:
- In `apts/skyfield_searches.py`, type hints and casts were added to `find_venus_greatest_brilliancy` to satisfy `pyright` while maintaining standard Skyfield patterns.
- `tests/unit/test_planetary_geometry.py` now includes a test for `apparent_polar` diameter, verifying the logic for oblate planets like Mars.
- Several unused imports were removed from test files, ensuring a cleaner codebase.

---
*PR created automatically by Jules for task [17662725802565596954](https://jules.google.com/task/17662725802565596954) started by @pozar87*