### PR TITLE
feat: Add moon condition to weather analysis

### DIFF
--- a/apts/observations.py
+++ b/apts/observations.py
@@ -769,6 +769,10 @@ class Observation:
         # Force a minimal check for is_moon_condition_met to allow it returning reasons later if needed,
         # but the current logic is to early-exit.
 
+        if not force and not self._is_moon_condition_met(effective_conditions):
+            logger.info("Skipping weather analysis due to moon condition.")
+            return []
+
         if self.place.weather is None:
             self.place.get_weather(
                 provider_name=provider_name,
@@ -776,14 +780,16 @@ class Observation:
                 observation_window=(self.start, self.stop),
                 force=force,
             )
+            if not force and not self._is_moon_condition_met(effective_conditions):
+                logger.info("Skipping weather analysis due to moon condition.")
+                return []
+
             if self.place.weather is None:
                 logger.warning("Weather data unavailable after fetch attempt.")
                 return []
 
         if not all([self.start, self.stop]):
-            logger.warning(
-                "Observation window (start, stop) is not fully defined."
-            )
+            logger.warning("Observation window (start, stop) is not fully defined.")
             return []
 
         hourly_data = self.place.weather.get_critical_data(self.start, self.stop)
@@ -825,13 +831,19 @@ class Observation:
             hourly_data["sqm"] = 21.0
 
         # Calculate moon altitudes exactly for each weather data point if not already cached
-        if "moon_altitude" in hourly_data.columns and not hourly_data["moon_altitude"].isna().all():
+        if (
+            "moon_altitude" in hourly_data.columns
+            and not hourly_data["moon_altitude"].isna().all()
+        ):
             hourly_data["Altitude"] = hourly_data["moon_altitude"]
         else:
             ts = self.place.ts
             times = ts.from_datetimes(hourly_data["time"].tolist())
             alt, _, _ = (
-                self.place.observer.at(times).observe(self.place.moon).apparent().altaz()
+                self.place.observer.at(times)
+                .observe(self.place.moon)
+                .apparent()
+                .altaz()
             )
             hourly_data["Altitude"] = alt.degrees
 
@@ -925,7 +937,9 @@ class Observation:
                     reasons = []
                     if is_bad_clouds.iloc[idx]:
                         reasons.append(
-                            gettext_("Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%")
+                            gettext_(
+                                "Cloud cover %(cloud_cover)s%% exceeds limit of %(max_clouds)s%%"
+                            )
                             % {
                                 "cloud_cover": f"{row['cloudCover']:.1f}",
                                 "max_clouds": effective_conditions.max_clouds,
@@ -953,7 +967,9 @@ class Observation:
                         )
                     if is_bad_wind.iloc[idx]:
                         reasons.append(
-                            gettext_("Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h")
+                            gettext_(
+                                "Wind speed %(wind_speed)s km/h exceeds limit of %(max_wind)s km/h"
+                            )
                             % {
                                 "wind_speed": f"{row['windSpeed']:.1f}",
                                 "max_wind": effective_conditions.max_wind,
@@ -961,7 +977,9 @@ class Observation:
                         )
                     if is_bad_temp.iloc[idx]:
                         reasons.append(
-                            gettext_("Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)")
+                            gettext_(
+                                "Temperature %(temp)s°C out of range (%(min_temp)s - %(max_temp)s°C)"
+                            )
                             % {
                                 "temp": f"{row['temperature']:.1f}",
                                 "min_temp": effective_conditions.min_temperature,
@@ -970,7 +988,9 @@ class Observation:
                         )
                     if is_bad_vis.iloc[idx]:
                         reasons.append(
-                            gettext_("Visibility %(vis)s km below limit of %(min_vis)s km")
+                            gettext_(
+                                "Visibility %(vis)s km below limit of %(min_vis)s km"
+                            )
                             % {
                                 "vis": f"{row['visibility']:.1f}",
                                 "min_vis": effective_conditions.min_visibility,
@@ -1006,7 +1026,9 @@ class Observation:
                         )
                     if is_bad_seeing.iloc[idx]:
                         reasons.append(
-                            gettext_("Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec")
+                            gettext_(
+                                "Seeing %(seeing)s arcsec exceeds limit of %(max_seeing)s arcsec"
+                            )
                             % {
                                 "seeing": f"{row['seeing']:.1f}",
                                 "max_seeing": effective_conditions.max_seeing,
@@ -1014,7 +1036,9 @@ class Observation:
                         )
                     if is_bad_sqm.iloc[idx]:
                         reasons.append(
-                            gettext_("Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²")
+                            gettext_(
+                                "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
+                            )
                             % {
                                 "sqm": f"{row['sqm']:.1f}",
                                 "min_sqm": effective_conditions.min_sqm,

--- a/tests/unit/test_moon_condition_optimization.py
+++ b/tests/unit/test_moon_condition_optimization.py
@@ -1,0 +1,149 @@
+
+import unittest
+import datetime
+from unittest.mock import MagicMock, patch
+import pandas as pd
+from apts.observations import Observation
+from apts.conditions import Conditions
+from tests import setup_observation
+
+class TestMoonConditionOptimization(unittest.TestCase):
+    def setUp(self):
+        # Start patcher to avoid Redis connection errors
+        self.get_cache_settings_patcher = patch("apts.config.get_cache_settings")
+        self.mock_get_cache_settings = self.get_cache_settings_patcher.start()
+        self.mock_get_cache_settings.return_value = {
+            "backend": "memory",
+            "expire_after": 300,
+            "redis_location": None,
+        }
+        self.addCleanup(self.get_cache_settings_patcher.stop)
+
+        self.obs = setup_observation()
+        self.test_tz = datetime.timezone.utc
+        self.base_date = pd.Timestamp("2024-01-01", tz=self.test_tz)
+        
+        # Mock place
+        self.mock_place = MagicMock()
+        self.mock_place.local_timezone = self.test_tz
+        self.mock_place.ts = self.obs.place.ts # Keep real timescale for linspace
+        self.mock_place.date = self.base_date
+        
+        # Mock observer
+        self.mock_observer = MagicMock()
+        self.mock_place.observer = self.mock_observer
+        
+        # Mock moon
+        self.mock_place.moon = MagicMock()
+        
+        self.obs.place = self.mock_place
+        self.obs.start = self.base_date.replace(hour=18, minute=0)
+        self.obs.stop = self.base_date.replace(hour=22, minute=0)
+        
+        self.obs.conditions = Conditions()
+        self.obs.conditions.max_moon_illumination = 50
+
+        # Mock weather
+        self.mock_place.weather = None
+        self.mock_place.get_weather = MagicMock()
+
+        # Default altaz return value
+        self.mock_altaz = MagicMock()
+        self.mock_observer.at.return_value.observe.return_value.apparent.return_value.altaz.return_value = (self.mock_altaz, None, None)
+        self.mock_altaz.degrees = [10.0] * 10
+
+    @patch("apts.observations.get_moon_illumination")
+    def test_weather_analysis_skipped_when_moon_too_bright(self, mock_get_illumination):
+        # Arrange: Moon is 80% illuminated (> 50% limit)
+        mock_get_illumination.return_value = 80.0
+        
+        # Act
+        results = self.obs.get_weather_analysis()
+        
+        # Assert
+        self.assertEqual(results, [])
+        self.mock_place.get_weather.assert_not_called()
+
+    @patch("apts.observations.get_moon_illumination")
+    def test_weather_analysis_not_skipped_when_moon_is_dim(self, mock_get_illumination):
+        # Arrange: Moon is 20% illuminated (< 50% limit)
+        mock_get_illumination.return_value = 20.0
+        
+        # Mock weather data
+        mock_df = pd.DataFrame([{
+            "time": self.obs.start,
+            "cloudCover": 0,
+            "precipIntensity": 0,
+            "precipProbability": 0,
+            "windSpeed": 0,
+            "temperature": 15,
+            "visibility": 100,
+            "moonIllumination": 20,
+            "fog": 0,
+            "seeing": 1.0,
+            "sqm": 21.0
+        }])
+        
+        # Mock get_weather to set weather
+        def set_weather(*args, **kwargs):
+            self.mock_place.weather = MagicMock()
+            self.mock_place.weather.get_critical_data.return_value = mock_df
+        self.mock_place.get_weather.side_effect = set_weather
+        
+        # Adjust altaz degrees to match mock_df length (1)
+        self.mock_altaz.degrees = [10.0]
+        
+        # Act
+        results = self.obs.get_weather_analysis()
+        
+        # Assert
+        self.assertNotEqual(results, [])
+        self.mock_place.get_weather.assert_called()
+
+    @patch("apts.observations.get_moon_illumination")
+    def test_weather_analysis_forced_when_moon_too_bright(self, mock_get_illumination):
+        # Arrange: Moon is 80% illuminated (> 50% limit)
+        mock_get_illumination.return_value = 80.0
+        
+        # Mock weather data
+        mock_df = pd.DataFrame([{
+            "time": self.obs.start,
+            "cloudCover": 0,
+            "precipIntensity": 0,
+            "precipProbability": 0,
+            "windSpeed": 0,
+            "temperature": 15,
+            "visibility": 100,
+            "moonIllumination": 80,
+            "fog": 0,
+            "seeing": 1.0,
+            "sqm": 21.0
+        }])
+        
+        # Mock get_weather to set weather
+        def set_weather(*args, **kwargs):
+            self.mock_place.weather = MagicMock()
+            self.mock_place.weather.get_critical_data.return_value = mock_df
+        self.mock_place.get_weather.side_effect = set_weather
+        
+        # Adjust altaz degrees to match mock_df length (1)
+        self.mock_altaz.degrees = [10.0]
+        
+        # Act
+        results = self.obs.get_weather_analysis(force=True)
+        
+        # Assert
+        self.assertNotEqual(results, [])
+        self.mock_place.get_weather.assert_called()
+
+    @patch("apts.observations.get_moon_illumination")
+    def test_is_weather_good_returns_false_when_moon_too_bright(self, mock_get_illumination):
+        # Arrange: Moon is 80% illuminated (> 50% limit)
+        mock_get_illumination.return_value = 80.0
+        
+        # Act
+        result = self.obs.is_weather_good()
+        
+        # Assert
+        self.assertFalse(result)
+        self.mock_place.get_weather.assert_not_called()

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -1501,7 +1501,7 @@ class TestObservationWeatherAnalysis(unittest.TestCase):
                 self.obs.place.weather.get_critical_data.return_value = mock_weather_df
                 self.obs._weather_analysis = None
 
-                results = self.obs.get_hourly_weather_analysis()
+                results = self.obs.get_hourly_weather_analysis(force=True)
                 self.assertTrue(results[0]["is_good_hour"], f"Boundary value {val} for {field} should be good. Reasons: {results[0].get('reasons')}")
 
 


### PR DESCRIPTION
Implement a check for moon illumination in the `get_weather_analysis` method. Weather analysis will be skipped if the moon illumination exceeds the configured maximum, unless the `force` flag is set to `True`. This optimization avoids unnecessary weather data fetching when the moon is too bright.