### PR TITLE
🌌 Oracle: Improved Lunar Eclipse precision and added Mars Closest Approach predictor

### DIFF
--- a/apts/constants/event_types.py
+++ b/apts/constants/event_types.py
@@ -44,6 +44,7 @@ class EventType(str, Enum):
     VENUS_GREAT_BRILLIANCY = "venus_great_brilliancy"
     SUPERMOONS = "supermoons"
     PLANETARY_DICHOTOMY = "planetary_dichotomy"
+    MARS_CLOSEST_APPROACH = "mars_closest_approach"
 
     def __str__(self):
         return self.value

--- a/apts/events.py
+++ b/apts/events.py
@@ -206,6 +206,8 @@ class AstronomicalEvents:
             futures.append(executor.submit(self.calculate_venus_greatest_brilliancy))
         if self.event_settings.get("supermoons"):
             futures.append(executor.submit(self.calculate_supermoons))
+        if self.event_settings.get("mars_closest_approach"):
+            futures.append(executor.submit(self.calculate_mars_closest_approach))
 
         # Golden hour, Blue hour and Culminations are disabled by default as they generate too many events
         if self.event_settings.get("golden_hour", False) or self.event_settings.get(
@@ -386,6 +388,8 @@ class AstronomicalEvents:
             return 3
         if event_type == "Planetary Dichotomy":
             return 3
+        if event_type == "Mars Closest Approach":
+            return 4
         return 1
 
     def calculate_venus_greatest_brilliancy(self):
@@ -493,7 +497,9 @@ class AstronomicalEvents:
 
     def calculate_lunar_eclipses(self):
         start_time = time.time()
-        events = skyfield_searches.find_lunar_eclipses(self.start_date, self.end_date)
+        events = skyfield_searches.find_lunar_eclipses(
+            self.start_date, self.end_date, observer=self.observer
+        )
         for event in events:
             event["event"] = "Lunar Eclipse"
             event["type"] = "Lunar Eclipse"
@@ -1191,4 +1197,14 @@ class AstronomicalEvents:
             event["date"] = event["date"].astimezone(utc)
             event["rarity"] = self._get_rarity("Supermoon", event)
         logger.debug(f"--- calculate_supermoons: {time.time() - start_time}s")
+        return events
+
+    def calculate_mars_closest_approach(self):
+        start_time = time.time()
+        events = skyfield_searches.find_mars_closest_approach(
+            self.start_date, self.end_date, observer=self.observer
+        )
+        for event in events:
+            event["rarity"] = self._get_rarity("Mars Closest Approach", event)
+        logger.debug(f"--- calculate_mars_closest_approach: {time.time() - start_time}s")
         return events

--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -1861,7 +1861,65 @@ def find_tiangong_flybys(
     )
 
 
-def find_lunar_eclipses(start_date, end_date):
+def find_mars_closest_approach(start_date, end_date, observer=None):
+    """
+    Finds when Mars is at its closest point to Earth (perigee).
+    """
+    ts = get_timescale()
+    t0 = ts.utc(start_date)
+    t1 = ts.utc(end_date)
+    eph = get_ephemeris()
+    earth = eph["earth"]
+    mars = eph["mars barycenter"]
+    sun = eph["sun"]
+
+    def distance_to_earth(t):
+        return cast(Any, earth).at(t).observe(mars).distance().au
+
+    # Mars closest approach happens every ~780 days.
+    # Step of 30 days is safe for find_minima.
+    setattr(distance_to_earth, "step_days", 30.0)
+    times, values = find_minima(t0, t1, distance_to_earth)
+
+    events = []
+    for t, dist in zip(times, values):
+        event = {
+            "date": t.utc_datetime(),
+            "event": "Mars Closest Approach",
+            "object": "Mars",
+            "type": "Mars Closest Approach",
+            "distance_au": float(dist),
+        }
+
+        if observer is not None:
+            v_obs = observer.at(t).observe(mars).apparent()
+            alt, _, _ = v_obs.altaz(temperature_C=10.0, pressure_mbar=1013.25)
+
+            sun_alt = (
+                observer.at(t)
+                .observe(sun)
+                .apparent()
+                .altaz(temperature_C=10.0, pressure_mbar=1013.25)[0]
+                .degrees
+            )
+
+            event.update(
+                {
+                    "altitude": float(alt.degrees),
+                    "sun_altitude": float(sun_alt),
+                    "is_visible": bool(alt.degrees > 0 and sun_alt <= -6),
+                }
+            )
+
+        events.append(event)
+
+    return events
+
+
+def find_lunar_eclipses(start_date, end_date, observer=None):
+    """
+    Finds lunar eclipses and provides visibility info if an observer is provided.
+    """
     ts = get_timescale()
     t0 = ts.utc(start_date)
     t1 = ts.utc(end_date)
@@ -1869,15 +1927,38 @@ def find_lunar_eclipses(start_date, end_date):
     t, y, details = eclipselib.lunar_eclipses(t0, t1, eph)
     events = []
     for i, (ti, yi) in enumerate(zip(t, y)):
-        events.append(
-            {
-                "date": ti.utc_datetime(),
-                "type": "Lunar Eclipse",
-                "eclipse_kind": eclipselib.LUNAR_ECLIPSES[yi],
-                "penumbral_magnitude": details["penumbral_magnitude"][i],
-                "umbral_magnitude": details["umbral_magnitude"][i],
-            }
-        )
+        event = {
+            "date": ti.utc_datetime(),
+            "type": "Lunar Eclipse",
+            "eclipse_kind": eclipselib.LUNAR_ECLIPSES[yi],
+            "penumbral_magnitude": details["penumbral_magnitude"][i],
+            "umbral_magnitude": details["umbral_magnitude"][i],
+        }
+
+        if observer is not None:
+            moon = eph["moon"]
+            sun = eph["sun"]
+
+            m_obs = observer.at(ti).observe(moon).apparent()
+            m_alt, _, _ = m_obs.altaz(temperature_C=10.0, pressure_mbar=1013.25)
+
+            s_alt = (
+                observer.at(ti)
+                .observe(sun)
+                .apparent()
+                .altaz(temperature_C=10.0, pressure_mbar=1013.25)[0]
+                .degrees
+            )
+
+            event.update(
+                {
+                    "altitude": float(m_alt.degrees),
+                    "sun_altitude": float(s_alt),
+                    "is_visible": bool(m_alt.degrees > 0 and s_alt <= -6),
+                }
+            )
+
+        events.append(event)
     return events
 
 

--- a/tests/unit/test_astronomical_events.py
+++ b/tests/unit/test_astronomical_events.py
@@ -60,6 +60,7 @@ class TestAstronomicalEvents(unittest.TestCase):
             "planet_solar_conjunctions": True,
             "lunar_features": True,
             "planet_planet_occultations": True,
+            "mars_closest_approach": True,
         }
 
         # Instantiate AstronomicalEvents AFTER patching
@@ -90,7 +91,8 @@ class TestAstronomicalEvents(unittest.TestCase):
         # 35: venus_greatest_brilliancy
         # 36: supermoons
         # 37: planetary_dichotomy
-        num_events = 37
+        # 38: mars_closest_approach
+        num_events = 38
         mock_futures = [MagicMock() for _ in range(num_events)]
         for future in mock_futures:
             future.result.return_value = []

--- a/tests/unit/test_oracle_new_features.py
+++ b/tests/unit/test_oracle_new_features.py
@@ -66,5 +66,57 @@ class OracleNewFeaturesTest(unittest.TestCase):
         # M4 is very close to Antares
         self.assertIn("M4", events_messier_df["object2"].values)
 
+class TestOracleLundarMars(unittest.TestCase):
+    def test_lunar_eclipse_visibility_filtering(self):
+        # Total Lunar Eclipse: March 14, 2025.
+        # Greatest eclipse around 06:58 UTC.
+        # For Tokyo (35.7, 139.7), the Moon is below the horizon at this time.
+
+        start_date = datetime(2025, 3, 14, 0, 0, tzinfo=utc)
+        end_date = datetime(2025, 3, 15, 0, 0, tzinfo=utc)
+
+        place_tokyo = Place(lat=35.6895, lon=139.6917, name="Tokyo")
+        from apts.skyfield_searches import find_lunar_eclipses
+        eclipses_tokyo = find_lunar_eclipses(start_date, end_date, observer=place_tokyo.observer)
+
+        self.assertGreater(len(eclipses_tokyo), 0)
+        eclipse = eclipses_tokyo[0]
+        self.assertFalse(eclipse["is_visible"])
+        self.assertLess(eclipse["altitude"], 0)
+
+        # For New York (40.7, -74.0), it should be visible.
+        # 06:58 UTC is 02:58 EDT.
+        place_ny = Place(lat=40.7128, lon=-74.0060, name="New York")
+        eclipses_ny = find_lunar_eclipses(start_date, end_date, observer=place_ny.observer)
+        self.assertGreater(len(eclipses_ny), 0)
+        self.assertTrue(eclipses_ny[0]["is_visible"])
+        self.assertGreater(eclipses_ny[0]["altitude"], 0)
+
+    def test_mars_closest_approach_2025(self):
+        # Mars closest approach in 2025 is Jan 12.
+        # Opposition is Jan 16.
+        start_date = datetime(2025, 1, 1, tzinfo=utc)
+        end_date = datetime(2025, 1, 31, tzinfo=utc)
+
+        from apts.skyfield_searches import find_mars_closest_approach
+        events = find_mars_closest_approach(start_date, end_date)
+        self.assertGreater(len(events), 0)
+        self.assertEqual(events[0]["date"].day, 12)
+        self.assertEqual(events[0]["date"].month, 1)
+        self.assertIn("distance_au", events[0])
+
+    def test_astronomical_events_integration(self):
+        start_date = datetime(2025, 1, 1, tzinfo=utc)
+        end_date = datetime(2025, 1, 31, tzinfo=utc)
+        place = Place(lat=52.2, lon=21.0) # Warsaw
+
+        ae = AstronomicalEvents(place, start_date, end_date, events_to_calculate=[EventType.MARS_CLOSEST_APPROACH])
+        df = ae.get_events()
+
+        self.assertFalse(df.empty)
+        self.assertEqual(df.iloc[0]["event"], "Mars Closest Approach")
+        self.assertEqual(df.iloc[0]["rarity"], 4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR addresses the "Oracle" mission by improving the accuracy of event timing and adding a new predictor.

Key changes:
1.  **Lunar Eclipse Precision**: `find_lunar_eclipses` now accepts an optional `observer` to calculate topocentric visibility. An eclipse is flagged as `is_visible` only if the Moon is above the horizon (> 0°) and the Sun is at or below the astronomical twilight threshold (≤ -6°) at the time of greatest eclipse.
2.  **Mars Closest Approach**: A new predictor finds the exact time of Mars' perigee (minimum distance to Earth) using high-precision iterative minimization. It also includes visibility checks.
3.  **Integration**: Both features are fully integrated into the `AstronomicalEvents` calculation engine and exposed via the `MARS_CLOSEST_APPROACH` event type.
4.  **Testing**: New unit tests verify the visibility logic for different global locations (e.g., Tokyo vs. New York) and the timing of Mars' 2025 closest approach. Existing tests were maintained and updated where necessary.

These improvements ensure that users receive astronomical predictions that are both physically accurate and locally relevant.

---
*PR created automatically by Jules for task [1233178548290205069](https://jules.google.com/task/1233178548290205069) started by @pozar87*