### PR TITLE
Weather plots for seeing and sky brightness

### DIFF
--- a/apts/conditions.py
+++ b/apts/conditions.py
@@ -25,6 +25,10 @@ class DefaultConditions:
     MIN_VISIBILITY = 10  # [km], range [0,∞)
     # Maximal fog
     MAX_FOG = 5  # [%], range [0,100]
+    # Minimal sky brightness
+    MIN_SQM = 19.0  # [mag/arcsec²], range [10,22]
+    # Maximal astronomical seeing
+    MAX_SEEING = 2.5  # [arcsec], range [0.5,5]
     # Max acceptable hour of return
     MAX_RETURN = "02:00:00"
     # Start time for observation
@@ -64,6 +68,8 @@ class Conditions:
         min_weather_goodness: float = DefaultConditions.MIN_WEATHER_GOODNESS,
         min_visibility: float = DefaultConditions.MIN_VISIBILITY,
         max_fog: float = DefaultConditions.MAX_FOG,
+        min_sqm: float = DefaultConditions.MIN_SQM,
+        max_seeing: float = DefaultConditions.MAX_SEEING,
         max_return: Optional[str] = DefaultConditions.MAX_RETURN,
         start_time: Optional[Union[str, datetime]] = DefaultConditions.START_TIME,
         min_object_altitude: float = DefaultConditions.MIN_OBJECT_ALTITUDE,
@@ -85,6 +91,8 @@ class Conditions:
         self.min_weather_goodness = min_weather_goodness
         self.min_visibility = min_visibility
         self.max_fog = max_fog
+        self.min_sqm = min_sqm
+        self.max_seeing = max_seeing
         self.max_return = max_return
         self.start_time = start_time
         self.min_object_altitude = min_object_altitude

--- a/apts/observations.py
+++ b/apts/observations.py
@@ -556,6 +556,30 @@ class Observation:
                 dark_mode_override=dark_mode_override, conditions=conditions, **args
             )
 
+    def plot_seeing(
+        self,
+        dark_mode_override: Optional[bool] = None,
+        language: Optional[str] = None,
+        conditions: Optional[Conditions] = None,
+        **args,
+    ):
+        with language_context(language):
+            return self.plot.seeing(
+                dark_mode_override=dark_mode_override, conditions=conditions, **args
+            )
+
+    def plot_sqm(
+        self,
+        dark_mode_override: Optional[bool] = None,
+        language: Optional[str] = None,
+        conditions: Optional[Conditions] = None,
+        **args,
+    ):
+        with language_context(language):
+            return self.plot.sqm(
+                dark_mode_override=dark_mode_override, conditions=conditions, **args
+            )
+
     def plot_weather_summary(
         self,
         dark_mode_override: Optional[bool] = None,
@@ -770,7 +794,12 @@ class Observation:
             return []
 
         # Filter by time limit and make a copy to avoid SettingWithCopyWarning
-        hourly_data = hourly_data[hourly_data.time <= self.time_limit].copy()
+        # Ensure we use aware comparison
+        t_limit = pd.Timestamp(self.time_limit)
+        if t_limit.tzinfo is None:
+            t_limit = t_limit.tz_localize(self.place.local_timezone)
+
+        hourly_data = hourly_data[hourly_data.time <= t_limit].copy()
 
         if "fog" not in hourly_data.columns:
             hourly_data["fog"] = 0
@@ -790,6 +819,10 @@ class Observation:
             hourly_data["visibility"] = 20
         if "moonIllumination" not in hourly_data.columns:
             hourly_data["moonIllumination"] = 0
+        if "seeing" not in hourly_data.columns:
+            hourly_data["seeing"] = 1.5
+        if "sqm" not in hourly_data.columns:
+            hourly_data["sqm"] = 21.0
 
         # Calculate moon altitudes exactly for each weather data point
         ts = self.place.ts
@@ -809,6 +842,8 @@ class Observation:
             "moonIllumination",
             "fog",
             "aurora",
+            "seeing",
+            "sqm",
         ]:
             if col in hourly_data.columns:
                 hourly_data[col] = pd.to_numeric(hourly_data[col], errors="coerce")
@@ -849,6 +884,12 @@ class Observation:
             is_bad_aurora = hourly_data.aurora.isna() | ~(
                 hourly_data.aurora >= effective_conditions.min_aurora
             )
+            is_bad_seeing = hourly_data.seeing.isna() | ~(
+                hourly_data.seeing <= effective_conditions.max_seeing
+            )
+            is_bad_sqm = hourly_data.sqm.isna() | ~(
+                hourly_data.sqm >= effective_conditions.min_sqm
+            )
 
             # Determine good hours
             is_good_hour_mask = ~(
@@ -861,6 +902,8 @@ class Observation:
                 | is_bad_fog
                 | is_bad_moon
                 | is_bad_aurora
+                | is_bad_seeing
+                | is_bad_sqm
             )
 
             # Pre-populate analysis_results with vectorized data
@@ -935,6 +978,16 @@ class Observation:
                                 "aurora": f"{row['aurora']:.1f}",
                                 "min_aurora": effective_conditions.min_aurora,
                             }
+                        )
+                    if is_bad_seeing.iloc[idx]:
+                        reasons.append(
+                            gettext_("Seeing %(seeing)s arcsec exceeds limit")
+                            % {"seeing": f"{row['seeing']:.1f}"}
+                        )
+                    if is_bad_sqm.iloc[idx]:
+                        reasons.append(
+                            gettext_("Sky brightness %(sqm)s mag/arcsec² below limit")
+                            % {"sqm": f"{row['sqm']:.1f}"}
                         )
                     reasons_col[idx] = reasons
 

--- a/apts/place.py
+++ b/apts/place.py
@@ -301,7 +301,20 @@ class Place:
             b_total *= 1 - 0.5 * (cloud_cover / 100.0)
 
         sqm = -2.5 * math.log10(max(b_total, 1e-10))
-        return min(max(sqm, 10.0), 22.0)
+        sqm_val = min(max(sqm, 10.0), 22.0)
+
+        # Update cache if time matches weather data
+        if (
+            self.weather is not None
+            and self.weather.data is not None
+            and not self.weather.data.empty
+        ):
+            dt = self._get_scalar_datetime(target_time)
+            idx = (self.weather.data["time"] - dt).abs().idxmin()
+            if (self.weather.data.loc[idx, "time"] - dt).total_seconds() == 0:
+                self.weather.data.loc[idx, "sqm"] = sqm_val
+
+        return sqm_val
 
     def get_seeing(self, time: Optional[Any] = None) -> float:
         """
@@ -333,7 +346,85 @@ class Place:
             if cloud_cover > 50:
                 s += 0.3
 
-        return min(max(s, 0.5), 5.0)
+        seeing_val = min(max(s, 0.5), 5.0)
+
+        # Update cache if time matches weather data
+        if (
+            self.weather is not None
+            and self.weather.data is not None
+            and not self.weather.data.empty
+        ):
+            dt = self._get_scalar_datetime(target_time)
+            idx = (self.weather.data["time"] - dt).abs().idxmin()
+            if (self.weather.data.loc[idx, "time"] - dt).total_seconds() == 0:
+                self.weather.data.loc[idx, "seeing"] = seeing_val
+
+        return seeing_val
+
+    def _add_extra_weather_info(self):
+        """
+        Calculates seeing and SQM for all time points in weather data.
+        """
+        if self.weather is None or self.weather.data is None or self.weather.data.empty:
+            return
+
+        ts = get_timescale()
+        times = ts.from_datetimes(self.weather.data["time"].tolist())
+
+        # Vectorized Sun/Moon altitude calculation
+        sun_alts = (
+            self.observer.at(times).observe(self.sun).apparent().altaz()[0].degrees
+        )
+        moon_alts = (
+            self.observer.at(times).observe(self.moon).apparent().altaz()[0].degrees
+        )
+        # Handle magnitude calculation for vectorized times
+        moon_mags = [get_planet_magnitude("moon", t) for t in times]
+
+        # Bortle info
+        bortle = self.get_light_pollution()
+        sqm_base = LightPollution.bortle_to_sqm(bortle)
+        b_starlight = 10 ** (-0.4 * sqm_base)
+
+        seeings = []
+        sqms = []
+
+        for i, row in self.weather.data.iterrows():
+            # SQM Calculation
+            b_total = b_starlight
+            sun_alt = sun_alts[i]
+            if sun_alt > -18:
+                b_sun = 10 ** (-0.4 * (21.8 - (18 + sun_alt) * 0.65))
+                b_total += b_sun
+
+            moon_alt = moon_alts[i]
+            if moon_alt > 0:
+                mag_m = moon_mags[i]
+                b_moon = 10 ** (-0.4 * (mag_m + 31)) * np.sin(np.radians(moon_alt))
+                b_total += b_moon
+
+            cloud_cover = float(row["cloudCover"])
+            if bortle > 4:
+                b_total *= 1 + 2 * (cloud_cover / 100.0)
+            else:
+                b_total *= 1 - 0.5 * (cloud_cover / 100.0)
+
+            sqm = -2.5 * math.log10(max(b_total, 1e-10))
+            sqms.append(min(max(sqm, 10.0), 22.0))
+
+            # Seeing Calculation
+            s = 1.5
+            wind_speed = float(row["windSpeed"])
+            humidity = float(row["humidity"])
+            s += max(0, (wind_speed - 15) / 50.0)
+            if humidity > 80:
+                s += (humidity - 80) / 40.0
+            if cloud_cover > 50:
+                s += 0.3
+            seeings.append(min(max(s, 0.5), 5.0))
+
+        self.weather.data["sqm"] = sqms
+        self.weather.data["seeing"] = seeings
 
     def get_weather(
         self,
@@ -355,6 +446,7 @@ class Place:
             observation_window=observation_window,
             force=force,
         )
+        self._add_extra_weather_info()
 
     def _previous_setting_time(self, obj_name, start, horizon_degrees=None):
         res = _previous_setting_time_utc(

--- a/apts/plot.py
+++ b/apts/plot.py
@@ -74,6 +74,12 @@ class Plotter:
     def aurora(self, conditions: Optional["Conditions"] = None, **args):
         return plot_aurora(self.observation, conditions=conditions, **args)
 
+    def seeing(self, conditions: Optional["Conditions"] = None, **args):
+        return plot_seeing(self.observation, conditions=conditions, **args)
+
+    def sqm(self, conditions: Optional["Conditions"] = None, **args):
+        return plot_sqm(self.observation, conditions=conditions, **args)
+
     def weather_summary(self, conditions: Optional["Conditions"] = None, **args):
         return plot_weather_summary(self.observation, conditions=conditions, **args)
 
@@ -306,6 +312,40 @@ def plot_aurora(
     )
 
 
+def plot_seeing(
+    observation: "Observation",
+    dark_mode_override: Optional[bool] = None,
+    conditions: Optional["Conditions"] = None,
+    **args,
+):
+    from .plotting.weather import generate_plot_seeing
+
+    _ensure_weather(observation, conditions)
+    return generate_plot_seeing(
+        observation,
+        dark_mode_override=dark_mode_override,
+        conditions=conditions,
+        **args,
+    )
+
+
+def plot_sqm(
+    observation: "Observation",
+    dark_mode_override: Optional[bool] = None,
+    conditions: Optional["Conditions"] = None,
+    **args,
+):
+    from .plotting.weather import generate_plot_sqm
+
+    _ensure_weather(observation, conditions)
+    return generate_plot_sqm(
+        observation,
+        dark_mode_override=dark_mode_override,
+        conditions=conditions,
+        **args,
+    )
+
+
 def plot_weather_summary(
     observation: "Observation",
     dark_mode_override: Optional[bool] = None,
@@ -376,6 +416,8 @@ __all__ = [
     "plot_moon_illumination",
     "plot_fog",
     "plot_aurora",
+    "plot_seeing",
+    "plot_sqm",
     "plot_weather_summary",
     "plot_skymap",
     "plot_visible_planets",

--- a/apts/plotting/weather.py
+++ b/apts/plotting/weather.py
@@ -324,6 +324,60 @@ def generate_plot_aurora(
     return None
 
 
+def generate_plot_seeing(
+    observation: "Observation",
+    dark_mode_override: Optional[bool] = None,
+    conditions: Optional["Conditions"] = None,
+    **args,
+):
+    effective_dark_mode, style = _get_plot_setup(observation, dark_mode_override)
+    eff_conditions = conditions or observation.conditions
+    if observation.place.weather is None:
+        return _handle_no_weather(gettext_("Seeing"), effective_dark_mode, style)
+
+    ax = observation.place.weather.plot_seeing(
+        dark_mode_override=effective_dark_mode, **args
+    )
+    if ax:
+        mark_observation(observation, ax, effective_dark_mode, style)
+        mark_good_conditions(
+            observation,
+            ax,
+            0,
+            eff_conditions.max_seeing,
+            effective_dark_mode,
+            style,
+        )
+    return ax
+
+
+def generate_plot_sqm(
+    observation: "Observation",
+    dark_mode_override: Optional[bool] = None,
+    conditions: Optional["Conditions"] = None,
+    **args,
+):
+    effective_dark_mode, style = _get_plot_setup(observation, dark_mode_override)
+    eff_conditions = conditions or observation.conditions
+    if observation.place.weather is None:
+        return _handle_no_weather(gettext_("Sky brightness"), effective_dark_mode, style)
+
+    ax = observation.place.weather.plot_sqm(
+        dark_mode_override=effective_dark_mode, **args
+    )
+    if ax:
+        mark_observation(observation, ax, effective_dark_mode, style)
+        mark_good_conditions(
+            observation,
+            ax,
+            eff_conditions.min_sqm,
+            22.0,
+            effective_dark_mode,
+            style,
+        )
+    return ax
+
+
 def generate_plot_weather_summary(
     observation: "Observation",
     dark_mode_override: Optional[bool] = None,
@@ -413,12 +467,12 @@ def generate_plot_weather(
         if (
             axes_arg is not None
             and isinstance(axes_arg, numpy.ndarray)
-            and axes_arg.shape == (6, 2)
+            and axes_arg.shape == (7, 2)
         ):
             axes = axes_arg
             fig = axes[0, 0].figure
         else:
-            fig, axes = pyplot.subplots(nrows=6, ncols=2, figsize=(13, 25), **args)
+            fig, axes = pyplot.subplots(nrows=7, ncols=2, figsize=(13, 30), **args)
 
         fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
 
@@ -478,19 +532,32 @@ def generate_plot_weather(
             conditions=conditions,
         )
 
-        plt_aurora_ax = generate_plot_aurora(
+        generate_plot_seeing(
             observation,
             ax=axes[5, 0],
             dark_mode_override=effective_dark_mode,
             conditions=conditions,
         )
+        generate_plot_sqm(
+            observation,
+            ax=axes[5, 1],
+            dark_mode_override=effective_dark_mode,
+            conditions=conditions,
+        )
+
+        plt_aurora_ax = generate_plot_aurora(
+            observation,
+            ax=axes[6, 0],
+            dark_mode_override=effective_dark_mode,
+            conditions=conditions,
+        )
         if plt_aurora_ax is None:
             # If the aurora column doesn't exist, you can hide the subplot
-            axes[5, 0].set_visible(False)
+            axes[6, 0].set_visible(False)
 
         generate_plot_weather_summary(
             observation,
-            ax=axes[5, 1],
+            ax=axes[6, 1],
             dark_mode_override=effective_dark_mode,
             conditions=conditions,
         )

--- a/apts/weather.py
+++ b/apts/weather.py
@@ -562,6 +562,8 @@ class Weather:
             "moonIllumination",
             "fog",
             "aurora",
+            "seeing",
+            "sqm",
         ]
         data = self._filter_data(critical_data_columns)
         return data[(data.time >= start) & (data.time <= stop)]  # pyright: ignore
@@ -772,5 +774,101 @@ class Weather:
 
         PlotUtils.annotate_plot(
             ax, gettext_("Aurora"), effective_dark_mode, self.local_timezone
+        )
+        return ax
+
+    def plot_seeing(self, hours=24, dark_mode_override: Optional[bool] = None, **args):
+        if dark_mode_override is not None:
+            effective_dark_mode = dark_mode_override
+        else:
+            effective_dark_mode = get_dark_mode()
+
+        style = get_plot_style(effective_dark_mode)
+        data = self._filter_data(["seeing"])
+        ax = args.pop("ax", None)
+        if data.empty:
+            return PlotUtils.plot_no_data(ax, gettext_("Seeing"), effective_dark_mode)
+
+        fig = None
+
+        if ax:
+            fig = ax.figure
+
+        plot_kwargs = args.copy()
+        plot_ax = data.plot(
+            x="time",
+            y="seeing",
+            xlim=(data.time.min(), data.time.max()),
+            ylim=(0, 5.5),
+            title=gettext_("Seeing"),
+            ax=ax,
+            x_compat=True,
+            **plot_kwargs,
+        )  # pyright: ignore
+
+        if not ax:
+            ax = plot_ax
+            fig = ax.figure
+            cast(Any, fig).patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+            ax.set_facecolor(style["AXES_FACE_COLOR"])
+        else:
+            ax.set_facecolor(style["AXES_FACE_COLOR"])
+            cast(Any, fig).patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+
+        ax.set_title(ax.get_title(), color=style["TEXT_COLOR"])
+
+        PlotUtils.style_legend(ax, style)
+
+        PlotUtils.annotate_plot(
+            ax, gettext_("Seeing [arcsec]"), effective_dark_mode, self.local_timezone
+        )
+        return ax
+
+    def plot_sqm(self, hours=24, dark_mode_override: Optional[bool] = None, **args):
+        if dark_mode_override is not None:
+            effective_dark_mode = dark_mode_override
+        else:
+            effective_dark_mode = get_dark_mode()
+
+        style = get_plot_style(effective_dark_mode)
+        data = self._filter_data(["sqm"])
+        ax = args.pop("ax", None)
+        if data.empty:
+            return PlotUtils.plot_no_data(
+                ax, gettext_("Sky brightness"), effective_dark_mode
+            )
+
+        fig = None
+
+        if ax:
+            fig = ax.figure
+
+        plot_kwargs = args.copy()
+        plot_ax = data.plot(
+            x="time",
+            y="sqm",
+            xlim=(data.time.min(), data.time.max()),
+            ylim=(10, 22.5),
+            title=gettext_("Sky brightness"),
+            ax=ax,
+            x_compat=True,
+            **plot_kwargs,
+        )  # pyright: ignore
+
+        if not ax:
+            ax = plot_ax
+            fig = ax.figure
+            cast(Any, fig).patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+            ax.set_facecolor(style["AXES_FACE_COLOR"])
+        else:
+            ax.set_facecolor(style["AXES_FACE_COLOR"])
+            cast(Any, fig).patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+
+        ax.set_title(ax.get_title(), color=style["TEXT_COLOR"])
+
+        PlotUtils.style_legend(ax, style)
+
+        PlotUtils.annotate_plot(
+            ax, gettext_("SQM [mag/arcsec²]"), effective_dark_mode, self.local_timezone
         )
         return ax

--- a/apts/weather_providers.py
+++ b/apts/weather_providers.py
@@ -142,6 +142,8 @@ class WeatherProvider(ABC):
         "moonIllumination",
         "moonWaxing",
         "aurora",
+        "seeing",
+        "sqm",
     ]
 
     def __init__(self, api_key, lat, lon, local_timezone):

--- a/tests/unit/test_custom_conditions.py
+++ b/tests/unit/test_custom_conditions.py
@@ -30,6 +30,8 @@ def mock_weather_data():
                     "fog": [0.0, 0.0, 0.0, 0.0, 0.0],
                     "aurora": [0.0, 0.0, 0.0, 0.0, 0.0],
                     "precipIntensity": [0.0, 0.0, 0.0, 0.0, 0.0],
+                    "seeing": [1.5, 1.5, 1.5, 1.5, 1.5],
+                    "sqm": [21.0, 21.0, 21.0, 21.0, 21.0],
                 }
             )
             mock_provider.download_data.return_value = mock_data

--- a/tests/weather/test_weather.py
+++ b/tests/weather/test_weather.py
@@ -402,7 +402,7 @@ def test_plot_weather_calls_sub_plots(mock_get_weather_settings, requests_mock):
         ) as mock_plot_weather_summary,
         patch(
             "apts.plotting.weather.pyplot.subplots",
-            return_value=(MagicMock(), MagicMock(shape=(6, 2))),
+            return_value=(MagicMock(), MagicMock(shape=(7, 2))),
         ) as mock_subplots,
         patch("apts.plotting.weather.mark_observation") as mock_mark_observation,
         patch(
@@ -413,10 +413,12 @@ def test_plot_weather_calls_sub_plots(mock_get_weather_settings, requests_mock):
             mock_weather_instance, "plot_moon_illumination"
         ) as mock_plot_moon_illumination,
         patch.object(mock_weather_instance, "plot_fog") as mock_plot_fog,
+        patch.object(mock_weather_instance, "plot_seeing") as mock_plot_seeing,
+        patch.object(mock_weather_instance, "plot_sqm") as mock_plot_sqm,
     ):
         fig = obs.plot_weather()
 
-        mock_subplots.assert_called_once_with(nrows=6, ncols=2, figsize=(13, 25))
+        mock_subplots.assert_called_once_with(nrows=7, ncols=2, figsize=(13, 30))
 
         mock_plot_clouds.assert_called_once()
         mock_plot_clouds_summary.assert_called_once()
@@ -428,6 +430,8 @@ def test_plot_weather_calls_sub_plots(mock_get_weather_settings, requests_mock):
         mock_plot_visibility.assert_called_once()
         mock_plot_moon_illumination.assert_called_once()
         mock_plot_fog.assert_called_once()
+        mock_plot_seeing.assert_called_once()
+        mock_plot_sqm.assert_called_once()
         mock_plot_weather_summary.assert_called_once()
 
         assert mock_mark_observation.call_count >= 1


### PR DESCRIPTION
Implemented weather plots and analysis for astronomical seeing and sky brightness (SQM).

Key changes:
1. **Conditions**: Added `MIN_SQM` (default 19.0) and `MAX_SEEING` (default 2.5 arcsec) thresholds.
2. **Place**: Added `_add_extra_weather_info` to pre-calculate seeing and SQM for all entries in weather data, accounting for location, Sun/Moon position, and atmospheric parameters.
3. **Weather Plotting**:
    - Created `plot_seeing()` and `plot_sqm()` methods.
    - Updated `generate_plot_weather` to use a 7x2 grid, adding the new metrics.
    - Added background shading for night, moon-up, and good condition periods.
4. **Weather Analysis**:
    - `Observation.get_weather_analysis` now checks seeing and SQM against thresholds.
    - Reports specific reasons (e.g., "Seeing 10.0 arcsec exceeds limit") when conditions are not met.
    - Fixed a bug where `seeing` and `sqm` columns were missing from the critical data extraction.
    - Fixed a bug in timestamp comparison between observation window and weather data.
5. **API Exposure**: New plotting methods are available via `observation.plot_seeing()`, `observation.plot_sqm()`, or through the `Plotter` object.

---
*PR created automatically by Jules for task [12188199415060887658](https://jules.google.com/task/12188199415060887658) started by @pozar87*