### PR TITLE
🔭 Stellar: Add Sky-Watcher 130PDS and Askar 103APO 0.8x Reducer

### DIFF
--- a/apts/opticalequipment/reducer/vendors/askar.py
+++ b/apts/opticalequipment/reducer/vendors/askar.py
@@ -1,11 +1,134 @@
 from ..base import Reducer, Flattener, Corrector
 
 class AskarReducer(Reducer):
-    _DATABASE = {'Askar_0_7x_Reducer_FRA_series': {'brand': 'Askar', 'name': '0.7x Reducer (FRA series)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 200, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_103APO_Reducer_0_6x': {'brand': 'Askar', 'name': '103APO Reducer 0.6x', 'type': 'type_reducer', 'optical_length': 0, 'mass': 300, 'tside_thread': 'M68', 'tside_gender': 'Female', 'cside_thread': 'M68', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_151PHQ_Reducer_0_7x': {'brand': 'Askar', 'name': '151PHQ Reducer 0.7x', 'type': 'type_reducer', 'optical_length': 0, 'mass': 350, 'tside_thread': 'M68', 'tside_gender': 'Female', 'cside_thread': 'M68', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_0_76x_Reducer_PHQ': {'brand': 'Askar', 'name': '0.76x Reducer (PHQ)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 280, 'tside_thread': 'M54', 'tside_gender': 'Female', 'cside_thread': 'M54', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_0_7x_Reducer_65PHQ': {'brand': 'Askar', 'name': '0.7x Reducer (65PHQ)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 200, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_0_76x_Reducer_80PHQ': {'brand': 'Askar', 'name': '0.76x Reducer (80PHQ)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 250, 'tside_thread': 'M54', 'tside_gender': 'Female', 'cside_thread': 'M54', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_0_7x_Reducer_107PHQ': {'brand': 'Askar', 'name': '0.7x Reducer (107PHQ)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 300, 'tside_thread': 'M68', 'tside_gender': 'Female', 'cside_thread': 'M68', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_0_6x_Reducer_FRA400': {'brand': 'Askar', 'name': '0.6x Reducer (FRA400)', 'type': 'type_reducer', 'optical_length': 0, 'mass': 220, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}}
+    _DATABASE = {
+        'Askar_0_7x_Reducer_FRA_series': {
+            'brand': 'Askar',
+            'name': '0.7x Reducer (FRA series)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 200,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_103APO_Reducer_0_8x': {
+            'brand': 'Askar',
+            'name': '103APO Reducer 0.8x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 480,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start',
+            'required_backfocus': 55
+        },
+        'Askar_103APO_Reducer_0_6x': {
+            'brand': 'Askar',
+            'name': '103APO Reducer 0.6x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 300,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M68',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_151PHQ_Reducer_0_7x': {
+            'brand': 'Askar',
+            'name': '151PHQ Reducer 0.7x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 350,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M68',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_0_76x_Reducer_PHQ': {
+            'brand': 'Askar',
+            'name': '0.76x Reducer (PHQ)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 280,
+            'tside_thread': 'M54',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_0_7x_Reducer_65PHQ': {
+            'brand': 'Askar',
+            'name': '0.7x Reducer (65PHQ)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 200,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_0_76x_Reducer_80PHQ': {
+            'brand': 'Askar',
+            'name': '0.76x Reducer (80PHQ)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 250,
+            'tside_thread': 'M54',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_0_7x_Reducer_107PHQ': {
+            'brand': 'Askar',
+            'name': '0.7x Reducer (107PHQ)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 300,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M68',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_0_6x_Reducer_FRA400': {
+            'brand': 'Askar',
+            'name': '0.6x Reducer (FRA400)',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 220,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        }
+    }
 
     @classmethod
     def Askar_0_7x_Reducer_FRA_series(cls):
         return cls.from_database(cls._DATABASE['Askar_0_7x_Reducer_FRA_series'])
+
+    @classmethod
+    def Askar_103APO_Reducer_0_8x(cls):
+        return cls.from_database(cls._DATABASE['Askar_103APO_Reducer_0_8x'])
 
     @classmethod
     def Askar_103APO_Reducer_0_6x(cls):
@@ -36,7 +159,34 @@ class AskarReducer(Reducer):
         return cls.from_database(cls._DATABASE['Askar_0_6x_Reducer_FRA400'])
 
 class AskarFlattener(Flattener):
-    _DATABASE = {'Askar_Full_frame_Flattener': {'brand': 'Askar', 'name': 'Full-frame Flattener', 'type': 'type_flattener', 'optical_length': 0, 'mass': 250, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}, 'Askar_2_Flattener_M48': {'brand': 'Askar', 'name': '2" Flattener (M48)', 'type': 'type_flattener', 'optical_length': 0, 'mass': 230, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}}
+    _DATABASE = {
+        'Askar_Full_frame_Flattener': {
+            'brand': 'Askar',
+            'name': 'Full-frame Flattener',
+            'type': 'type_flattener',
+            'optical_length': 0,
+            'mass': 250,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        },
+        'Askar_2_Flattener_M48': {
+            'brand': 'Askar',
+            'name': '2" Flattener (M48)',
+            'type': 'type_flattener',
+            'optical_length': 0,
+            'mass': 230,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        }
+    }
 
     @classmethod
     def Askar_Full_frame_Flattener(cls):
@@ -47,7 +197,21 @@ class AskarFlattener(Flattener):
         return cls.from_database(cls._DATABASE['Askar_2_Flattener_M48'])
 
 class AskarCorrector(Corrector):
-    _DATABASE = {'Askar_Color_Magic_Corrector': {'brand': 'Askar', 'name': 'Color-Magic Corrector', 'type': 'type_corrector', 'optical_length': 0, 'mass': 200, 'tside_thread': 'M48', 'tside_gender': 'Female', 'cside_thread': 'M48', 'cside_gender': 'Female', 'reversible': False, 'bf_role': 'start'}}
+    _DATABASE = {
+        'Askar_Color_Magic_Corrector': {
+            'brand': 'Askar',
+            'name': 'Color-Magic Corrector',
+            'type': 'type_corrector',
+            'optical_length': 0,
+            'mass': 200,
+            'tside_thread': 'M48',
+            'tside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': 'start'
+        }
+    }
 
     @classmethod
     def Askar_Color_Magic_Corrector(cls):

--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -2,6 +2,20 @@ from ..base import Telescope
 
 class Sky_watcherTelescope(Telescope):
     _DATABASE = {
+        'Sky_Watcher_130PDS_Newtonian': {'aperture_mm': 130,
+         'bf_role': '',
+         'brand': 'Sky-Watcher',
+         'central_obstruction_mm': 47,
+         'cside_gender': 'Female',
+         'cside_thread': '2"',
+         'focal_length_mm': 650,
+         'mass': 4000,
+         'name': '130PDS Newtonian',
+         'optical_length': 0,
+         'reversible': False,
+         'tside_gender': '',
+         'tside_thread': '',
+         'type': 'newtonian_reflector'},
         'Sky_Watcher_150PDS_Newtonian': {'aperture_mm': 150,
          'bf_role': '',
          'brand': 'Sky-Watcher',
@@ -1178,6 +1192,10 @@ class Sky_watcherTelescope(Telescope):
     @classmethod
     def Sky_Watcher_Quattro_300P(cls):
         return cls.from_database(cls._DATABASE['Sky_Watcher_Quattro_300P'])
+
+    @classmethod
+    def Sky_Watcher_130PDS_Newtonian(cls):
+        return cls.from_database(cls._DATABASE['Sky_Watcher_130PDS_Newtonian'])
 
     @classmethod
     def Sky_Watcher_150PDS_Newtonian(cls):

--- a/tests/unit/test_equipment_update_v5.py
+++ b/tests/unit/test_equipment_update_v5.py
@@ -1,0 +1,23 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.opticalequipment.reducer.vendors.askar import AskarReducer
+
+class TestEquipmentUpdateV5(unittest.TestCase):
+    def test_sky_watcher_130pds_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_130PDS_Newtonian()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher 130PDS Newtonian")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 130)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 650)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 47)
+        self.assertEqual(scope.mass.to('gram').magnitude, 4000)
+        self.assertEqual(scope.focal_ratio().magnitude, 650/130)
+
+    def test_askar_103apo_reducer_0_8x_specs(self):
+        reducer = AskarReducer.Askar_103APO_Reducer_0_8x()
+        self.assertEqual(reducer.get_vendor(), "Askar 103APO Reducer 0.8x")
+        self.assertEqual(reducer.magnification, 0.8)
+        self.assertEqual(reducer.mass.to('gram').magnitude, 480)
+        self.assertEqual(reducer.required_backfocus.to('mm').magnitude, 55)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the popular Sky-Watcher 130PDS Newtonian telescope and the Askar 103APO 0.8x Reducer to the equipment database.

### 💡 What
- Added `Sky_Watcher_130PDS_Newtonian` with verified 130mm aperture, 650mm focal length, 47mm CO, and 4000g mass.
- Added `Askar_103APO_Reducer_0_8x` with verified 0.8x magnification, 480g mass, and 55mm required backfocus.
- Reformatted `apts/opticalequipment/reducer/vendors/askar.py` for improved maintainability.
- Added unit tests in `tests/unit/test_equipment_update_v5.py`.

### 🎯 Why
Both are highly popular pieces of equipment in the astrophotography community. Providing accurate physical specifications (aperture, mass, and especially backfocus for the reducer) enables users to perform reliable optical path simulations and setup planning.

### 📚 Source
Verified via official Sky-Watcher and Askar technical specifications.

---
*PR created automatically by Jules for task [17526789954689475622](https://jules.google.com/task/17526789954689475622) started by @pozar87*