### PR TITLE
Upgrade Skyfield to 1.54 to fix Astrometric.apparent() TypeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests-cache==1.2.1
 requests-mock==1.12.1
 scipy==1.16.3
 seaborn==0.13.2
-skyfield==1.53
+skyfield==1.54
 svgwrite==1.4.3
 timezonefinder==8.1.0
 astropy==7.2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "aenum>=2.0.6",
         "ephem>=3.7.6.0",
-        "skyfield",
+        "skyfield>=1.54",
         "scipy>=1.0.0",
         "matplotlib>=2.1.2",
         "numpy>=1.14.0",


### PR DESCRIPTION
This change upgrades the `skyfield` dependency from version 1.53 to 1.54 in both `requirements.txt` and `setup.py`. This resolves a `TypeError: Astrometric.apparent() got an unexpected keyword argument 'deflectors'` that occurred when calculating certain astronomical events (like Jovian mutual events) that use the `deflectors` parameter to optimize or limit gravitational deflection calculations.

All unit tests have been verified to pass after the upgrade.

---
*PR created automatically by Jules for task [8492112513150076696](https://jules.google.com/task/8492112513150076696) started by @pozar87*