### PR TITLE
Add weather condition translation strings

### DIFF
--- a/apts/locale/de/LC_MESSAGES/messages.po
+++ b/apts/locale/de/LC_MESSAGES/messages.po
@@ -995,3 +995,36 @@ msgstr "Masse [g]"
 
 msgid "Mass"
 msgstr "Masse"
+
+msgid "Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%"
+msgstr "Bewölkung von %(cloud_cover)s%% überschreitet das Limit von %(max_clouds)s%%"
+
+msgid "Precipitation probability %(precip_prob)s%% exceeds limit of %(max_precip_prob)s%%"
+msgstr "Niederschlagswahrscheinlichkeit von %(precip_prob)s%% überschreitet das Limit von %(max_precip_prob)s%%"
+
+msgid "Precipitation intensity %(precip_intens)s mm exceeds limit of %(max_precip_intens)s mm"
+msgstr "Niederschlagsintensität von %(precip_intens)s mm überschreitet das Limit von %(max_precip_intens)s mm"
+
+msgid "Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h"
+msgstr "Windgeschwindigkeit von %(wind_speed)s km/h überschreitet das Limit von %(max_wind)s km/h"
+
+msgid "Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)"
+msgstr "Temperatur von %(temp)s°C außerhalb des Bereichs (%(min_temp)s - %(max_temp)s°C)"
+
+msgid "Visibility %(vis)s km below limit of %(min_vis)s km"
+msgstr "Sichtweite von %(vis)s km unter dem Limit von %(min_vis)s km"
+
+msgid "Fog %(fog)s%% exceeds limit of %(max_fog)s%%"
+msgstr "Nebel von %(fog)s%% überschreitet das Limit von %(max_fog)s%%"
+
+msgid "Moon illumination %(illum)s%% exceeds limit of %(max_illum)s%% while moon is up"
+msgstr "Mondbeleuchtung von %(illum)s%% überschreitet das Limit von %(max_illum)s%% während der Mond aufgegangen ist"
+
+msgid "Aurora %(aurora)s%% below limit of %(min_aurora)s%%"
+msgstr "Aurora von %(aurora)s%% unter dem Limit von %(min_aurora)s%%"
+
+msgid "Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec"
+msgstr "Seeing von %(seeing)s Bogensekunden überschreitet das Limit von %(max_seeing)s Bogensekunden"
+
+msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
+msgstr "Himmelshelligkeit von %(sqm)s mag/arcsec² unter dem Limit von %(min_sqm)s mag/arcsec²"

--- a/apts/locale/es/LC_MESSAGES/messages.po
+++ b/apts/locale/es/LC_MESSAGES/messages.po
@@ -1018,3 +1018,36 @@ msgstr "Masa [g]"
 
 msgid "Mass"
 msgstr "Masa"
+
+msgid "Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%"
+msgstr "La nubosidad del %(cloud_cover)s%% supera el límite del %(max_clouds)s%%"
+
+msgid "Precipitation probability %(precip_prob)s%% exceeds limit of %(max_precip_prob)s%%"
+msgstr "La probabilidad de precipitación del %(precip_prob)s%% supera el límite del %(max_precip_prob)s%%"
+
+msgid "Precipitation intensity %(precip_intens)s mm exceeds limit of %(max_precip_intens)s mm"
+msgstr "La intensidad de precipitación de %(precip_intens)s mm supera el límite de %(max_precip_intens)s mm"
+
+msgid "Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h"
+msgstr "La velocidad del viento de %(wind_speed)s km/h supera el límite de %(max_wind)s km/h"
+
+msgid "Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)"
+msgstr "Temperatura de %(temp)s°C fuera de rango (%(min_temp)s - %(max_temp)s°C)"
+
+msgid "Visibility %(vis)s km below limit of %(min_vis)s km"
+msgstr "Visibilidad de %(vis)s km por debajo del límite de %(min_vis)s km"
+
+msgid "Fog %(fog)s%% exceeds limit of %(max_fog)s%%"
+msgstr "La niebla del %(fog)s%% supera el límite del %(max_fog)s%%"
+
+msgid "Moon illumination %(illum)s%% exceeds limit of %(max_illum)s%% while moon is up"
+msgstr "La iluminación lunar del %(illum)s%% supera el límite del %(max_illum)s%% con la luna visible"
+
+msgid "Aurora %(aurora)s%% below limit of %(min_aurora)s%%"
+msgstr "Aurora del %(aurora)s%% por debajo del límite del %(min_aurora)s%%"
+
+msgid "Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec"
+msgstr "El seeing de %(seeing)s arcsec supera el límite de %(max_seeing)s arcsec"
+
+msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
+msgstr "Brillo del cielo de %(sqm)s mag/arcsec² por debajo del límite de %(min_sqm)s mag/arcsec²"

--- a/apts/locale/pl/LC_MESSAGES/messages.po
+++ b/apts/locale/pl/LC_MESSAGES/messages.po
@@ -1023,3 +1023,36 @@ msgstr "Massa [g]"
 
 msgid "Mass"
 msgstr "Massa"
+
+msgid "Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%"
+msgstr "Zachmurzenie %(cloud_cover)s%% przekracza limit %(max_clouds)s%%"
+
+msgid "Precipitation probability %(precip_prob)s%% exceeds limit of %(max_precip_prob)s%%"
+msgstr "Prawdopodobieństwo opadów %(precip_prob)s%% przekracza limit %(max_precip_prob)s%%"
+
+msgid "Precipitation intensity %(precip_intens)s mm exceeds limit of %(max_precip_intens)s mm"
+msgstr "Intensywność opadów %(precip_intens)s mm przekracza limit %(max_precip_intens)s mm"
+
+msgid "Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h"
+msgstr "Prędkość wiatru %(wind_speed)s km/h przekracza limit %(max_wind)s km/h"
+
+msgid "Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)"
+msgstr "Temperatura %(temp)s°C poza zakresem (%(min_temp)s - %(max_temp)s°C)"
+
+msgid "Visibility %(vis)s km below limit of %(min_vis)s km"
+msgstr "Widzialność %(vis)s km poniżej limitu %(min_vis)s km"
+
+msgid "Fog %(fog)s%% exceeds limit of %(max_fog)s%%"
+msgstr "Zamglenie %(fog)s%% przekracza limit %(max_fog)s%%"
+
+msgid "Moon illumination %(illum)s%% exceeds limit of %(max_illum)s%% while moon is up"
+msgstr "Oświetlenie Księżyca %(illum)s%% przekracza limit %(max_illum)s%%, gdy Księżyc jest nad horyzontem"
+
+msgid "Aurora %(aurora)s%% below limit of %(min_aurora)s%%"
+msgstr "Zorza polarna %(aurora)s%% poniżej limitu %(min_aurora)s%%"
+
+msgid "Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec"
+msgstr "Seeing %(seeing)s arcsec przekracza limit %(max_seeing)s arcsec"
+
+msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
+msgstr "Jasność nieba %(sqm)s mag/arcsec² poniżej limitu %(min_sqm)s mag/arcsec²"

--- a/apts/locale/pt/LC_MESSAGES/messages.po
+++ b/apts/locale/pt/LC_MESSAGES/messages.po
@@ -1018,3 +1018,36 @@ msgstr "Massa [g]"
 
 msgid "Mass"
 msgstr "Massa"
+
+msgid "Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%"
+msgstr "A cobertura de nuvens de %(cloud_cover)s%% excede o limite de %(max_clouds)s%%"
+
+msgid "Precipitation probability %(precip_prob)s%% exceeds limit of %(max_precip_prob)s%%"
+msgstr "A probabilidade de precipitação de %(precip_prob)s%% excede o limite de %(max_precip_prob)s%%"
+
+msgid "Precipitation intensity %(precip_intens)s mm exceeds limit of %(max_precip_intens)s mm"
+msgstr "A intensidade de precipitação de %(precip_intens)s mm excede o limite de %(max_precip_intens)s mm"
+
+msgid "Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h"
+msgstr "A velocidade do vento de %(wind_speed)s km/h excede o limite de %(max_wind)s km/h"
+
+msgid "Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)"
+msgstr "Temperatura de %(temp)s°C fora do intervalo (%(min_temp)s - %(max_temp)s°C)"
+
+msgid "Visibility %(vis)s km below limit of %(min_vis)s km"
+msgstr "Visibilidade de %(vis)s km abaixo do limite de %(min_vis)s km"
+
+msgid "Fog %(fog)s%% exceeds limit of %(max_fog)s%%"
+msgstr "O nevoeiro de %(fog)s%% excede o limite de %(max_fog)s%%"
+
+msgid "Moon illumination %(illum)s%% exceeds limit of %(max_illum)s%% while moon is up"
+msgstr "A iluminação lunar de %(illum)s%% excede o limite de %(max_illum)s%% com a lua visível"
+
+msgid "Aurora %(aurora)s%% below limit of %(min_aurora)s%%"
+msgstr "Aurora de %(aurora)s%% abaixo do limite de %(min_aurora)s%%"
+
+msgid "Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec"
+msgstr "O seeing de %(seeing)s arcsec excede o limite de %(max_seeing)s arcsec"
+
+msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
+msgstr "O brilho do céu de %(sqm)s mag/arcsec² está abaixo do limite de %(min_sqm)s mag/arcsec²"


### PR DESCRIPTION
This commit adds new translation strings for various weather conditions and their associated limits. These strings are used to display informative messages to the user when weather conditions do not meet custom thresholds.