### PR TITLE
🔭 Stellar: Vectorized planetary geometry calculations

### DIFF
--- a/apts/optics.py
+++ b/apts/optics.py
@@ -1032,7 +1032,7 @@ class OpticalPath:
 
     def planetary_size_in_pixels(
         self, planet_name: str, time: Any, which: str = "equatorial"
-    ) -> Optional[float]:
+    ) -> Optional[Union[float, numpy.ndarray]]:
         """
         Calculates the projected size of a planet on the sensor in pixels.
         Uses the planet's angular diameter and the setup's pixel scale.
@@ -1052,11 +1052,14 @@ class OpticalPath:
         if p_scale is None or p_scale.magnitude == 0:
             return None
 
-        return float(angular_diameter / p_scale.magnitude)
+        res = angular_diameter / p_scale.magnitude
+        return float(res) if numpy.isscalar(res) else res
 
     def saturn_ring_size_in_pixels(
         self, time: Any
-    ) -> Optional[tuple[float, float]]:
+    ) -> Optional[
+        tuple[Union[float, numpy.ndarray], Union[float, numpy.ndarray]]
+    ]:
         """
         Calculates the projected size of Saturn's rings on the sensor in pixels.
         Returns a tuple (major_axis_pixels, minor_axis_pixels).
@@ -1072,7 +1075,10 @@ class OpticalPath:
         major = details["major_axis_arcsec"] / p_scale.magnitude
         minor = details["minor_axis_arcsec"] / p_scale.magnitude
 
-        return float(major), float(minor)
+        def _maybe_float(val):
+            return float(val) if numpy.isscalar(val) else val
+
+        return _maybe_float(major), _maybe_float(minor)
 
     def rule_of_500(self) -> "Quantity":
         """

--- a/apts/utils/planetary.py
+++ b/apts/utils/planetary.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 import numpy as np
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Union, cast
 
 from skyfield.data import mpc
 from skyfield.constants import GM_SUN_Pitjeva_2005_km3_s2 as GM_SUN_KM3_S2
@@ -148,17 +148,20 @@ def get_planet_rotation_period(planet_name: str) -> float:
 
 def get_planet_distance_km(
     planet_name: str, time: Any, observer: Any = None
-) -> float:
+) -> Union[float, np.ndarray]:
     """
     Returns the geocentric (or topocentric) distance to the planet in km.
     """
     eph = get_ephemeris()
     obs_obj = observer if observer is not None else eph["earth"]
     planet_obj = get_skyfield_obj(planet_name)
-    return cast(Any, obs_obj).at(time).observe(planet_obj).distance().km
+    res = cast(Any, obs_obj).at(time).observe(planet_obj).distance().km
+    return float(res) if np.isscalar(res) else res
 
 
-def get_planet_pole_coords(planet_name: str, time: Any) -> tuple[float, float]:
+def get_planet_pole_coords(
+    planet_name: str, time: Any
+) -> tuple[Union[float, np.ndarray], Union[float, np.ndarray]]:
     """
     Returns the planet's North Pole coordinates (RA, Dec) in degrees for the given time.
     Uses the IAU 2015 model.
@@ -174,6 +177,8 @@ def get_planet_pole_coords(planet_name: str, time: Any) -> tuple[float, float]:
     if name_norm == "saturn":
         return get_saturn_pole(time)
     if name_norm == "uranus":
+        if hasattr(T, "shape") and T.shape:
+            return np.full_like(T, 257.311), np.full_like(T, -15.175)
         return 257.311, -15.175
     if name_norm == "neptune":
         # IAU 2015 model for Neptune (including nutation)
@@ -187,12 +192,14 @@ def get_planet_pole_coords(planet_name: str, time: Any) -> tuple[float, float]:
 
     # Default to Earth pole (approx) or raise error
     if name_norm == "earth":
+        if hasattr(T, "shape") and T.shape:
+            return np.full_like(T, 0.0), np.full_like(T, 90.0)
         return 0.0, 90.0
 
     raise ValueError(f"Pole coordinates for '{planet_name}' not supported.")
 
 
-def get_sub_observer_latitude(planet_name: str, time: Any) -> float:
+def get_sub_observer_latitude(planet_name: str, time: Any) -> Union[float, np.ndarray]:
     """
     Calculates the sub-observer latitude (planetocentric latitude of the Earth) in degrees.
     This represents the tilt of the planet's equator relative to the observer.
@@ -224,12 +231,13 @@ def get_sub_observer_latitude(planet_name: str, time: Any) -> float:
     ) * np.cos(alpha0_rad - alpha_rad)
     De_rad = np.arcsin(np.clip(sin_De, -1.0, 1.0))
 
-    return float(np.degrees(De_rad))
+    res = np.degrees(De_rad)
+    return float(res) if np.isscalar(res) else res
 
 
 def get_planet_angular_diameter(
     planet_name: str, time: Any, which: str = "equatorial", observer: Any = None
-) -> float:
+) -> Union[float, np.ndarray]:
     """
     Returns the apparent angular diameter of the planet in arcseconds.
 
@@ -265,10 +273,13 @@ def get_planet_angular_diameter(
     alpha_rad = 2 * np.arcsin(radius / distance)
 
     # Convert to arcseconds
-    return float(np.degrees(alpha_rad) * 3600.0)
+    res = np.degrees(alpha_rad) * 3600.0
+    return float(res) if np.isscalar(res) else res
 
 
-def get_saturn_pole(time: Any) -> tuple[float, float]:
+def get_saturn_pole(
+    time: Any,
+) -> tuple[Union[float, np.ndarray], Union[float, np.ndarray]]:
     """
     Returns Saturn's North Pole coordinates (RA, Dec) in degrees for the given time.
     Uses the IAU 2015 model.
@@ -315,22 +326,29 @@ def get_saturn_ring_details(time: Any) -> dict:
     )
 
     # sin(B) is the dot product of the pole vector and the Saturn-Earth vector
-    sin_B = np.dot(p, v_sat_earth)
+    if hasattr(time, "shape") and time.shape:
+        sin_B = np.sum(p * v_sat_earth, axis=0)
+    else:
+        sin_B = np.dot(p, v_sat_earth)
+
     B_rad = np.arcsin(np.clip(sin_B, -1.0, 1.0))
-    B_deg = float(np.degrees(B_rad))
+    B_deg = np.degrees(B_rad)
 
     # Major axis (outer edge of A ring)
     dist_km = pos.distance().km
     radius_km = astronomy.SATURN_RING_OUTER_RADIUS_KM
-    major_arcsec = float(2 * np.degrees(np.arcsin(radius_km / dist_km)) * 3600.0)
+    major_arcsec = 2 * np.degrees(np.arcsin(radius_km / dist_km)) * 3600.0
 
     # Minor axis
     minor_arcsec = major_arcsec * abs(np.sin(B_rad))
 
+    def _maybe_float(val):
+        return float(val) if np.isscalar(val) else val
+
     return {
-        "tilt_degrees": B_deg,
-        "major_axis_arcsec": major_arcsec,
-        "minor_axis_arcsec": minor_arcsec,
+        "tilt_degrees": _maybe_float(B_deg),
+        "major_axis_arcsec": _maybe_float(major_arcsec),
+        "minor_axis_arcsec": _maybe_float(minor_arcsec),
     }
 
 

--- a/reproduce_vectorization_issue.py
+++ b/reproduce_vectorization_issue.py
@@ -1,0 +1,22 @@
+import datetime
+import numpy as np
+from apts.utils import planetary
+from apts.cache import get_timescale
+
+ts = get_timescale()
+times = ts.utc(2024, 1, [1, 2])
+
+print("Testing get_planet_angular_diameter with vector time...")
+try:
+    diam = planetary.get_planet_angular_diameter("Jupiter", times)
+    print(f"Result type: {type(diam)}")
+    print(f"Result: {diam}")
+except Exception as e:
+    print(f"Error: {e}")
+
+print("\nTesting get_saturn_ring_details with vector time...")
+try:
+    details = planetary.get_saturn_ring_details(times)
+    print(f"Result: {details}")
+except Exception as e:
+    print(f"Error: {e}")

--- a/tests/unit/test_vectorized_planetary.py
+++ b/tests/unit/test_vectorized_planetary.py
@@ -1,0 +1,73 @@
+import pytest
+import numpy as np
+from apts.utils import planetary
+from apts.cache import get_timescale
+from apts.equipment import OpticalEquipment
+from apts.optics import OpticalPath
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+
+def test_vectorized_planetary_utilities():
+    ts = get_timescale()
+    # Vector of 3 times
+    times = ts.utc(2024, 1, [1, 2, 3])
+
+    # Test distance
+    dist = planetary.get_planet_distance_km("Jupiter", times)
+    assert isinstance(dist, np.ndarray)
+    assert len(dist) == 3
+
+    # Test angular diameter (equatorial)
+    diam_eq = planetary.get_planet_angular_diameter("Jupiter", times, which="equatorial")
+    assert isinstance(diam_eq, np.ndarray)
+    assert len(diam_eq) == 3
+
+    # Test angular diameter (apparent polar - involves sub-observer latitude and pole coords)
+    diam_pol = planetary.get_planet_angular_diameter("Jupiter", times, which="apparent_polar")
+    assert isinstance(diam_pol, np.ndarray)
+    assert len(diam_pol) == 3
+
+    # Test Saturn ring details
+    rings = planetary.get_saturn_ring_details(times)
+    assert isinstance(rings["tilt_degrees"], np.ndarray)
+    assert isinstance(rings["major_axis_arcsec"], np.ndarray)
+    assert isinstance(rings["minor_axis_arcsec"], np.ndarray)
+    assert len(rings["tilt_degrees"]) == 3
+
+def test_vectorized_optical_path_methods():
+    ts = get_timescale()
+    times = ts.utc(2024, 1, [1, 2])
+
+    telescope = Sky_watcherTelescope.Sky_Watcher_Evostar_80ED_DS_Pro()
+    camera = ZwoCamera.ZWO_ASI_2600MC_Pro()
+    path = OpticalPath.from_path([telescope, camera])
+
+    # Test planetary size in pixels
+    px_size = path.planetary_size_in_pixels("Jupiter", times)
+    assert isinstance(px_size, np.ndarray)
+    assert len(px_size) == 2
+
+    # Test Saturn ring size in pixels
+    major, minor = path.saturn_ring_size_in_pixels(times)
+    assert isinstance(major, np.ndarray)
+    assert isinstance(minor, np.ndarray)
+    assert len(major) == 2
+
+def test_scalar_consistency():
+    ts = get_timescale()
+    t_scalar = ts.utc(2024, 6, 15)
+    t_vector = ts.utc(2024, 6, [15])
+
+    # Distance
+    dist_s = planetary.get_planet_distance_km("Mars", t_scalar)
+    dist_v = planetary.get_planet_distance_km("Mars", t_vector)
+    assert np.isscalar(dist_s)
+    assert isinstance(dist_v, np.ndarray)
+    assert float(dist_s) == pytest.approx(float(dist_v[0]))
+
+    # Ring details
+    rings_s = planetary.get_saturn_ring_details(t_scalar)
+    rings_v = planetary.get_saturn_ring_details(t_vector)
+    assert np.isscalar(rings_s["tilt_degrees"])
+    assert isinstance(rings_v["tilt_degrees"], np.ndarray)
+    assert float(rings_s["tilt_degrees"]) == pytest.approx(float(rings_v["tilt_degrees"][0]))


### PR DESCRIPTION
Vectorized core planetary geometry calculations to support Skyfield Time vectors. This improvement allows for efficient bulk calculations of planetary distances, angular diameters, and Saturn's ring details, which is essential for high-performance plotting and time-series analysis in astrophotography.

Key changes:
- Vectorized `get_planet_distance_km`, `get_planet_angular_diameter`, and `get_saturn_ring_details` in `apts/utils/planetary.py`.
- Updated `OpticalPath.planetary_size_in_pixels` and `OpticalPath.saturn_ring_size_in_pixels` in `apts/optics.py` to handle vectorized inputs and outputs.
- Maintained backward compatibility for scalar inputs by ensuring they still return floats.
- Used `Union` instead of `|` for type hints to ensure compatibility with Python 3.8+.
- Added comprehensive unit tests in `tests/unit/test_vectorized_planetary.py` to verify both vector and scalar consistency.

---
*PR created automatically by Jules for task [2772933350978299947](https://jules.google.com/task/2772933350978299947) started by @pozar87*