### PR TITLE
🔭 Stellar: Added planetary rotation blur limit calculation

### DIFF
--- a/.jules/stellar.md
+++ b/.jules/stellar.md
@@ -242,3 +242,26 @@
 - Updated `apts/constants/astronomy.py`, `apts/utils/planetary.py`, and `apts/optics.py`.
 - Verified with `tests/unit/test_planetary_geometry.py`.
 - Example: Jupiter apparent polar diameter is ~6.5% smaller than equatorial.
+
+## 2025-05-24 - Planetary Rotation Blur Limit
+
+### Observe
+- Planetary imagers (lucky imaging) need to know how long they can record a video before the planet's rotation causes visible blur in the final stacked image.
+- The library was missing constants for planetary rotation periods and a method to calculate this duration limit based on the setup's pixel scale and target planet.
+
+### Target
+- Priority 3: Implement a new utility function.
+- Added `max_planetary_rotation_duration` to `OpticalPath`.
+
+### Calibrate
+- **Rotation Periods:** Added sidereal rotation periods for Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, and Pluto to `apts/constants/astronomy.py`. Derived from IAU 2015 rotation rates ($W$).
+- **Formula:** $t_{max} = \frac{\text{Tolerance} \cdot \text{PixelScale}}{\text{EquatorialAngularVelocity}}$, where $\omega = \frac{2\pi \cdot R_{eq}}{T_{sidereal}}$.
+- The blur is most severe at the center of the planet's disk (equator).
+- Source: IAU 2015 Standards, Archinal et al. (2018).
+
+### Develop
+- Updated `astronomy.py` with rotation period constants.
+- Implemented `get_planet_rotation_period` in `apts/utils/planetary.py`.
+- Integrated `max_planetary_rotation_duration` into `OpticalPath` in `apts/optics.py`.
+- Verified with `tests/unit/test_planetary_rotation.py`.
+- Benchmarks: Jupiter at 0.1"/px scale allows ~24s for 1px blur; Mars at same scale allows ~200s.

--- a/apts/constants/astronomy.py
+++ b/apts/constants/astronomy.py
@@ -35,6 +35,19 @@ SATURN_RING_OUTER_RADIUS_KM = 136775.0
 # Astronomical Unit in km
 AU_KM = 149597870.7
 
+# Sidereal Rotation Period in seconds
+# Sources: IAU 2015 Standards / Archinal et al. (2018)
+# Calculated from rotation rate W (deg/day): T = (360 / |W|) * 86400
+MERCURY_ROTATION_PERIOD_S = 5067033.9
+VENUS_ROTATION_PERIOD_S = 20996797.0
+EARTH_ROTATION_PERIOD_S = 86164.1
+MARS_ROTATION_PERIOD_S = 88642.7
+JUPITER_ROTATION_PERIOD_S = 35729.7
+SATURN_ROTATION_PERIOD_S = 38362.4
+URANUS_ROTATION_PERIOD_S = 62064.0
+NEPTUNE_ROTATION_PERIOD_S = 57996.0
+PLUTO_ROTATION_PERIOD_S = 551856.1
+
 # Jupiter Great Red Spot (GRS) Longitude in System II (degrees)
 # Note: This is a reference value for early 2026 (approx 80.0°).
 # The library uses a dynamic drift model in `apts.utils.planetary.get_jupiter_grs_longitude`

--- a/apts/optics.py
+++ b/apts/optics.py
@@ -1261,3 +1261,51 @@ class OpticalPath:
         """
         from .utils import planetary
         return planetary.get_sun_physical_details(time)
+
+    def max_planetary_rotation_duration(
+        self, planet_name: str, time: Any, tolerance_pixels: float = 1.0
+    ) -> Optional["Quantity"]:
+        """
+        Calculates the maximum recording duration (in seconds) before planetary rotation
+        causes a blur exceeding the given pixel tolerance.
+        Useful for planetary imagers (lucky imaging) to determine when to start a new capture
+        or use tools like WinJUPOS for de-rotation.
+        """
+        from .utils import planetary
+
+        scale_q = self.pixel_scale()
+        if scale_q is None:
+            return None
+
+        scale = scale_q.to("arcsecond").magnitude
+
+        # Equatorial angular radius (half of diameter)
+        r_eq = (
+            planetary.get_planet_angular_diameter(planet_name, time, which="equatorial")
+            / 2.0
+        )
+
+        # Sidereal rotation period in seconds
+        period = planetary.get_planet_rotation_period(planet_name)
+
+        # Sub-observer latitude (tilt)
+        try:
+            de_deg = planetary.get_sub_observer_latitude(planet_name, time)
+            cos_de = math.cos(math.radians(de_deg))
+        except ValueError:
+            # Fallback for planets without pole models (e.g., Mercury, Venus)
+            cos_de = 1.0
+
+        if r_eq <= 0 or period <= 0:
+            return None
+
+        # Angular velocity of a point at the center of the disk as seen from Earth (arcsec/s)
+        # v_arcsec = (2 * pi * r_eq_arcsec * cos(De)) / T
+        omega = (2.0 * math.pi * r_eq * cos_de) / period
+
+        if omega <= 1e-12:
+            return 3600 * get_unit_registry().second  # Cap at 1 hour for very slow rotators
+
+        t_max = (tolerance_pixels * scale) / omega
+
+        return t_max * get_unit_registry().second

--- a/apts/utils/planetary.py
+++ b/apts/utils/planetary.py
@@ -108,6 +108,18 @@ PLANET_POLAR_RADII_KM = {
     "neptune": astronomy.NEPTUNE_POLAR_RADIUS_KM,
 }
 
+PLANET_ROTATION_PERIODS_S = {
+    "mercury": astronomy.MERCURY_ROTATION_PERIOD_S,
+    "venus": astronomy.VENUS_ROTATION_PERIOD_S,
+    "earth": astronomy.EARTH_ROTATION_PERIOD_S,
+    "mars": astronomy.MARS_ROTATION_PERIOD_S,
+    "jupiter": astronomy.JUPITER_ROTATION_PERIOD_S,
+    "saturn": astronomy.SATURN_ROTATION_PERIOD_S,
+    "uranus": astronomy.URANUS_ROTATION_PERIOD_S,
+    "neptune": astronomy.NEPTUNE_ROTATION_PERIOD_S,
+    "pluto": astronomy.PLUTO_ROTATION_PERIOD_S,
+}
+
 
 def get_planet_radius_km(planet_name: str) -> float:
     """
@@ -119,6 +131,19 @@ def get_planet_radius_km(planet_name: str) -> float:
     if radius is None:
         raise ValueError(f"Radius for object '{planet_name}' not found.")
     return radius
+
+
+def get_planet_rotation_period(planet_name: str) -> float:
+    """
+    Returns the sidereal rotation period of a planet in seconds.
+    """
+    simple_name = get_simple_name(planet_name).lower()
+    period = PLANET_ROTATION_PERIODS_S.get(simple_name)
+    if period is None:
+        raise ValueError(
+            f"Sidereal rotation period for object '{planet_name}' not found."
+        )
+    return period
 
 
 def get_planet_distance_km(

--- a/tests/unit/test_planetary_rotation.py
+++ b/tests/unit/test_planetary_rotation.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from apts.optics import OpticalPath
+from apts.units import get_unit_registry
+from apts.constants import astronomy
+
+class TestPlanetaryRotation(unittest.TestCase):
+    @patch("apts.utils.planetary.get_planet_angular_diameter")
+    @patch("apts.utils.planetary.get_planet_rotation_period")
+    @patch("apts.utils.planetary.get_sub_observer_latitude")
+    def test_max_planetary_rotation_duration_jupiter(self, mock_lat, mock_period, mock_diameter):
+        # Setup mocks for Jupiter
+        # Typical opposition diameter ~48 arcsec => radius 24 arcsec
+        mock_diameter.return_value = 48.0
+        # Sidereal period ~9h 55m
+        mock_period.return_value = astronomy.JUPITER_ROTATION_PERIOD_S
+        # Zero tilt for simplicity
+        mock_lat.return_value = 0.0
+
+        # Mock OpticalPath setup
+        t = MagicMock()
+        c = MagicMock()
+        path = OpticalPath(t, [], [], [], [], c)
+
+        # Case 1: High resolution setup (0.1 arcsec/pixel)
+        # scale = 0.1 "/px
+        # r_eq = 24.0 "
+        # T = 35729.7 s
+        # omega = (2 * pi * 24.0) / 35729.7 = 0.150796 / 35729.7 * 10^3 (approx)
+        # omega = 0.004218 "/s
+        # t_max = (1.0 * 0.1) / 0.004218 = 23.7 s
+        with MagicMock() as mock_scale:
+            mock_scale.to.return_value.magnitude = 0.1
+            path.pixel_scale = MagicMock(return_value=mock_scale)
+
+            duration = path.max_planetary_rotation_duration("jupiter", datetime(2025, 1, 1))
+            self.assertAlmostEqual(duration.magnitude, 23.7, places=1)
+            self.assertEqual(duration.units, get_unit_registry().second)
+
+        # Case 2: Lower resolution setup (0.3 arcsec/pixel)
+        # t_max = (1.0 * 0.3) / 0.004218 = 71.1 s
+        with MagicMock() as mock_scale:
+            mock_scale.to.return_value.magnitude = 0.3
+            path.pixel_scale = MagicMock(return_value=mock_scale)
+
+            duration = path.max_planetary_rotation_duration("jupiter", datetime(2025, 1, 1))
+            self.assertAlmostEqual(duration.magnitude, 71.1, places=1)
+
+    @patch("apts.utils.planetary.get_planet_angular_diameter")
+    @patch("apts.utils.planetary.get_planet_rotation_period")
+    @patch("apts.utils.planetary.get_sub_observer_latitude")
+    def test_max_planetary_rotation_duration_mars(self, mock_lat, mock_period, mock_diameter):
+        # Setup mocks for Mars
+        # Typical opposition diameter ~15 arcsec => radius 7.5 arcsec
+        mock_diameter.return_value = 15.0
+        # Sidereal period ~24.6h
+        mock_period.return_value = astronomy.MARS_ROTATION_PERIOD_S
+        mock_lat.return_value = 20.0 # Significant tilt
+
+        # Mock OpticalPath setup
+        t = MagicMock()
+        c = MagicMock()
+        path = OpticalPath(t, [], [], [], [], c)
+
+        # scale = 0.1 "/px
+        # r_eq = 7.5 "
+        # T = 88642.7 s
+        # cos(20) = 0.9397
+        # omega = (2 * pi * 7.5 * 0.9397) / 88642.7 = 44.28 / 88642.7 = 0.0004995 "/s
+        # t_max = (1.0 * 0.1) / 0.0004995 = 200.2 s
+        with MagicMock() as mock_scale:
+            mock_scale.to.return_value.magnitude = 0.1
+            path.pixel_scale = MagicMock(return_value=mock_scale)
+
+            duration = path.max_planetary_rotation_duration("mars", datetime(2025, 1, 1))
+            self.assertAlmostEqual(duration.magnitude, 200.2, places=1)
+
+    def test_max_planetary_rotation_duration_none_scale(self):
+        t = MagicMock()
+        c = MagicMock()
+        path = OpticalPath(t, [], [], [], [], c)
+        path.pixel_scale = MagicMock(return_value=None)
+
+        self.assertIsNone(path.max_planetary_rotation_duration("jupiter", datetime(2025, 1, 1)))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added a new utility function `max_planetary_rotation_duration` to the `OpticalPath` class. This feature allows planetary imagers to calculate the maximum recording duration (in seconds) for a given planet before its rotation causes a blur exceeding a specific pixel tolerance (e.g., 1 pixel).

The calculation accounts for:
- The setup's pixel scale (arcsec/pixel).
- The planet's equatorial angular radius at the time of observation.
- The planet's sidereal rotation period (using IAU 2015 standards).
- The sub-observer latitude (tilt), ensuring the most accurate results for feature tracking on the planetary disk.

This addition provides significant value for high-resolution planetary imaging planning and lucky imaging workflows.

---
*PR created automatically by Jules for task [18040674441611059950](https://jules.google.com/task/18040674441611059950) started by @pozar87*