### PR TITLE
Add 2D texture mode to skymap

### DIFF
--- a/apts/observations.py
+++ b/apts/observations.py
@@ -688,7 +688,7 @@ class Observation:
 
     def plot_skymap(
         self,
-        target_name: str,
+        target_name: Optional[str] = None,
         dark_mode_override: Optional[bool] = None,
         zoom_deg: Optional[float] = None,
         star_magnitude_limit: Optional[float] = None,
@@ -696,11 +696,15 @@ class Observation:
         plot_messier: bool = False,
         plot_ngc: bool = False,
         plot_planets: bool = False,
+        plot_sun: bool = False,
+        plot_moon: bool = False,
         plot_date: Optional[datetime] = None,
         flip_horizontally: Optional[bool] = None,
         flip_vertically: Optional[bool] = None,
         coordinate_system: Optional[CoordinateSystem] = None,
         language: Optional[str] = None,
+        texture_mode: bool = False,
+        plot_labels: Optional[bool] = None,
         **kwargs,
     ) -> "matplotlib.figure.Figure":
         """
@@ -712,7 +716,7 @@ class Observation:
         certain telescopes.
 
         Args:
-            target_name (str): The name of the target object to center the skymap on.
+            target_name (Optional[str]): The name of the target object to center the skymap on.
             dark_mode_override (Optional[bool]): If set, overrides the system's dark mode setting.
             zoom_deg (Optional[float]): The diameter of the zoomed-in view in degrees. If None, a full skymap is generated.
             star_magnitude_limit (Optional[float]): The faintest magnitude of stars to plot.
@@ -720,12 +724,16 @@ class Observation:
             plot_messier (bool): Whether to plot Messier objects. Defaults to False.
             plot_ngc (bool): Whether to plot NGC objects. Defaults to False.
             plot_planets (bool): Whether to plot planets. Defaults to False.
+            plot_sun (bool): Whether to plot Sun. Defaults to False.
+            plot_moon (bool): Whether to plot Moon. Defaults to False.
             plot_date (Optional[datetime]): The specific date and time for which to generate the skymap.
                                             If None, the middle of the observation window is used.
             flip_horizontally (Optional[bool]): If True, the skymap's horizontal axis is inverted.
             flip_vertically (Optional[bool]): If True, the skymap's vertical axis is inverted.
             coordinate_system (Optional[CoordinateSystem]): The coordinate system to use for the skymap (e.g., 'altaz', 'radec').
-            **kwargs: Additional keyword arguments to pass to the plotting function, including `equipment_id`.
+            texture_mode (bool): If True, generates a 2D texture of the whole sky.
+            plot_labels (Optional[bool]): Whether to plot labels. Defaults to True (False in texture mode).
+            **kwargs: Additional keyword arguments to pass to the plotting function, including `equipment_id` and `figsize`.
 
         Returns:
             A matplotlib Figure object representing the skymap.
@@ -746,6 +754,67 @@ class Observation:
                     flip_horizontally=flip_horizontally,
                     flip_vertically=flip_vertically,
                     coordinate_system=coordinate_system,
+                    texture_mode=texture_mode,
+                    plot_labels=plot_labels,
+                    **kwargs,
+                ),
+            )
+
+    def plot_skymap_texture(
+        self,
+        dark_mode_override: Optional[bool] = None,
+        star_magnitude_limit: Optional[float] = None,
+        plot_stars: bool = True,
+        plot_messier: bool = False,
+        plot_ngc: bool = False,
+        plot_planets: bool = False,
+        plot_sun: bool = False,
+        plot_moon: bool = False,
+        plot_date: Optional[datetime] = None,
+        coordinate_system: Optional[CoordinateSystem] = None,
+        language: Optional[str] = None,
+        plot_labels: bool = False,
+        figsize: tuple = (40, 20),
+        **kwargs,
+    ) -> "matplotlib.figure.Figure":
+        """
+        Generates and displays a high-resolution skymap texture.
+
+        Args:
+            dark_mode_override (Optional[bool]): If set, overrides the system's dark mode setting.
+            star_magnitude_limit (Optional[float]): The faintest magnitude of stars to plot.
+            plot_stars (bool): Whether to plot stars. Defaults to True.
+            plot_messier (bool): Whether to plot Messier objects. Defaults to False.
+            plot_ngc (bool): Whether to plot NGC objects. Defaults to False.
+            plot_planets (bool): Whether to plot planets. Defaults to False.
+            plot_sun (bool): Whether to plot Sun. Defaults to False.
+            plot_moon (bool): Whether to plot Moon. Defaults to False.
+            plot_date (Optional[datetime]): The specific date and time for which to generate the skymap.
+            coordinate_system (Optional[CoordinateSystem]): The coordinate system to use.
+            language (Optional[str]): Language for translation.
+            plot_labels (bool): Whether to plot labels. Defaults to False.
+            figsize (tuple): Figure size for hi-res output. Defaults to (40, 20).
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A matplotlib Figure object representing the skymap texture.
+        """
+        with language_context(language):
+            return cast(
+                "matplotlib.figure.Figure",
+                self.plot.skymap_texture(
+                    dark_mode_override=dark_mode_override,
+                    star_magnitude_limit=star_magnitude_limit,
+                    plot_stars=plot_stars,
+                    plot_messier=plot_messier,
+                    plot_ngc=plot_ngc,
+                    plot_planets=plot_planets,
+                    plot_sun=plot_sun,
+                    plot_moon=plot_moon,
+                    plot_date=plot_date,
+                    coordinate_system=coordinate_system,
+                    plot_labels=plot_labels,
+                    figsize=figsize,
                     **kwargs,
                 ),
             )

--- a/apts/plot.py
+++ b/apts/plot.py
@@ -86,6 +86,9 @@ class Plotter:
     def skymap(self, **args):
         return plot_skymap(self.observation, **args)
 
+    def skymap_texture(self, **args):
+        return plot_skymap(self.observation, texture_mode=True, **args)
+
     def visible_planets(self, **args):
         return plot_visible_planets(self.observation, **args)
 

--- a/apts/plotting/skymap.py
+++ b/apts/plotting/skymap.py
@@ -9,6 +9,7 @@ from apts.constants.graphconstants import get_plot_style
 from apts.constants.plot import CoordinateSystem
 from apts.i18n import _thread_local, gettext_
 from apts.plotting.skymap_polar import _generate_polar_skymap
+from apts.plotting.skymap_texture import _generate_texture_skymap
 from apts.plotting.skymap_zoom import _generate_zoom_skymap
 from apts.utils.planetary import get_reverse_translated_planet_names
 
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def _generate_plot_skymap(
     observation: "Observation",
-    target_name: str,
+    target_name: Optional[str] = None,
     dark_mode_override: Optional[bool] = None,
     zoom_deg: Optional[float] = None,
     star_magnitude_limit: Optional[float] = None,
@@ -36,6 +37,8 @@ def _generate_plot_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    texture_mode: bool = False,
+    plot_labels: Optional[bool] = None,
     **kwargs,
 ) -> figure.Figure:
     """
@@ -75,6 +78,42 @@ def _generate_plot_skymap(
     generation_time_str = t.astimezone(observation.place.local_timezone).strftime(
         "%Y-%m-%d %H:%M %Z"
     )
+
+    if texture_mode:
+        figsize = kwargs.get("figsize", (20, 10))
+        _, ax = pyplot.subplots(figsize=figsize)
+        return cast(
+            figure.Figure,
+            _generate_texture_skymap(
+                observation,
+                ax,
+                style,
+                observer,
+                effective_dark_mode,
+                star_magnitude_limit,
+                plot_stars,
+                plot_messier,
+                plot_ngc,
+                plot_planets,
+                plot_sun,
+                plot_moon,
+                coordinate_system,
+                plot_labels=plot_labels if plot_labels is not None else False,
+            ),
+        )
+
+    if not target_name:
+        # If not texture mode, target_name is required.
+        fig, ax = pyplot.subplots(figsize=(10, 10))
+        ax.text(
+            0.5,
+            0.5,
+            gettext_("Target name is required for polar/zoom skymaps."),
+            horizontalalignment="center",
+            verticalalignment="center",
+            transform=ax.transAxes,
+        )
+        return cast(figure.Figure, fig)
 
     target_object = None
     target_object_data = None
@@ -197,7 +236,7 @@ def _generate_plot_skymap(
 
 def plot_skymap(
     observation: "Observation",
-    target_name: str,
+    target_name: Optional[str] = None,
     dark_mode_override: Optional[bool] = None,
     zoom_deg: Optional[float] = None,
     star_magnitude_limit: Optional[float] = None,
@@ -214,6 +253,8 @@ def plot_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    texture_mode: bool = False,
+    plot_labels: Optional[bool] = None,
     **kwargs,
 ) -> figure.Figure:
     flipped_horizontally = False
@@ -245,5 +286,7 @@ def plot_skymap(
         flipped_horizontally=flipped_horizontally,
         flipped_vertically=flipped_vertically,
         coordinate_system=coordinate_system,
+        texture_mode=texture_mode,
+        plot_labels=plot_labels,
         **kwargs,
     )

--- a/apts/plotting/skymap_objects.py
+++ b/apts/plotting/skymap_objects.py
@@ -33,6 +33,8 @@ def _plot_bright_stars_on_skymap(
     zoom_deg: Optional[float] = None,
     coordinate_system: Optional[CoordinateSystem] = None,
     target_name: Optional[str] = None,
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
     bright_stars_df = cast(pd.DataFrame, observation.local_stars.objects.copy())
     if target_name:
@@ -74,8 +76,8 @@ def _plot_bright_stars_on_skymap(
     ra, dec, _ = star_positions.apparent().radec()
 
     # For Equatorial plots, we don't filter by horizon. All stars in the catalog are candidates.
-    # For Horizontal plots, we only want stars above the horizon.
-    if coordinate_system == CoordinateSystem.HORIZONTAL:
+    # For Horizontal plots, we only want stars above the horizon unless ignore_horizon is True.
+    if coordinate_system == CoordinateSystem.HORIZONTAL and not ignore_horizon:
         visible_mask = alt.degrees > 0
     else:
         visible_mask = numpy.ones(len(bright_stars_df), dtype=bool)
@@ -91,78 +93,91 @@ def _plot_bright_stars_on_skymap(
 
     star_color = style.get("EMPHASIS_COLOR", "yellow")
 
-    if (
-        not is_polar
-        and zoom_deg is not None
-        and coordinate_system == CoordinateSystem.HORIZONTAL
-    ):
-        xlim = ax.get_xlim()
-        ylim = ax.get_ylim()
+    if not is_polar:
+        if coordinate_system == CoordinateSystem.HORIZONTAL:
+            if zoom_deg is not None:
+                xlim = ax.get_xlim()
+                ylim = ax.get_ylim()
 
-        zoom_mask = (
-            (az_visible_deg >= xlim[0])
-            & (az_visible_deg <= xlim[1])
-            & (alt_visible_deg >= ylim[0])
-            & (alt_visible_deg <= ylim[1])
-        )
-
-        df_zoomed = df_visible[zoom_mask]
-        alt_zoomed_deg = alt_visible_deg[zoom_mask]
-        az_zoomed_deg = az_visible_deg[zoom_mask]
-
-        if df_zoomed.empty:  # type: ignore
-            return
-
-        ax.scatter(az_zoomed_deg, alt_zoomed_deg, s=40, color=star_color, marker="*")
-
-        for name, x, y in zip(df_zoomed["Name"], az_zoomed_deg, alt_zoomed_deg):
-            ax.annotate(
-                name,
-                (x, y),
-                textcoords="offset points",
-                xytext=(5, 5),
-                color=star_color,
-                fontsize=8,
-            )
-    elif coordinate_system == CoordinateSystem.EQUATORIAL and zoom_deg is not None:
-        xlim = ax.get_xlim()
-        ylim = ax.get_ylim()
-
-        ra_hours_apparent = ra.hours
-        dec_degrees_apparent = dec.degrees
-
-        zoom_mask = create_ra_zoom_mask(ra_hours_apparent, xlim) & (
-            (dec_degrees_apparent >= ylim[0]) & (dec_degrees_apparent <= ylim[1])
-        )
-
-        df_zoomed = df_visible[zoom_mask]
-        if df_zoomed.empty:  # type: ignore
-            return
-
-        ra_zoomed = ra_hours_apparent[zoom_mask]
-        dec_zoomed = dec_degrees_apparent[zoom_mask]
-
-        ax.scatter(ra_zoomed, dec_zoomed, s=40, color=star_color, marker="*")
-
-        for name, x, y in zip(df_zoomed["Name"], ra_zoomed, dec_zoomed):
-            ax.annotate(
-                name,
-                (x, y),
-                textcoords="offset points",
-                xytext=(5, 5),
-                color=star_color,
-                fontsize=8,
-            )
-    else:
-        if is_polar:
-            if coordinate_system == CoordinateSystem.HORIZONTAL:
-                ax.scatter(
-                    az_visible_rad,
-                    90 - alt_visible_deg,
-                    s=40,
-                    color=star_color,
-                    marker="*",
+                zoom_mask = (
+                    (az_visible_deg >= xlim[0])
+                    & (az_visible_deg <= xlim[1])
+                    & (alt_visible_deg >= ylim[0])
+                    & (alt_visible_deg <= ylim[1])
                 )
+
+                df_zoomed = df_visible[zoom_mask]
+                alt_plot = alt_visible_deg[zoom_mask]
+                az_plot = az_visible_deg[zoom_mask]
+                names_plot = df_zoomed["Name"]
+            else:
+                zoom_mask = numpy.ones(len(df_visible), dtype=bool)
+                alt_plot = alt_visible_deg
+                az_plot = az_visible_deg
+                names_plot = df_visible["Name"]
+
+            if len(az_plot) == 0:
+                return
+
+            ax.scatter(az_plot, alt_plot, s=40, color=star_color, marker="*")
+
+            if plot_labels:
+                for name, x, y in zip(names_plot, az_plot, alt_plot):
+                    ax.annotate(
+                        name,
+                        (x, y),
+                        textcoords="offset points",
+                        xytext=(5, 5),
+                        color=star_color,
+                        fontsize=8,
+                    )
+        else:  # EQUATORIAL
+            ra_hours_apparent = ra.hours[visible_mask]
+            dec_degrees_apparent = dec.degrees[visible_mask]
+
+            if zoom_deg is not None:
+                xlim = ax.get_xlim()
+                ylim = ax.get_ylim()
+
+                zoom_mask = create_ra_zoom_mask(ra_hours_apparent, xlim) & (
+                    (dec_degrees_apparent >= ylim[0]) & (dec_degrees_apparent <= ylim[1])
+                )
+
+                df_zoomed = df_visible[zoom_mask]
+                ra_plot = ra_hours_apparent[zoom_mask]
+                dec_plot = dec_degrees_apparent[zoom_mask]
+                names_plot = df_zoomed["Name"]
+            else:
+                zoom_mask = numpy.ones(len(df_visible), dtype=bool)
+                ra_plot = ra_hours_apparent
+                dec_plot = dec_degrees_apparent
+                names_plot = df_visible["Name"]
+
+            if len(ra_plot) == 0:
+                return
+
+            ax.scatter(ra_plot, dec_plot, s=40, color=star_color, marker="*")
+
+            if plot_labels:
+                for name, x, y in zip(names_plot, ra_plot, dec_plot):
+                    ax.annotate(
+                        name,
+                        (x, y),
+                        textcoords="offset points",
+                        xytext=(5, 5),
+                        color=star_color,
+                        fontsize=8,
+                    )
+    else:  # is_polar
+        if coordinate_system == CoordinateSystem.HORIZONTAL:
+            ax.scatter(
+                az_visible_rad,
+                90 - alt_visible_deg,
+                s=40,
+                color=star_color,
+                marker="*",
+            )
+            if plot_labels:
                 for name, x, y in zip(
                     df_visible["Name"], az_visible_rad, 90 - alt_visible_deg
                 ):
@@ -174,20 +189,21 @@ def _plot_bright_stars_on_skymap(
                         color=star_color,
                         fontsize=8,
                     )
-            else:
-                is_sh = observation.place.lat_decimal < 0
-                radius = (
-                    90 + dec.degrees[visible_mask]
-                    if is_sh
-                    else 90 - dec.degrees[visible_mask]
-                )
-                ax.scatter(
-                    ra.radians[visible_mask],
-                    radius,
-                    s=40,
-                    color=star_color,
-                    marker="*",
-                )
+        else:
+            is_sh = observation.place.lat_decimal < 0
+            radius = (
+                90 + dec.degrees[visible_mask]
+                if is_sh
+                else 90 - dec.degrees[visible_mask]
+            )
+            ax.scatter(
+                ra.radians[visible_mask],
+                radius,
+                s=40,
+                color=star_color,
+                marker="*",
+            )
+            if plot_labels:
                 ra_rad_visible = ra.radians[visible_mask]
                 for name, x, y in zip(df_visible["Name"], ra_rad_visible, radius):
                     ax.annotate(
@@ -198,23 +214,6 @@ def _plot_bright_stars_on_skymap(
                         color=star_color,
                         fontsize=8,
                     )
-        else:
-            ax.scatter(
-                az_visible_deg,
-                alt_visible_deg,
-                s=40,
-                color=star_color,
-                marker="*",
-            )
-            for name, x, y in zip(df_visible["Name"], az_visible_deg, alt_visible_deg):
-                ax.annotate(
-                    name,
-                    (x, y),
-                    textcoords="offset points",
-                    xytext=(5, 5),
-                    color=star_color,
-                    fontsize=8,
-                )
 
 
 def _plot_stars_on_skymap(
@@ -230,6 +229,8 @@ def _plot_stars_on_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
     stars = get_hipparcos_data()
 
@@ -317,104 +318,105 @@ def _plot_stars_on_skymap(
     alt, az, _ = star_positions.apparent().altaz()
     ra, dec, _ = star_positions.apparent().radec()
 
-    if coordinate_system == CoordinateSystem.HORIZONTAL:
+    if coordinate_system == CoordinateSystem.HORIZONTAL and not ignore_horizon:
         visible = alt.degrees > 0
     else:
         visible = numpy.ones(len(bright_stars), dtype=bool)
 
-    if not any(visible):
+    if not any(visible) and not ignore_horizon:
         return
 
-    if (
-        not is_polar
-        and zoom_deg is not None
-        and coordinate_system == CoordinateSystem.HORIZONTAL
-    ):
-        xlim = ax.get_xlim()
-        ylim = ax.get_ylim()
+    if not is_polar:
+        if coordinate_system == CoordinateSystem.HORIZONTAL:
+            az_apparent = az.degrees[visible]
+            alt_apparent = alt.degrees[visible]
+            mag_apparent = bright_stars[visible]["magnitude"]
 
-        visible_mask = alt.degrees > 0
+            if zoom_deg is not None:
+                xlim = ax.get_xlim()
+                ylim = ax.get_ylim()
 
-        az_visible = az.degrees[visible_mask]
-        alt_visible = alt.degrees[visible_mask]
-
-        zoom_mask = (
-            (az_visible >= xlim[0])
-            & (az_visible <= xlim[1])
-            & (alt_visible >= ylim[0])
-            & (alt_visible <= ylim[1])
-        )
-
-        az_plot = az_visible[zoom_mask]
-        alt_plot = alt_visible[zoom_mask]
-
-        mag_plot = bright_stars[visible_mask][zoom_mask]["magnitude"]
-
-        sizes = (limit + 1 - numpy.array(mag_plot)) * 3
-        ax.scatter(
-            az_plot,
-            alt_plot,
-            s=sizes,
-            color=style["TEXT_COLOR"],
-            marker=".",
-        )
-    elif coordinate_system == CoordinateSystem.EQUATORIAL and zoom_deg is not None:
-        xlim = ax.get_xlim()
-        ylim = ax.get_ylim()
-
-        ra_hours_apparent = ra.hours[visible]
-        dec_degrees_apparent = dec.degrees[visible]
-
-        zoom_mask = create_ra_zoom_mask(ra_hours_apparent, xlim) & (
-            (dec_degrees_apparent >= ylim[0]) & (dec_degrees_apparent <= ylim[1])
-        )
-
-        ra_plot = ra_hours_apparent[zoom_mask]
-        dec_plot = dec_degrees_apparent[zoom_mask]
-        mag_plot = bright_stars[visible][zoom_mask]["magnitude"]
-
-        sizes = (limit + 1 - numpy.array(mag_plot)) * 3
-        ax.scatter(
-            ra_plot,
-            dec_plot,
-            s=sizes,
-            color=style["TEXT_COLOR"],
-            marker=".",
-        )
-    else:
-        sizes = (limit + 1 - numpy.array(bright_stars["magnitude"][visible])) * (
-            5 if is_polar else 3
-        )
-        if is_polar:
-            if coordinate_system == CoordinateSystem.HORIZONTAL:
-                ax.scatter(
-                    az.radians[visible],
-                    90 - alt.degrees[visible],
-                    s=sizes,
-                    color=ax.get_facecolor(),
-                    marker=".",
-                    edgecolors=style["TEXT_COLOR"],
+                zoom_mask = (
+                    (az_apparent >= xlim[0])
+                    & (az_apparent <= xlim[1])
+                    & (alt_apparent >= ylim[0])
+                    & (alt_apparent <= ylim[1])
                 )
+
+                az_plot = az_apparent[zoom_mask]
+                alt_plot = alt_apparent[zoom_mask]
+                mag_plot = mag_apparent[zoom_mask]
             else:
-                is_sh = observation.place.lat_decimal < 0
-                radius = (
-                    90 + dec.degrees[visible] if is_sh else 90 - dec.degrees[visible]
-                )
-                ax.scatter(
-                    ra.radians[visible],
-                    radius,
-                    s=sizes,
-                    color=ax.get_facecolor(),
-                    marker=".",
-                    edgecolors=style["TEXT_COLOR"],
-                )
-        else:
+                az_plot = az_apparent
+                alt_plot = alt_apparent
+                mag_plot = mag_apparent
+
+            if len(az_plot) == 0:
+                return
+
+            sizes = (limit + 1 - numpy.array(mag_plot)) * 3
             ax.scatter(
-                az.degrees[visible],
-                alt.degrees[visible],
+                az_plot,
+                alt_plot,
                 s=sizes,
                 color=style["TEXT_COLOR"],
                 marker=".",
+            )
+        else:  # EQUATORIAL
+            ra_hours_apparent = ra.hours[visible]
+            dec_degrees_apparent = dec.degrees[visible]
+            mag_apparent = bright_stars[visible]["magnitude"]
+
+            if zoom_deg is not None:
+                xlim = ax.get_xlim()
+                ylim = ax.get_ylim()
+
+                zoom_mask = create_ra_zoom_mask(ra_hours_apparent, xlim) & (
+                    (dec_degrees_apparent >= ylim[0]) & (dec_degrees_apparent <= ylim[1])
+                )
+
+                ra_plot = ra_hours_apparent[zoom_mask]
+                dec_plot = dec_degrees_apparent[zoom_mask]
+                mag_plot = mag_apparent[zoom_mask]
+            else:
+                ra_plot = ra_hours_apparent
+                dec_plot = dec_degrees_apparent
+                mag_plot = mag_apparent
+
+            if len(ra_plot) == 0:
+                return
+
+            sizes = (limit + 1 - numpy.array(mag_plot)) * 3
+            ax.scatter(
+                ra_plot,
+                dec_plot,
+                s=sizes,
+                color=style["TEXT_COLOR"],
+                marker=".",
+            )
+    else:  # is_polar
+        sizes = (limit + 1 - numpy.array(bright_stars["magnitude"][visible])) * 5
+        if coordinate_system == CoordinateSystem.HORIZONTAL:
+            ax.scatter(
+                az.radians[visible],
+                90 - alt.degrees[visible],
+                s=sizes,
+                color=ax.get_facecolor(),
+                marker=".",
+                edgecolors=style["TEXT_COLOR"],
+            )
+        else:
+            is_sh = observation.place.lat_decimal < 0
+            radius = (
+                90 + dec.degrees[visible] if is_sh else 90 - dec.degrees[visible]
+            )
+            ax.scatter(
+                ra.radians[visible],
+                radius,
+                s=sizes,
+                color=ax.get_facecolor(),
+                marker=".",
+                edgecolors=style["TEXT_COLOR"],
             )
 
 
@@ -436,6 +438,7 @@ def _plot_celestial_object(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
     is_sh: bool = False,
+    plot_labels: bool = True,
 ):
     """Helper function to plot a celestial object on a skymap."""
     if is_polar:
@@ -446,13 +449,14 @@ def _plot_celestial_object(
             x, y = ra_rad, 90 + dec_deg if is_sh else 90 - dec_deg
 
         ax.scatter(x, y, s=size, color=edge_color, marker="+")
-        ax.annotate(
-            name,
-            (x, y),
-            textcoords="offset points",
-            xytext=(5, 5),
-            color=edge_color,
-        )
+        if plot_labels:
+            ax.annotate(
+                name,
+                (x, y),
+                textcoords="offset points",
+                xytext=(5, 5),
+                color=edge_color,
+            )
     else:  # Cartesian / Zoomed
         if coordinate_system == CoordinateSystem.HORIZONTAL:
             x_coord, y_coord = az_deg, alt_deg
@@ -471,13 +475,14 @@ def _plot_celestial_object(
             alpha=0.6,
         )
         ax.add_patch(ellipse)
-        ax.annotate(
-            name,
-            (x_coord, y_coord),
-            textcoords="offset points",
-            xytext=(5, 5),
-            color=edge_color,
-        )
+        if plot_labels:
+            ax.annotate(
+                name,
+                (x_coord, y_coord),
+                textcoords="offset points",
+                xytext=(5, 5),
+                color=edge_color,
+            )
 
 
 def _plot_messier_on_skymap(
@@ -491,8 +496,13 @@ def _plot_messier_on_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
-    visible_messier = observation.get_visible_messier()
+    if ignore_horizon:
+        visible_messier = observation.local_messier.objects
+    else:
+        visible_messier = observation.get_visible_messier()
     if visible_messier.empty:
         return
 
@@ -620,8 +630,8 @@ def _plot_messier_on_skymap(
     # Restoration of original plotting loop with helper function to ensure visual consistency
     # while retaining the performance benefits of bulk Skyfield observations.
     for i in range(len(alt_deg)):
-        # Restore original filtering: only plot objects above the horizon
-        if alt_deg[i] <= 0:
+        # Restore original filtering: only plot objects above the horizon unless ignore_horizon is True
+        if alt_deg[i] <= 0 and not ignore_horizon:
             continue
 
         parallactic_angle = calculate_parallactic_angle(
@@ -651,6 +661,7 @@ def _plot_messier_on_skymap(
             ra_rad=float(ra_rad[i]),
             coordinate_system=coordinate_system,
             is_sh=observation.place.lat_decimal < 0,
+            plot_labels=plot_labels,
         )
 
 
@@ -697,8 +708,10 @@ def _plot_ngc_on_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
-    if zoom_deg is not None and target_object is not None:
+    if (zoom_deg is not None and target_object is not None) or ignore_horizon:
         # Use direct reference to avoid costly copy of 14k entries
         visible_ngc = observation.local_ngc.objects
     else:
@@ -740,7 +753,7 @@ def _plot_ngc_on_skymap(
             ]
 
             if not ngc_in_box.empty:
-                # Use target object's position directly
+                # Use target_object's position directly
                 observed_center = observer.observe(target_object)
 
                 # Vectorized Skyfield observation for separation calculation
@@ -810,8 +823,12 @@ def _plot_ngc_on_skymap(
 
         # Optimization: use vectorized coordinates for visibility and basic plot values
         # This handles the alt_deg > 0 check efficiently for all objects.
-        is_above_horizon = alt_all_deg > 0
-        if not numpy.any(is_above_horizon):
+        if ignore_horizon:
+            is_above_horizon = numpy.ones(len(alt_all_deg), dtype=bool)
+        else:
+            is_above_horizon = alt_all_deg > 0
+
+        if not numpy.any(is_above_horizon) and not ignore_horizon:
             return
 
         # Prepare data for plotting
@@ -872,14 +889,15 @@ def _plot_ngc_on_skymap(
             ax.scatter(x_vals, y_vals, s=sizes, color="green", marker="+")
 
             # Annotation loop still needed but optimized to avoid iterrows()
-            for name, x, y in zip(active_names, x_vals, y_vals):
-                ax.annotate(
-                    name,
-                    (x, y),
-                    textcoords="offset points",
-                    xytext=(5, 5),
-                    color="green",
-                )
+            if plot_labels:
+                for name, x, y in zip(active_names, x_vals, y_vals):
+                    ax.annotate(
+                        name,
+                        (x, y),
+                        textcoords="offset points",
+                        xytext=(5, 5),
+                        color="green",
+                    )
         else:
             # Cartesian / Zoomed view - still using loop for Ellipse patches but optimized
             # (PatchCollection could be used but Ellipse initialization is still per-object)
@@ -919,6 +937,7 @@ def _plot_ngc_on_skymap(
                     ra_rad=float(active_ras_r[i]),
                     coordinate_system=coordinate_system,
                     is_sh=observation.place.lat_decimal < 0,
+                    plot_labels=plot_labels,
                 )
 
 
@@ -933,15 +952,21 @@ def _plot_planets_on_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
-    visible_planets = observation.get_visible_planets()
+    if ignore_horizon:
+        visible_planets = observation.local_planets.objects.copy()
+        visible_planets["TechnicalName"] = visible_planets[ObjectTableLabels.NAME]
+    else:
+        visible_planets = observation.get_visible_planets()
     if not visible_planets.empty:
         target_technical_name = (
             planetary.get_technical_name(target_name) if target_name else None
         )
         for _, p_obj in visible_planets.iterrows():
             planet_name = p_obj[ObjectTableLabels.NAME]
-            technical_name = p_obj["TechnicalName"]
+            technical_name = p_obj.get("TechnicalName", planet_name)
             if (
                 planet_name == target_name
                 or technical_name == target_name
@@ -957,6 +982,8 @@ def _plot_planets_on_skymap(
                 str(technical_name),
                 display_name=cast(str, planet_name),
                 coordinate_system=coordinate_system,
+                plot_labels=plot_labels,
+                ignore_horizon=ignore_horizon,
             )
 
 
@@ -972,6 +999,8 @@ def _plot_solar_system_object_on_skymap(
     coordinate_system: CoordinateSystem = cast(
         CoordinateSystem, CoordinateSystem.HORIZONTAL
     ),
+    plot_labels: bool = True,
+    ignore_horizon: bool = False,
 ):
     """Helper to plot a solar system object, handling regular and target styles."""
     obj = observation.local_planets.find_by_name(object_name)
@@ -988,7 +1017,11 @@ def _plot_solar_system_object_on_skymap(
     ra, dec, _ = astrometric.radec()
 
     is_below_horizon = numpy.all(numpy.asarray(alt.degrees) <= 0)
-    if is_below_horizon and coordinate_system == CoordinateSystem.HORIZONTAL:
+    if (
+        is_below_horizon
+        and coordinate_system == CoordinateSystem.HORIZONTAL
+        and not ignore_horizon
+    ):
         return
 
     size_deg = get_object_angular_size_deg(observation, object_name)
@@ -1044,7 +1077,7 @@ def _plot_solar_system_object_on_skymap(
             is_sh = observation.place.lat_decimal < 0
             x, y = ra.radians, 90 + dec.degrees if is_sh else 90 - dec.degrees
         ax.scatter(x, y, s=size, color=edge_color, marker=marker)
-        if not is_target:
+        if not is_target and plot_labels:
             ax.annotate(
                 display_name,
                 (x, y),
@@ -1076,7 +1109,7 @@ def _plot_solar_system_object_on_skymap(
             alpha=0.6,
         )
         ax.add_patch(ellipse)
-        if not is_target:
+        if not is_target and plot_labels:
             ax.annotate(
                 display_name,
                 (x_coord, y_coord),

--- a/apts/plotting/skymap_texture.py
+++ b/apts/plotting/skymap_texture.py
@@ -1,0 +1,140 @@
+from typing import TYPE_CHECKING, Any, Optional
+
+from matplotlib import axes
+
+from apts.constants.plot import CoordinateSystem
+from apts.plotting.skymap_objects import (
+    _plot_bright_stars_on_skymap,
+    _plot_messier_on_skymap,
+    _plot_ngc_on_skymap,
+    _plot_planets_on_skymap,
+    _plot_solar_system_object_on_skymap,
+    _plot_stars_on_skymap,
+)
+
+if TYPE_CHECKING:
+    from ..observations import Observation
+
+
+def _generate_texture_skymap(
+    observation: "Observation",
+    ax: axes.Axes,
+    style: dict,
+    observer: Any,
+    effective_dark_mode: bool,
+    star_magnitude_limit: Optional[float],
+    plot_stars: bool,
+    plot_messier: bool,
+    plot_ngc: bool,
+    plot_planets: bool,
+    plot_sun: bool,
+    plot_moon: bool,
+    coordinate_system: CoordinateSystem,
+    plot_labels: bool = False,
+):
+    fig = ax.get_figure()
+    if fig:
+        fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+        # Remove all margins
+        fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
+
+    ax.set_facecolor(style["AXES_FACE_COLOR"])
+    # Hide all axis decorations
+    ax.set_axis_off()
+
+    if coordinate_system == CoordinateSystem.HORIZONTAL:
+        ax.set_xlim(0, 360)
+        ax.set_ylim(-90, 90)
+        # Width 360, Height 180. aspect=1 gives 2:1 physical ratio.
+        ax.set_aspect("equal", adjustable="box")
+    else:  # EQUATORIAL
+        ax.set_xlim(24, 0)  # RA usually increases to the left
+        ax.set_ylim(-90, 90)
+        # 1 hour (x) = 15 degrees. We want 1:1 degree ratio.
+        ax.set_aspect(1.0 / 15.0, adjustable="box")
+
+    # Plot everything with ignore_horizon=True and the specified plot_labels setting
+    if plot_stars:
+        _plot_stars_on_skymap(
+            observation,
+            ax,
+            observer,
+            star_magnitude_limit,
+            is_polar=False,
+            style=style,
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+        _plot_bright_stars_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            style=style,
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+    if plot_messier:
+        _plot_messier_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            target_name="",  # No specific target
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+    if plot_ngc:
+        _plot_ngc_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            target_name="",
+            star_magnitude_limit=star_magnitude_limit,
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+    if plot_planets:
+        _plot_planets_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            effective_dark_mode=effective_dark_mode,
+            style=style,
+            target_name="",
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+    if plot_sun:
+        _plot_solar_system_object_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            style=style,
+            object_name="Sun",
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+    if plot_moon:
+        _plot_solar_system_object_on_skymap(
+            observation,
+            ax,
+            observer,
+            is_polar=False,
+            style=style,
+            object_name="Moon",
+            coordinate_system=coordinate_system,
+            plot_labels=plot_labels,
+            ignore_horizon=True,
+        )
+
+    return fig

--- a/tests/plotting/test_skymap_texture.py
+++ b/tests/plotting/test_skymap_texture.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+from apts.place import Place
+from apts.observations import Observation
+from apts.equipment import Equipment
+from apts.constants.plot import CoordinateSystem
+
+def test_skymap_texture_generation():
+    place = Place(52.2297, 21.0122, "Warsaw")
+    equipment = Equipment()
+    observation = Observation(place, equipment)
+
+    # Test horizontal texture
+    filename_hor = "test_texture_hor.png"
+    fig = observation.plot_skymap_texture(
+        coordinate_system=CoordinateSystem.HORIZONTAL,
+        figsize=(10, 5)
+    )
+    fig.savefig(filename_hor)
+    assert os.path.exists(filename_hor)
+    assert os.path.getsize(filename_hor) > 0
+    os.remove(filename_hor)
+
+    # Test equatorial texture
+    filename_eq = "test_texture_eq.png"
+    fig = observation.plot_skymap_texture(
+        coordinate_system=CoordinateSystem.EQUATORIAL,
+        figsize=(10, 5)
+    )
+    fig.savefig(filename_eq)
+    assert os.path.exists(filename_eq)
+    assert os.path.getsize(filename_eq) > 0
+    os.remove(filename_eq)
+
+def test_skymap_texture_no_labels():
+    # This just ensures it runs without error with labels=False (default)
+    place = Place(52.2297, 21.0122, "Warsaw")
+    equipment = Equipment()
+    observation = Observation(place, equipment)
+    filename = "test_texture_no_labels.png"
+    fig = observation.plot_skymap_texture(
+        plot_labels=False
+    )
+    fig.savefig(filename)
+    assert os.path.exists(filename)
+    os.remove(filename)


### PR DESCRIPTION
This change introduces a new "texture mode" for generating 2D equirectangular projections of the entire sky, intended for use as textures in 3D visualizations. 

Key improvements:
- New `plot_skymap_texture` method on the `Observation` class provides a high-resolution, clean 2D map.
- All axis decorations, grids, and borders are removed in texture mode.
- Support for rendering objects below the horizon when generating full-sky textures.
- Optional label rendering across all skymap types.
- Maintains backward compatibility with existing polar and zoom skymaps.

---
*PR created automatically by Jules for task [4153610178662593495](https://jules.google.com/task/4153610178662593495) started by @pozar87*