### PR TITLE
🔭 Stellar: Added Seestar sensors and Askar reduced variants

### DIFF
--- a/.jules/stellar.md
+++ b/.jules/stellar.md
@@ -337,3 +337,28 @@
 - Updated `apts/opticalequipment/camera/vendors/zwo.py` and `apts/opticalequipment/telescope/vendors/zwo.py` / `dwarflab.py`.
 - Verified with `tests/unit/test_stellar_audit_v2.py`.
 - Verified no regressions in existing optics tests.
+
+## 2026-03-20 - Seestar Sensors and Askar Reduced Variants
+
+### Observe
+- Users of Seestar smart telescopes often want to model their specific sensors for simulation or custom setups, but these were missing from the camera database.
+- Askar APO refractors (103, 120, 140) are popular for their dedicated reducers, which were missing from the database.
+
+### Target
+- Priority 2: Add missing popular camera and telescopes to the internal database.
+
+### Calibrate
+- **Seestar Sensors:**
+  - S50: IMX462, 1920x1080, 2.9µm, 12ke- full well.
+  - S30: IMX662, 1920x1080, 2.9µm, 38.2ke- full well.
+  - S30 Pro: IMX678, 3840x2160, 2.0µm, 11.27ke- full well.
+- **Askar APO Reduced:** Calculated focal lengths with 0.8x reducer:
+  - 103APO: 560mm
+  - 120APO: 672mm
+  - 140APO: 784mm
+
+### Develop
+- Added Seestar sensor entries to `apts/opticalequipment/camera/vendors/zwo.py`.
+- Added reduced focal length variants for Askar APO series to `apts/opticalequipment/telescope/vendors/askar.py`.
+- Verified with `tests/unit/test_new_equipment_audit_v3.py`.
+- All 606 unit tests passed.

--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -2448,6 +2448,69 @@ class ZwoCamera(Camera):
             "type": "type_camera",
             "width": 3864,
         },
+        "ZWO_Seestar_S50_Sensor": {
+            "bf_role": "end",
+            "brand": "ZWO",
+            "cside_gender": "",
+            "cside_thread": "",
+            "full_well_e": 12000,
+            "height": 1080,
+            "mass": 0,
+            "name": "Seestar S50 Sensor",
+            "optical_length": 0,
+            "pixel_size_um": 2.9,
+            "quantum_efficiency_pct": 80,
+            "read_noise_e": 1.0,
+            "reversible": False,
+            "sensor_height_mm": 3.2,
+            "sensor_width_mm": 5.6,
+            "tside_gender": "",
+            "tside_thread": "",
+            "type": "type_camera",
+            "width": 1920,
+        },
+        "ZWO_Seestar_S30_Sensor": {
+            "bf_role": "end",
+            "brand": "ZWO",
+            "cside_gender": "",
+            "cside_thread": "",
+            "full_well_e": 38200,
+            "height": 1080,
+            "mass": 0,
+            "name": "Seestar S30 Sensor",
+            "optical_length": 0,
+            "pixel_size_um": 2.9,
+            "quantum_efficiency_pct": 91,
+            "read_noise_e": 0.8,
+            "reversible": False,
+            "sensor_height_mm": 3.13,
+            "sensor_width_mm": 5.57,
+            "tside_gender": "",
+            "tside_thread": "",
+            "type": "type_camera",
+            "width": 1920,
+        },
+        "ZWO_Seestar_S30_Pro_Sensor": {
+            "bf_role": "end",
+            "brand": "ZWO",
+            "cside_gender": "",
+            "cside_thread": "",
+            "full_well_e": 11270,
+            "height": 2160,
+            "mass": 0,
+            "name": "Seestar S30 Pro Sensor",
+            "optical_length": 0,
+            "pixel_size_um": 2.0,
+            "quantum_efficiency_pct": 83,
+            "read_noise_e": 0.6,
+            "reversible": False,
+            "sensor_height_mm": 4.32,
+            "sensor_width_mm": 7.68,
+            "tside_gender": "",
+            "tside_thread": "",
+            "type": "type_camera",
+            "width": 3840,
+        },
     }
 
     @classmethod
@@ -3061,3 +3124,15 @@ class ZwoCamera(Camera):
     @classmethod
     def ZWO_ASI_2600MM_Air(cls):
         return cls.from_database(cls._DATABASE["ZWO_ASI_2600MM_Air"])
+
+    @classmethod
+    def ZWO_Seestar_S50_Sensor(cls):
+        return cls.from_database(cls._DATABASE["ZWO_Seestar_S50_Sensor"])
+
+    @classmethod
+    def ZWO_Seestar_S30_Sensor(cls):
+        return cls.from_database(cls._DATABASE["ZWO_Seestar_S30_Sensor"])
+
+    @classmethod
+    def ZWO_Seestar_S30_Pro_Sensor(cls):
+        return cls.from_database(cls._DATABASE["ZWO_Seestar_S30_Pro_Sensor"])

--- a/apts/opticalequipment/telescope/vendors/askar.py
+++ b/apts/opticalequipment/telescope/vendors/askar.py
@@ -24,6 +24,9 @@ class AskarTelescope(Telescope):
         'Askar_ACL200': {'brand': 'Askar', 'name': 'ACL200', 'type': 'type_camera_lens', 'optical_length': 0, 'mass': 1800, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M54', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 50, 'focal_length_mm': 200},
         'Askar_SQA55': {'brand': 'Askar', 'name': 'SQA55', 'type': 'type_refractor', 'optical_length': 0, 'mass': 1840, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M48', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 55, 'focal_length_mm': 264}, # Verified via specs
         'Askar_71F': {'brand': 'Askar', 'name': '71F', 'type': 'type_refractor', 'optical_length': 0, 'mass': 3000, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M48', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 71, 'focal_length_mm': 490}, # Verified via specs
+        'Askar_103APO_Reduced': {'brand': 'Askar', 'name': '103APO (Reduced)', 'type': 'type_refractor', 'optical_length': 0, 'mass': 5500, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M54', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 103, 'focal_length_mm': 560}, # With 0.8x reducer
+        'Askar_120APO_Reduced': {'brand': 'Askar', 'name': '120APO (Reduced)', 'type': 'type_refractor', 'optical_length': 0, 'mass': 6500, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M54', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 120, 'focal_length_mm': 672}, # With 0.8x reducer
+        'Askar_140APO_Reduced': {'brand': 'Askar', 'name': '140APO (Reduced)', 'type': 'type_refractor', 'optical_length': 0, 'mass': 10000, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M54', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 140, 'focal_length_mm': 784}, # With 0.8x reducer
     }
 
     @classmethod
@@ -113,3 +116,15 @@ class AskarTelescope(Telescope):
     @classmethod
     def Askar_71F(cls):
         return cls.from_database(cls._DATABASE['Askar_71F'])
+
+    @classmethod
+    def Askar_103APO_Reduced(cls):
+        return cls.from_database(cls._DATABASE['Askar_103APO_Reduced'])
+
+    @classmethod
+    def Askar_120APO_Reduced(cls):
+        return cls.from_database(cls._DATABASE['Askar_120APO_Reduced'])
+
+    @classmethod
+    def Askar_140APO_Reduced(cls):
+        return cls.from_database(cls._DATABASE['Askar_140APO_Reduced'])

--- a/tests/unit/test_new_equipment_audit_v3.py
+++ b/tests/unit/test_new_equipment_audit_v3.py
@@ -1,0 +1,64 @@
+import pytest
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.opticalequipment.telescope.vendors.askar import AskarTelescope
+
+def test_seestar_sensor_specs():
+    """Verify Seestar sensor entries in ZwoCamera database."""
+    # S50 Sensor (IMX462)
+    s50 = ZwoCamera.ZWO_Seestar_S50_Sensor()
+    assert s50.sensor_width.magnitude == 5.6
+    assert s50.sensor_height.magnitude == 3.2
+    assert s50.width == 1920
+    assert s50.height == 1080
+    assert s50.pixel_size().to("micrometer").magnitude == pytest.approx(2.9)
+    assert s50.full_well == 12000
+
+    # S30 Sensor (IMX662)
+    s30 = ZwoCamera.ZWO_Seestar_S30_Sensor()
+    assert s30.sensor_width.magnitude == 5.57
+    assert s30.sensor_height.magnitude == 3.13
+    assert s30.pixel_size().to("micrometer").magnitude == pytest.approx(2.9)
+    assert s30.full_well == 38200
+
+    # S30 Pro Sensor (IMX678)
+    s30p = ZwoCamera.ZWO_Seestar_S30_Pro_Sensor()
+    assert s30p.sensor_width.magnitude == 7.68
+    assert s30p.sensor_height.magnitude == 4.32
+    assert s30p.width == 3840
+    assert s30p.height == 2160
+    assert s30p.pixel_size().to("micrometer").magnitude == pytest.approx(2.0)
+    assert s30p.full_well == 11270
+
+def test_askar_apo_specs():
+    """Verify Askar APO refractor entries including reduced variants."""
+    # 103APO
+    a103 = AskarTelescope.Askar_103APO()
+    assert a103.aperture.magnitude == 103
+    assert a103.focal_length.magnitude == pytest.approx(700.4)
+
+    # 103APO Reduced (0.8x)
+    a103r = AskarTelescope.Askar_103APO_Reduced()
+    assert a103r.focal_length.magnitude == 560
+
+    # 120APO
+    a120 = AskarTelescope.Askar_120APO()
+    assert a120.aperture.magnitude == 120
+    assert a120.focal_length.magnitude == 840
+
+    # 120APO Reduced (0.8x)
+    a120r = AskarTelescope.Askar_120APO_Reduced()
+    assert a120r.focal_length.magnitude == 672
+
+    # 140APO
+    a140 = AskarTelescope.Askar_140APO()
+    assert a140.aperture.magnitude == 140
+    assert a140.focal_length.magnitude == 980
+
+    # 140APO Reduced (0.8x)
+    a140r = AskarTelescope.Askar_140APO_Reduced()
+    assert a140r.focal_length.magnitude == 784
+
+    # 185APO
+    a185 = AskarTelescope.Askar_185APO()
+    assert a185.aperture.magnitude == 185
+    assert a185.focal_length.magnitude == 1295


### PR DESCRIPTION
Added sensor specifications for Seestar S50, S30, and S30 Pro to the ZWO camera database. This allows users to model these popular smart telescope sensors in custom optical paths. Also added reduced focal length variants for the Askar APO series (103, 120, 140) to reflect common usage with their dedicated 0.8x reducers. Verified all new entries with unit tests.

---
*PR created automatically by Jules for task [12459644486299104886](https://jules.google.com/task/12459644486299104886) started by @pozar87*