### PR TITLE
Include object name in culmination event strings

### DIFF
--- a/apts/skyfield_searches.py
+++ b/apts/skyfield_searches.py
@@ -2447,7 +2447,7 @@ def find_culminations(observer, start_date, end_date, sun_alt_threshold=-6):
                     events.append(
                         {
                             "date": t.utc_datetime(),
-                            "event": "Culmination",
+                            "event": f"{simple_name} Culmination",
                             "object": simple_name,
                             "type": "Culmination",
                             "altitude": float(alt),
@@ -2578,7 +2578,7 @@ def find_object_culminations(
                 events.append(
                     {
                         "date": t.utc_datetime(),
-                        "event": "Culmination",
+                        "event": f"{name} Culmination",
                         "object": name,
                         "type": "Messier Culmination",
                         "altitude": float(alt),
@@ -2613,7 +2613,7 @@ def find_object_culminations(
                     events.append(
                         {
                             "date": t.utc_datetime(),
-                            "event": "Culmination",
+                            "event": f"{name} Culmination",
                             "object": name,
                             "type": "Messier Culmination",
                             "altitude": float(alt),


### PR DESCRIPTION
Culmination events now include the object name in the 'event' field, allowing users to easily identify which Messier object or planet is culminating. Previously, these events only stated 'Culmination'.

Changes:
- Updated `find_culminations` in `apts/skyfield_searches.py` to use `f"{simple_name} Culmination"`.
- Updated `find_object_culminations` in `apts/skyfield_searches.py` to use `f"{name} Culmination"`.
- Compiled `.po` to `.mo` files in `apts/locale` to resolve translation-related test failures.

---
*PR created automatically by Jules for task [18064910596220541544](https://jules.google.com/task/18064910596220541544) started by @pozar87*