### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Evolux and Explorer/Quattro series

### DIFF
--- a/.jules/optics.md
+++ b/.jules/optics.md
@@ -630,3 +630,19 @@
     - http://skywatcher.com/series/astrophotography-reflectors/
     - https://www.skywatcherusa.com/products/sky-watcher-quattro-250p-imaging-newtonian-10-254-mm
     - https://www.skywatcherusa.com/products/sky-watcher-quattro-300p-imaging-newtonian-12-305-mm
+
+## 2026-05-21 - Audit of Sky-Watcher Evolux and Explorer/Quattro series
+
+- **Items:** Evolux 62ED, Evolux 82ED, Explorer 200P, Quattro 200P.
+- **Vendor File:** `apts/opticalequipment/telescope/vendors/sky_watcher.py`
+- **Verified Specs (Source: Sky-Watcher Global / First Light Optics):**
+    - **Evolux 62ED:** Aperture 62mm, FL 400mm, Mass 2.5kg (2500g). CO 0mm.
+    - **Evolux 82ED:** Aperture 82mm, FL 530mm, Mass 2.92kg (2920g). CO 0mm.
+    - **Explorer 200P:** Aperture 200mm, FL 1000mm, Mass 8.8kg (8800g). CO 52mm.
+    - **Quattro 200P:** Aperture 205mm, FL 800mm, Mass 9.5kg (9500g). CO 70mm.
+- **Action:** Updated all models with verified physical specs and added official source URLs in comments. Corrected Quattro 200P aperture to 205mm. Verified via static analysis of the database.
+- **Source URLs:**
+    - http://www.skywatcher.com/product/evolux-62ed/
+    - http://www.skywatcher.com/product/evolux-82ed/
+    - https://www.firstlightoptics.com/reflectors/skywatcher-explorer-200p-ota.html
+    - http://skywatcher.com/product/quattro-200-st/

--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -99,7 +99,7 @@ class Sky_watcherTelescope(Telescope):
          'reversible': False,
          'tside_gender': '',
          'tside_thread': '',
-         'type': 'type_refractor'},
+         'type': 'type_refractor'}, # Verified via Sky-Watcher official specs (2.5 kg OTA) http://www.skywatcher.com/product/evolux-62ed/
         'Sky_Watcher_Evolux_82ED': {'aperture_mm': 82,
          'bf_role': '',
          'brand': 'Sky-Watcher',
@@ -113,7 +113,7 @@ class Sky_watcherTelescope(Telescope):
          'reversible': False,
          'tside_gender': '',
          'tside_thread': '',
-         'type': 'type_refractor'},
+         'type': 'type_refractor'}, # Verified via Sky-Watcher official specs (2.92 kg OTA) http://www.skywatcher.com/product/evolux-82ed/
         'Sky_Watcher_Black_Diamond_ED120': {'aperture_mm': 120,
          'bf_role': '',
          'brand': 'Sky-Watcher',
@@ -407,7 +407,7 @@ class Sky_watcherTelescope(Telescope):
          'reversible': False,
          'tside_gender': '',
          'tside_thread': '',
-         'type': 'newtonian_reflector'}, # Verified via manufacturer technical specs (52mm CO, 8.8kg OTA)
+         'type': 'newtonian_reflector'}, # Verified via manufacturer technical specs (52mm CO, 8.8kg OTA) https://www.firstlightoptics.com/reflectors/skywatcher-explorer-200p-ota.html
         'Sky_Watcher_Explorer_250P': {'aperture_mm': 254,
          'bf_role': '',
          'brand': 'Sky-Watcher',
@@ -620,7 +620,7 @@ class Sky_watcherTelescope(Telescope):
          'tside_gender': '',
          'tside_thread': '',
          'type': 'newtonian_reflector'},
-        'Sky_Watcher_Quattro_200P': {'aperture_mm': 200,
+        'Sky_Watcher_Quattro_200P': {'aperture_mm': 205,
          'bf_role': '',
          'brand': 'Sky-Watcher',
          'central_obstruction_mm': 70,
@@ -633,7 +633,7 @@ class Sky_watcherTelescope(Telescope):
          'reversible': False,
          'tside_gender': '',
          'tside_thread': '',
-         'type': 'newtonian_reflector'},
+         'type': 'newtonian_reflector'}, # Verified via Sky-Watcher official specs (205mm diameter, 9.5kg tube) http://skywatcher.com/product/quattro-200-st/
         'Sky_Watcher_Quattro_250P': {'aperture_mm': 254,
          'bf_role': '',
          'brand': 'Sky-Watcher',

--- a/scripts/verify_skywatcher_static.py
+++ b/scripts/verify_skywatcher_static.py
@@ -1,0 +1,44 @@
+import ast
+import os
+
+def verify():
+    filepath = 'apts/opticalequipment/telescope/vendors/sky_watcher.py'
+    with open(filepath, 'r') as f:
+        tree = ast.parse(f.read())
+
+    database = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == '_DATABASE':
+                    database = ast.literal_eval(node.value)
+                    break
+
+    expected = {
+        'Sky_Watcher_Evolux_62ED': {'aperture_mm': 62, 'focal_length_mm': 400, 'mass': 2500, 'central_obstruction_mm': 0},
+        'Sky_Watcher_Evolux_82ED': {'aperture_mm': 82, 'focal_length_mm': 530, 'mass': 2920, 'central_obstruction_mm': 0},
+        'Sky_Watcher_Explorer_200P': {'aperture_mm': 200, 'focal_length_mm': 1000, 'mass': 8800, 'central_obstruction_mm': 52},
+        'Sky_Watcher_Quattro_200P': {'aperture_mm': 205, 'focal_length_mm': 800, 'mass': 9500, 'central_obstruction_mm': 70}
+    }
+
+    for model, specs in expected.items():
+        if model not in database:
+            print(f"FAILED: {model} not found in database")
+            return False
+
+        actual = database[model]
+        for key, value in specs.items():
+            if actual.get(key) != value:
+                print(f"FAILED: {model} {key} expected {value}, got {actual.get(key)}")
+                return False
+        print(f"PASSED: {model}")
+
+    return True
+
+if __name__ == '__main__':
+    if verify():
+        print("Static verification successful!")
+        exit(0)
+    else:
+        print("Static verification failed!")
+        exit(1)

--- a/tests/unit/test_skywatcher_audit.py
+++ b/tests/unit/test_skywatcher_audit.py
@@ -35,7 +35,7 @@ def test_skywatcher_quattro_specs():
 
     # Quattro 200P
     q200 = Sky_watcherTelescope.Sky_Watcher_Quattro_200P()
-    assert q200.aperture.magnitude == 200
+    assert q200.aperture.magnitude == 205
     assert q200.focal_length.magnitude == 800
     assert q200.mass.to('g').magnitude == 9500
     assert q200.central_obstruction.magnitude == 70

--- a/tests/unit/test_skywatcher_evolux_explorer_audit.py
+++ b/tests/unit/test_skywatcher_evolux_explorer_audit.py
@@ -1,0 +1,30 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_evolux_62ed_specs():
+    model = Sky_watcherTelescope.Sky_Watcher_Evolux_62ED()
+    assert model.aperture.magnitude == 62
+    assert model.focal_length.magnitude == 400
+    assert model.mass == 2500
+    assert model.central_obstruction.magnitude == 0
+
+def test_evolux_82ed_specs():
+    model = Sky_watcherTelescope.Sky_Watcher_Evolux_82ED()
+    assert model.aperture.magnitude == 82
+    assert model.focal_length.magnitude == 530
+    assert model.mass == 2920
+    assert model.central_obstruction.magnitude == 0
+
+def test_explorer_200p_specs():
+    model = Sky_watcherTelescope.Sky_Watcher_Explorer_200P()
+    assert model.aperture.magnitude == 200
+    assert model.focal_length.magnitude == 1000
+    assert model.mass == 8800
+    assert model.central_obstruction.magnitude == 52
+
+def test_quattro_200p_specs():
+    model = Sky_watcherTelescope.Sky_Watcher_Quattro_200P()
+    assert model.aperture.magnitude == 205
+    assert model.focal_length.magnitude == 800
+    assert model.mass == 9500
+    assert model.central_obstruction.magnitude == 70

--- a/tests/unit/test_skywatcher_evolux_explorer_audit.py
+++ b/tests/unit/test_skywatcher_evolux_explorer_audit.py
@@ -5,26 +5,26 @@ def test_evolux_62ed_specs():
     model = Sky_watcherTelescope.Sky_Watcher_Evolux_62ED()
     assert model.aperture.magnitude == 62
     assert model.focal_length.magnitude == 400
-    assert model.mass == 2500
+    assert model.mass.to('g').magnitude == 2500
     assert model.central_obstruction.magnitude == 0
 
 def test_evolux_82ed_specs():
     model = Sky_watcherTelescope.Sky_Watcher_Evolux_82ED()
     assert model.aperture.magnitude == 82
     assert model.focal_length.magnitude == 530
-    assert model.mass == 2920
+    assert model.mass.to('g').magnitude == 2920
     assert model.central_obstruction.magnitude == 0
 
 def test_explorer_200p_specs():
     model = Sky_watcherTelescope.Sky_Watcher_Explorer_200P()
     assert model.aperture.magnitude == 200
     assert model.focal_length.magnitude == 1000
-    assert model.mass == 8800
+    assert model.mass.to('g').magnitude == 8800
     assert model.central_obstruction.magnitude == 52
 
 def test_quattro_200p_specs():
     model = Sky_watcherTelescope.Sky_Watcher_Quattro_200P()
     assert model.aperture.magnitude == 205
     assert model.focal_length.magnitude == 800
-    assert model.mass == 9500
+    assert model.mass.to('g').magnitude == 9500
     assert model.central_obstruction.magnitude == 70


### PR DESCRIPTION
This PR performs a physical specification audit for four Sky-Watcher telescope models based on official manufacturer documentation (Sky-Watcher Global and First Light Optics).

Key changes:
1.  **Quattro 200P:** Corrected aperture from 200mm to 205mm. Manufacturer specs explicitly state a 205mm optical diameter for this model.
2.  **Evolux 82ED:** Confirmed mass is 2.92kg (2920g) for the OTA assembly.
3.  **Evolux 62ED:** Confirmed mass is 2.5kg (2500g).
4.  **Explorer 200P:** Confirmed 52mm central obstruction (secondary mirror diameter) and 8.8kg mass.
5.  **Documentation:** Added source URLs in comments for all four models for future traceability.
6.  **Verification:** 
    - Created `tests/unit/test_skywatcher_evolux_explorer_audit.py` for standard object-model verification.
    - Created `scripts/verify_skywatcher_static.py` to allow static verification of the database dictionary (useful in environments where complex dependencies like `pandas` are missing).
7.  **Audit Log:** Documented findings in `.jules/optics.md`.

All data has been cross-referenced with non-truncated documentation from Sky-Watcher Global.

---
*PR created automatically by Jules for task [12662439006214923310](https://jules.google.com/task/12662439006214923310) started by @pozar87*