### PR TITLE
🔍 Optic: Data audit for iOptron Photron RC and Refractor series

### DIFF
--- a/.jules/optics.md
+++ b/.jules/optics.md
@@ -646,3 +646,24 @@
     - http://www.skywatcher.com/product/evolux-82ed/
     - https://www.firstlightoptics.com/reflectors/skywatcher-explorer-200p-ota.html
     - http://skywatcher.com/product/quattro-200-st/
+
+## 2026-05-22 - Audit of iOptron Photron RC and Refractor series
+
+- **Items:** Photron RC 6", 8", 10" (Steel & Truss), 12" (Truss), 16" (Truss), and R80 refractor.
+- **Vendor File:** `apts/opticalequipment/telescope/vendors/ioptron.py`
+- **Initial State:** RC 6/8 had inaccurate mass and central obstruction values. RC 10/12/16 and R80 were missing. APO 80/102 were missing explicit central obstruction.
+- **Verified Specs (Source: iOptron Official Website / Manuals):**
+    - **Photron RC 6":** 150/1370mm, CO 67mm, Mass 5.44kg (12 lbs).
+    - **Photron RC 8":** 200/1624mm, CO 95mm, Mass 8.16kg (18 lbs).
+    - **Photron RC 10" (Steel):** 250/2000mm, CO 110mm, Mass 15.88kg (35 lbs).
+    - **Photron RC 10" (Truss):** 254/2032mm, CO 110mm, Mass 15.42kg (34 lbs).
+    - **Photron RC 12" (Truss):** 304/2432mm, CO 150mm, Mass 24.04kg (53 lbs).
+    - **Photron RC 16" (Truss):** 406/3250mm, CO 171mm (est), Mass 42.18kg (93 lbs).
+    - **R80 Achromatic:** 80/400mm, CO 0mm, Mass 1.0kg (2.2 lbs).
+- **Action:** Updated RC6/RC8, added RC10/12/16 and R80 with verified specs. Standardized APO 80/102 with explicit `central_obstruction_mm: 0`. Added source comments.
+- **Source URLs:**
+    - https://www.ioptron.com/product-p/6111.htm (RC6)
+    - https://www.ioptron.com/product-p/6112.htm (RC8)
+    - https://www.ioptron.com/product-p/6113af.htm (RC10 Steel)
+    - https://www.ioptron.com/v/Manuals/611X_RCTruss_Manual.pdf (RC Truss Manual)
+    - https://www.ioptron.com/product-p/8710.htm (R80)

--- a/apts/opticalequipment/telescope/vendors/ioptron.py
+++ b/apts/opticalequipment/telescope/vendors/ioptron.py
@@ -2,24 +2,204 @@ from ..base import Telescope
 
 class IoptronTelescope(Telescope):
     _DATABASE = {
-        'iOptron_iOptron_RC_6': {'brand': 'iOptron', 'name': 'iOptron RC 6"', 'type': 'catadioptric', 'optical_length': 0, 'mass': 5400, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M90', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 152, 'focal_length_mm': 1370, 'central_obstruction_mm': 61},
-        'iOptron_iOptron_RC_8': {'brand': 'iOptron', 'name': 'iOptron RC 8"', 'type': 'catadioptric', 'optical_length': 0, 'mass': 7500, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M90', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 203, 'focal_length_mm': 1624, 'central_obstruction_mm': 85},
-        'iOptron_iOptron_80mm_APO': {'brand': 'iOptron', 'name': 'iOptron 80mm APO', 'type': 'type_refractor', 'optical_length': 0, 'mass': 3100, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M48', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 80, 'focal_length_mm': 480},
-        'iOptron_iOptron_102mm_APO': {'brand': 'iOptron', 'name': 'iOptron 102mm APO', 'type': 'type_refractor', 'optical_length': 0, 'mass': 4500, 'tside_thread': '', 'tside_gender': '', 'cside_thread': 'M48', 'cside_gender': 'Male', 'reversible': False, 'bf_role': '', 'aperture_mm': 102, 'focal_length_mm': 714},
+        'iOptron_Photron_RC_6': {
+            'brand': 'iOptron',
+            'name': 'Photron 6" RC',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 5443, # 12 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M90',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 150,
+            'focal_length_mm': 1370,
+            'central_obstruction_mm': 67 # Verified via iOptron Website
+        },
+        'iOptron_Photron_RC_8': {
+            'brand': 'iOptron',
+            'name': 'Photron 8" RC',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 8165, # 18 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M90',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 200,
+            'focal_length_mm': 1624,
+            'central_obstruction_mm': 95 # Verified via iOptron Website
+        },
+        'iOptron_Photron_RC_10_Steel': {
+            'brand': 'iOptron',
+            'name': 'Photron 10" RC (Steel)',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 15876, # 35 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M117',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 250,
+            'focal_length_mm': 2000,
+            'central_obstruction_mm': 110 # Verified via iOptron Website
+        },
+        'iOptron_Photron_RC_10_Truss': {
+            'brand': 'iOptron',
+            'name': 'Photron 10" RC (Truss)',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 15422, # 34 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M117',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 254,
+            'focal_length_mm': 2032,
+            'central_obstruction_mm': 110 # Verified via iOptron Manual
+        },
+        'iOptron_Photron_RC_12_Truss': {
+            'brand': 'iOptron',
+            'name': 'Photron 12" RC (Truss)',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 24040, # 53 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M117',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 304,
+            'focal_length_mm': 2432,
+            'central_obstruction_mm': 150 # Verified via iOptron Manual
+        },
+        'iOptron_Photron_RC_16_Truss': {
+            'brand': 'iOptron',
+            'name': 'Photron 16" RC (Truss)',
+            'type': 'catadioptric',
+            'optical_length': 0,
+            'mass': 42184, # 93 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M117',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 406,
+            'focal_length_mm': 3250,
+            'central_obstruction_mm': 171 # Estimated based on 42% obstruction typical for these large RCs
+        },
+        'iOptron_80mm_APO': {
+            'brand': 'iOptron',
+            'name': 'iOptron 80mm APO',
+            'type': 'type_refractor',
+            'optical_length': 0,
+            'mass': 3100,
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M48',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 80,
+            'focal_length_mm': 480,
+            'central_obstruction_mm': 0
+        },
+        'iOptron_102mm_APO': {
+            'brand': 'iOptron',
+            'name': 'iOptron 102mm APO',
+            'type': 'type_refractor',
+            'optical_length': 0,
+            'mass': 4500,
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': 'M48',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 102,
+            'focal_length_mm': 714,
+            'central_obstruction_mm': 0
+        },
+        'iOptron_R80': {
+            'brand': 'iOptron',
+            'name': 'iOptron R80',
+            'type': 'type_refractor',
+            'optical_length': 0,
+            'mass': 998, # 2.2 lbs
+            'tside_thread': '',
+            'tside_gender': '',
+            'cside_thread': '1.25"',
+            'cside_gender': 'Female',
+            'reversible': False,
+            'bf_role': '',
+            'aperture_mm': 80,
+            'focal_length_mm': 400,
+            'central_obstruction_mm': 0 # Verified via iOptron Manual
+        },
     }
 
     @classmethod
+    def iOptron_Photron_RC_6(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_6'])
+
+    @classmethod
     def iOptron_iOptron_RC_6(cls):
-        return cls.from_database(cls._DATABASE['iOptron_iOptron_RC_6'])
+        """Legacy method for backward compatibility."""
+        return cls.iOptron_Photron_RC_6()
+
+    @classmethod
+    def iOptron_Photron_RC_8(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_8'])
 
     @classmethod
     def iOptron_iOptron_RC_8(cls):
-        return cls.from_database(cls._DATABASE['iOptron_iOptron_RC_8'])
+        """Legacy method for backward compatibility."""
+        return cls.iOptron_Photron_RC_8()
+
+    @classmethod
+    def iOptron_Photron_RC_10_Steel(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_10_Steel'])
+
+    @classmethod
+    def iOptron_Photron_RC_10_Truss(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_10_Truss'])
+
+    @classmethod
+    def iOptron_Photron_RC_12_Truss(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_12_Truss'])
+
+    @classmethod
+    def iOptron_Photron_RC_16_Truss(cls):
+        return cls.from_database(cls._DATABASE['iOptron_Photron_RC_16_Truss'])
+
+    @classmethod
+    def iOptron_80mm_APO(cls):
+        return cls.from_database(cls._DATABASE['iOptron_80mm_APO'])
 
     @classmethod
     def iOptron_iOptron_80mm_APO(cls):
-        return cls.from_database(cls._DATABASE['iOptron_iOptron_80mm_APO'])
+        """Legacy method for backward compatibility."""
+        return cls.iOptron_80mm_APO()
+
+    @classmethod
+    def iOptron_102mm_APO(cls):
+        return cls.from_database(cls._DATABASE['iOptron_102mm_APO'])
 
     @classmethod
     def iOptron_iOptron_102mm_APO(cls):
-        return cls.from_database(cls._DATABASE['iOptron_iOptron_102mm_APO'])
+        """Legacy method for backward compatibility."""
+        return cls.iOptron_102mm_APO()
+
+    @classmethod
+    def iOptron_R80(cls):
+        return cls.from_database(cls._DATABASE['iOptron_R80'])

--- a/tests/unit/test_ioptron_specs.py
+++ b/tests/unit/test_ioptron_specs.py
@@ -1,0 +1,28 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.ioptron import IoptronTelescope
+
+@pytest.mark.parametrize("factory_method, expected_aperture, expected_focal, expected_mass, expected_co, expected_type", [
+    (IoptronTelescope.iOptron_Photron_RC_6, 150, 1370, 5443, 67, "catadioptric"),
+    (IoptronTelescope.iOptron_iOptron_RC_6, 150, 1370, 5443, 67, "catadioptric"), # Legacy
+    (IoptronTelescope.iOptron_Photron_RC_8, 200, 1624, 8165, 95, "catadioptric"),
+    (IoptronTelescope.iOptron_iOptron_RC_8, 200, 1624, 8165, 95, "catadioptric"), # Legacy
+    (IoptronTelescope.iOptron_Photron_RC_10_Steel, 250, 2000, 15876, 110, "catadioptric"),
+    (IoptronTelescope.iOptron_Photron_RC_10_Truss, 254, 2032, 15422, 110, "catadioptric"),
+    (IoptronTelescope.iOptron_Photron_RC_12_Truss, 304, 2432, 24040, 150, "catadioptric"),
+    (IoptronTelescope.iOptron_Photron_RC_16_Truss, 406, 3250, 42184, 171, "catadioptric"),
+    (IoptronTelescope.iOptron_80mm_APO, 80, 480, 3100, 0, "refractor"),
+    (IoptronTelescope.iOptron_iOptron_80mm_APO, 80, 480, 3100, 0, "refractor"), # Legacy
+    (IoptronTelescope.iOptron_102mm_APO, 102, 714, 4500, 0, "refractor"),
+    (IoptronTelescope.iOptron_iOptron_102mm_APO, 102, 714, 4500, 0, "refractor"), # Legacy
+    (IoptronTelescope.iOptron_R80, 80, 400, 998, 0, "refractor"),
+])
+def test_ioptron_telescope_specs(factory_method, expected_aperture, expected_focal, expected_mass, expected_co, expected_type):
+    """Verify iOptron telescope hardware specifications against manufacturer data."""
+    telescope = factory_method()
+
+    assert telescope.aperture.magnitude == expected_aperture
+    assert telescope.focal_length.magnitude == expected_focal
+    assert telescope.mass.magnitude == expected_mass
+    assert telescope.central_obstruction.magnitude == expected_co
+    assert telescope.get_vendor().startswith("iOptron")
+    assert telescope.telescope_type.value == expected_type


### PR DESCRIPTION
### 🔍 Optic: Data Audit for iOptron Photron RC and Refractor Series

This pull request presents a comprehensive audit and update of the iOptron telescope hardware specifications within the `apts` database. Using official manufacturer documentation and manuals, I have corrected existing inaccuracies and expanded the database with several missing models from the Photron RC and refractor lines.

#### Key Changes:
- **Corrected RC 6" & 8" Specs:** Updated aperture, focal length, mass (using exact conversions from lbs to grams), and central obstruction values.
- **Added New Models:** 
  - Photron 10" RC (Steel)
  - Photron 10" RC (Truss)
  - Photron 12" RC (Truss)
  - Photron 16" RC (Truss)
  - iOptron R80 (Achromatic Refractor)
- **Standardized Refractor Data:** Updated existing `80mm_APO` and `102mm_APO` entries to include explicit `central_obstruction_mm: 0` for better area calculations and standardized their naming/formatting.
- **Backward Compatibility:** Added legacy method aliases (e.g., `iOptron_iOptron_RC_6`) to ensure existing code remains functional despite more accurate internal naming.
- **Documentation:** Appended a detailed audit log to `.jules/optics.md` with verified source URLs for all models.

#### Verification:
- **Unit Testing:** Created a new test file `tests/unit/test_ioptron_specs.py` which parameterizes all factory methods and verifies their physical properties against manufacturer data. All 13 tests passed.
- **Regression Testing:** Verified that related vendor tests (Meade, Takahashi) still pass.

Precision in the database is the foundation of precision in the field. This audit ensures that users of iOptron equipment can rely on accurate calculations for FOV, light gathering, and resolving power.

---
*PR created automatically by Jules for task [3656041741026296825](https://jules.google.com/task/3656041741026296825) started by @pozar87*