### PR TITLE
🔭 Stellar: Added dedicated Askar APO reducers and refined specifications

### DIFF
--- a/apts/opticalequipment/reducer/vendors/askar.py
+++ b/apts/opticalequipment/reducer/vendors/askar.py
@@ -24,7 +24,7 @@ class AskarReducer(Reducer):
             'tside_thread': 'M68',
             'tside_gender': 'Female',
             'cside_thread': 'M54',
-            'cside_gender': 'Female',
+            'cside_gender': 'Male',
             'reversible': False,
             'bf_role': 'start',
             'required_backfocus': 55
@@ -34,26 +34,70 @@ class AskarReducer(Reducer):
             'name': '103APO Reducer 0.6x',
             'type': 'type_reducer',
             'optical_length': 0,
-            'mass': 300,
+            'mass': 980,
             'tside_thread': 'M68',
             'tside_gender': 'Female',
-            'cside_thread': 'M68',
-            'cside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Male',
             'reversible': False,
-            'bf_role': 'start'
+            'bf_role': 'start',
+            'required_backfocus': 55
         },
         'Askar_151PHQ_Reducer_0_7x': {
             'brand': 'Askar',
             'name': '151PHQ Reducer 0.7x',
             'type': 'type_reducer',
             'optical_length': 0,
-            'mass': 350,
+            'mass': 600,
             'tside_thread': 'M68',
             'tside_gender': 'Female',
-            'cside_thread': 'M68',
-            'cside_gender': 'Female',
+            'cside_thread': 'M48',
+            'cside_gender': 'Male',
             'reversible': False,
-            'bf_role': 'start'
+            'bf_role': 'start',
+            'required_backfocus': 55
+        },
+        'Askar_120APO_Reducer_0_8x': {
+            'brand': 'Askar',
+            'name': '120APO Reducer 0.8x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 750,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': 'start',
+            'required_backfocus': 55
+        },
+        'Askar_140APO_Reducer_0_8x': {
+            'brand': 'Askar',
+            'name': '140APO Reducer 0.8x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 750,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': 'start',
+            'required_backfocus': 55
+        },
+        'Askar_185APO_Reducer_0_8x': {
+            'brand': 'Askar',
+            'name': '185APO Reducer 0.8x',
+            'type': 'type_reducer',
+            'optical_length': 0,
+            'mass': 950,
+            'tside_thread': 'M68',
+            'tside_gender': 'Female',
+            'cside_thread': 'M54',
+            'cside_gender': 'Male',
+            'reversible': False,
+            'bf_role': 'start',
+            'required_backfocus': 55
         },
         'Askar_0_76x_Reducer_PHQ': {
             'brand': 'Askar',
@@ -137,6 +181,18 @@ class AskarReducer(Reducer):
     @classmethod
     def Askar_151PHQ_Reducer_0_7x(cls):
         return cls.from_database(cls._DATABASE['Askar_151PHQ_Reducer_0_7x'])
+
+    @classmethod
+    def Askar_120APO_Reducer_0_8x(cls):
+        return cls.from_database(cls._DATABASE['Askar_120APO_Reducer_0_8x'])
+
+    @classmethod
+    def Askar_140APO_Reducer_0_8x(cls):
+        return cls.from_database(cls._DATABASE['Askar_140APO_Reducer_0_8x'])
+
+    @classmethod
+    def Askar_185APO_Reducer_0_8x(cls):
+        return cls.from_database(cls._DATABASE['Askar_185APO_Reducer_0_8x'])
 
     @classmethod
     def Askar_0_76x_Reducer_PHQ(cls):

--- a/scripts/verify_askar_reducers_static.py
+++ b/scripts/verify_askar_reducers_static.py
@@ -1,0 +1,60 @@
+import ast
+import os
+
+def verify_askar_reducers():
+    filepath = 'apts/opticalequipment/reducer/vendors/askar.py'
+    with open(filepath, 'r') as f:
+        tree = ast.parse(f.read())
+
+    askar_reducer_db = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == 'AskarReducer':
+            for item in node.body:
+                if isinstance(item, ast.Assign):
+                    for target in item.targets:
+                        if isinstance(target, ast.Name) and target.id == '_DATABASE':
+                            askar_reducer_db = ast.literal_eval(item.value)
+                            break
+
+    if not askar_reducer_db:
+        print("FAILED: AskarReducer _DATABASE not found")
+        return False
+
+    expected_entries = {
+        'Askar_103APO_Reducer_0_6x': {'mass': 980, 'tside_thread': 'M68', 'cside_thread': 'M48', 'cside_gender': 'Male', 'required_backfocus': 55},
+        'Askar_151PHQ_Reducer_0_7x': {'mass': 600, 'tside_thread': 'M68', 'cside_thread': 'M48', 'cside_gender': 'Male', 'required_backfocus': 55},
+        'Askar_120APO_Reducer_0_8x': {'mass': 750, 'tside_thread': 'M68', 'cside_thread': 'M54', 'cside_gender': 'Male', 'required_backfocus': 55},
+        'Askar_140APO_Reducer_0_8x': {'mass': 750, 'tside_thread': 'M68', 'cside_thread': 'M54', 'cside_gender': 'Male', 'required_backfocus': 55},
+        'Askar_185APO_Reducer_0_8x': {'mass': 950, 'tside_thread': 'M68', 'cside_thread': 'M54', 'cside_gender': 'Male', 'required_backfocus': 55},
+    }
+
+    for key, expected in expected_entries.items():
+        if key not in askar_reducer_db:
+            print(f"FAILED: {key} not found in _DATABASE")
+            return False
+        entry = askar_reducer_db[key]
+        for field, value in expected.items():
+            if entry.get(field) != value:
+                print(f"FAILED: {key} field '{field}' expected {value}, got {entry.get(field)}")
+                return False
+        print(f"VERIFIED: {key}")
+
+    # Verify factory methods exist in AskarReducer
+    methods = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == 'AskarReducer':
+            methods = [item.name for item in node.body if isinstance(item, ast.FunctionDef)]
+            break
+
+    for key in ['Askar_120APO_Reducer_0_8x', 'Askar_140APO_Reducer_0_8x', 'Askar_185APO_Reducer_0_8x']:
+        if key not in methods:
+            print(f"FAILED: Factory method {key} not found in AskarReducer")
+            return False
+        print(f"VERIFIED: Factory method {key}")
+
+    print("ALL VERIFICATIONS PASSED")
+    return True
+
+if __name__ == "__main__":
+    if not verify_askar_reducers():
+        exit(1)


### PR DESCRIPTION
### 🔭 Stellar: Added dedicated Askar APO reducers and refined specifications

#### 💡 What:
- Added dedicated 0.8x focal reducers for **Askar 120APO**, **140APO**, and **185APO** to the equipment database.
- Corrected specifications for existing **Askar 103APO 0.6x** (mass updated to 980g) and **151PHQ 0.7x** (mass updated to 600g).
- Standardized `cside_gender` to 'Male' for these reducers to accurately reflect their physical output interface.
- Added explicit `required_backfocus: 55` to ensure accurate backfocus gap calculations.
- Implemented corresponding factory methods for the new models.
- Added a static verification script `scripts/verify_askar_reducers_static.py` for data integrity checks.

#### 🎯 Why:
- The Askar APO triplet refractor series is extremely popular among DSO astrophotographers.
- Accurate mass data is critical for mount capacity planning and balance simulations.
- Explicit backfocus data enables the library's automated backfocus gap reporting, a high-value feature for users setting up their imaging trains.
- Correct thread gender modeling is necessary for path validation in the library's equipment graph.

#### 📚 Source:
- Manufacturer official technical specifications (Sharpstar-Optics/Askar) verified via Starizona and official product manuals.
- CML II / GRS reference: Project Pluto.

---
*PR created automatically by Jules for task [1556997575028732015](https://jules.google.com/task/1556997575028732015) started by @pozar87*