### PR TITLE
Fix Seestar specification discrepancies in tests

### DIFF
--- a/tests/test_stellar_improvements.py
+++ b/tests/test_stellar_improvements.py
@@ -188,8 +188,8 @@ def test_seestar_s30_pro_instantiation():
     s30p = ZwoTelescope.ZWO_Seestar_S30_Pro()
     assert s30p.get_vendor() == "ZWO Seestar S30 Pro"
     assert s30p.aperture.to(ureg.mm).magnitude == 30
-    assert s30p.focal_length.to(ureg.mm).magnitude == 150
-    assert s30p.pixel_size().to(ureg.micrometer).magnitude == pytest.approx(2.0)
+    assert s30p.focal_length.to(ureg.mm).magnitude == 160
+    assert s30p.pixel_size().to(ureg.micrometer).magnitude == pytest.approx(2.9)
     assert s30p.mass.to(ureg.gram).magnitude == 1650
 
 

--- a/tests/unit/test_new_equipment_audit_v3.py
+++ b/tests/unit/test_new_equipment_audit_v3.py
@@ -11,7 +11,7 @@ def test_seestar_sensor_specs():
     assert s50.width == 1920
     assert s50.height == 1080
     assert s50.pixel_size().to("micrometer").magnitude == pytest.approx(2.9)
-    assert s50.full_well == 12000
+    assert s50.full_well == 11200
 
     # S30 Sensor (IMX662)
     s30 = ZwoCamera.ZWO_Seestar_S30_Sensor()
@@ -20,14 +20,14 @@ def test_seestar_sensor_specs():
     assert s30.pixel_size().to("micrometer").magnitude == pytest.approx(2.9)
     assert s30.full_well == 38200
 
-    # S30 Pro Sensor (IMX678)
+    # S30 Pro Sensor (IMX585)
     s30p = ZwoCamera.ZWO_Seestar_S30_Pro_Sensor()
-    assert s30p.sensor_width.magnitude == 7.68
-    assert s30p.sensor_height.magnitude == 4.32
+    assert s30p.sensor_width.magnitude == 11.13
+    assert s30p.sensor_height.magnitude == 6.26
     assert s30p.width == 3840
     assert s30p.height == 2160
-    assert s30p.pixel_size().to("micrometer").magnitude == pytest.approx(2.0)
-    assert s30p.full_well == 11270
+    assert s30p.pixel_size().to("micrometer").magnitude == pytest.approx(2.9)
+    assert s30p.full_well == 40000
 
 def test_askar_apo_specs():
     """Verify Askar APO refractor entries including reduced variants."""

--- a/tests/unit/test_stellar_updates.py
+++ b/tests/unit/test_stellar_updates.py
@@ -9,13 +9,13 @@ class TestStellarUpdates(unittest.TestCase):
     def test_seestar_s30_pro_specs(self):
         s30_pro = ZwoTelescope.ZWO_Seestar_S30_Pro()
         self.assertEqual(s30_pro.aperture.magnitude, 30)
-        self.assertEqual(s30_pro.focal_length.magnitude, 150)
-        self.assertEqual(s30_pro.sensor_width.magnitude, 7.68)
-        self.assertEqual(s30_pro.sensor_height.magnitude, 4.32)
-        # Pixel size for IMX678 (3840x2160 on 7.68x4.32mm) is 2.0um
-        self.assertAlmostEqual(s30_pro.pixel_size().magnitude, 2.0, places=1)
-        self.assertEqual(s30_pro.full_well, 11270)
-        self.assertEqual(s30_pro.quantum_efficiency, 83)
+        self.assertEqual(s30_pro.focal_length.magnitude, 160)
+        self.assertEqual(s30_pro.sensor_width.magnitude, 11.13)
+        self.assertEqual(s30_pro.sensor_height.magnitude, 6.26)
+        # Pixel size for IMX585 (3840x2160 on 11.13x6.26mm) is 2.9um
+        self.assertAlmostEqual(s30_pro.pixel_size().magnitude, 2.9, places=1)
+        self.assertEqual(s30_pro.full_well, 40000)
+        self.assertEqual(s30_pro.quantum_efficiency, 91)
 
     def test_asi585mm_pro_specs(self):
         cam = ZwoCamera.ZWO_ASI_585MM_Pro()


### PR DESCRIPTION
Updated Seestar S30 Pro and S50 specifications in unit tests to match the audited values in the production code, which correctly reflect the hardware (Sony IMX585 and IMX462 sensors). This resolves three test failures.

---
*PR created automatically by Jules for task [10918593209238238887](https://jules.google.com/task/10918593209238238887) started by @pozar87*