### PR TITLE
Standardize Messier and NGC catalog dimension columns

### DIFF
--- a/apts/catalogs.py
+++ b/apts/catalogs.py
@@ -45,10 +45,6 @@ def _load_messier_with_units():
     }
     messier_df[ObjectTableLabels.DSO_TYPE] = messier_df["Type"].map(messier_type_map).fillna(DSOType.OTHER)
 
-    # Standardize dimensions
-    messier_df[ObjectTableLabels.SIZE_MAJOR] = messier_df["Width"]
-    messier_df[ObjectTableLabels.SIZE_MINOR] = messier_df["Height"]
-
     # Pre-calculate Skyfield objects using raw floats before wrapping in Quantities
     # Optimization: avoiding row-wise apply and costly Quantity.to().magnitude calls
     messier_df["skyfield_object"] = [
@@ -68,9 +64,16 @@ def _load_messier_with_units():
     messier_df["Distance"] = list(messier_df["Distance"].values * ureg.light_year)
     messier_df["RA"] = list(messier_df["RA"].values * ureg.hour)
     messier_df["Dec"] = list(messier_df["Dec"].values * ureg.degree)
-    messier_df["Width"] = list(messier_df["Width"].values * ureg.arcminute)
-    messier_df["Height"] = list(messier_df["Height"].values * ureg.arcminute)
+    messier_df[ObjectTableLabels.SIZE_MAJOR] = list(
+        messier_df["Width"].values * ureg.arcminute
+    )
+    messier_df[ObjectTableLabels.SIZE_MINOR] = list(
+        messier_df["Height"].values * ureg.arcminute
+    )
     messier_df["Magnitude"] = list(messier_df["Magnitude"].values * ureg.mag)
+
+    # Drop redundant columns
+    messier_df.drop(columns=["Width", "Height"], inplace=True)
 
     # Add external links (vectorized list comprehension)
     quoted_messier = [urllib.parse.quote(str(x)) for x in messier_df["Messier"]]
@@ -96,7 +99,7 @@ def _load_ngc_with_units():
 
     # Rename columns for consistency
     ngc_df.rename(
-        columns={"Const": "Constellation", "V-Mag": "Magnitude", "MajAx": "Size", "MinAx": "Size_Minor"},
+        columns={"Const": "Constellation", "V-Mag": "Magnitude"},
         inplace=True,
     )
 
@@ -123,11 +126,18 @@ def _load_ngc_with_units():
         "RfN": DSOType.RN,
         "SNR": DSOType.SNR,
     }
-    ngc_df[ObjectTableLabels.DSO_TYPE] = ngc_df["Type"].map(ngc_type_map).fillna(DSOType.OTHER)
+    ngc_df[ObjectTableLabels.DSO_TYPE] = (
+        ngc_df["Type"].map(ngc_type_map).fillna(DSOType.OTHER)
+    )
 
     # Standardize dimensions
-    ngc_df[ObjectTableLabels.SIZE_MAJOR] = pd.to_numeric(ngc_df["Size"], errors="coerce")
-    ngc_df[ObjectTableLabels.SIZE_MINOR] = pd.to_numeric(ngc_df["Size_Minor"], errors="coerce").fillna(ngc_df["Size"])
+    ngc_df[ObjectTableLabels.SIZE_MAJOR] = pd.to_numeric(ngc_df["MajAx"], errors="coerce")
+    ngc_df[ObjectTableLabels.SIZE_MINOR] = pd.to_numeric(
+        ngc_df["MinAx"], errors="coerce"
+    ).fillna(ngc_df[ObjectTableLabels.SIZE_MAJOR])
+
+    # Drop redundant columns
+    ngc_df.drop(columns=["MajAx", "MinAx"], inplace=True)
 
     # Map constellation abbreviations to full names
     ngc_df["Constellation"] = ngc_df["Constellation"].map(constellation_map)  # type: ignore
@@ -179,8 +189,12 @@ def _load_ngc_with_units():
     # for performance. They are converted to Pint Quantities lazily in NGC.get_visible().
     # We use object dtype to avoid FutureWarnings when restoring Quantities.
     ngc_df["Magnitude"] = cast(pd.Series, magnitudes).astype(object)
-    ngc_df["Size"] = cast(pd.Series, pd.to_numeric(ngc_df["Size"], errors="coerce")).astype(object)
-    ngc_df["Size_Minor"] = cast(pd.Series, pd.to_numeric(ngc_df["Size_Minor"], errors="coerce")).astype(object)
+    ngc_df[ObjectTableLabels.SIZE_MAJOR] = ngc_df[ObjectTableLabels.SIZE_MAJOR].astype(
+        object
+    )
+    ngc_df[ObjectTableLabels.SIZE_MINOR] = ngc_df[ObjectTableLabels.SIZE_MINOR].astype(
+        object
+    )
 
     # Add external links (vectorized list comprehension)
     quoted_names = [urllib.parse.quote(str(x)) for x in ngc_df["Name"]]

--- a/apts/constants/objecttablelabels.py
+++ b/apts/constants/objecttablelabels.py
@@ -32,8 +32,6 @@ class ObjectTableLabels:
 
     MESSIER = "Messier"
     NGC = "NGC"
-    WIDTH = "Width"
-    HEIGHT = "Height"
     TYPE = "Type"
     DSO_TYPE = "DSO Type"
     SIZE_MAJOR = "Size Major"

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -107,15 +107,21 @@ class NGC(Objects):
                 self.objects.loc[indices_to_restore, "Magnitude"] = mags_q
 
                 # Size restoration
-                sizes_q = [
+                sizes_major_q = [
                     x * ureg.arcminute if pd.notna(x) else None
-                    for x in self.objects.loc[indices_to_restore, "Size"]
+                    for x in self.objects.loc[indices_to_restore, ObjectTableLabels.SIZE_MAJOR]
                 ]
-                self.objects.loc[indices_to_restore, "Size"] = sizes_q
+                sizes_minor_q = [
+                    x * ureg.arcminute if pd.notna(x) else None
+                    for x in self.objects.loc[indices_to_restore, ObjectTableLabels.SIZE_MINOR]
+                ]
+                self.objects.loc[indices_to_restore, ObjectTableLabels.SIZE_MAJOR] = sizes_major_q
+                self.objects.loc[indices_to_restore, ObjectTableLabels.SIZE_MINOR] = sizes_minor_q
 
                 # Refresh the 'visible' slice with restored objects
                 visible.loc[indices_to_restore, "Magnitude"] = mags_q
-                visible.loc[indices_to_restore, "Size"] = sizes_q
+                visible.loc[indices_to_restore, ObjectTableLabels.SIZE_MAJOR] = sizes_major_q
+                visible.loc[indices_to_restore, ObjectTableLabels.SIZE_MINOR] = sizes_minor_q
 
         return visible
 

--- a/apts/plotting/altitude.py
+++ b/apts/plotting/altitude.py
@@ -82,23 +82,20 @@ def generate_plot_messier(
 
         # Vectorized property extraction to avoid slow iterrows()
         # Ensure numeric columns are floats to avoid Pint/Quantity overhead
-        for col in [ObjectTableLabels.ALTITUDE, ObjectTableLabels.WIDTH, "Height"]:
+        for col in [
+            ObjectTableLabels.ALTITUDE,
+            ObjectTableLabels.SIZE_MAJOR,
+            ObjectTableLabels.SIZE_MINOR,
+        ]:
             if col in messier_df.columns:
                 messier_df[col] = [
                     getattr(x, "magnitude", x) for x in messier_df[col].values
                 ]
 
-        # Handle missing Height
-        if "Height" not in messier_df.columns:
-            messier_df["Height"] = messier_df[ObjectTableLabels.WIDTH]
-        else:
-            messier_df["Height"] = messier_df["Height"].fillna(
-                messier_df[ObjectTableLabels.WIDTH]
-            )
-
         # Vectorized marker size: marker area (s) as width * height
         messier_df["marker_size"] = (
-            messier_df[ObjectTableLabels.WIDTH] * messier_df["Height"]
+            messier_df[ObjectTableLabels.SIZE_MAJOR]
+            * messier_df[ObjectTableLabels.SIZE_MINOR]
         )
 
         # Determine colors (Type is often already translated in get_visible_messier)

--- a/apts/plotting/skymap_objects.py
+++ b/apts/plotting/skymap_objects.py
@@ -606,10 +606,8 @@ def _plot_messier_on_skymap(
             )
         return numpy.full(len(plot_df), default_val)
 
-    widths_deg = get_dim(ObjectTableLabels.WIDTH) / 60.0
-    heights_deg = get_dim("Height", numpy.nan) / 60.0
-    # Fallback height to width if missing
-    heights_deg = numpy.where(numpy.isnan(heights_deg), widths_deg, heights_deg)
+    widths_deg = get_dim(ObjectTableLabels.SIZE_MAJOR) / 60.0
+    heights_deg = get_dim(ObjectTableLabels.SIZE_MINOR) / 60.0
     pos_angles = get_dim("PosAng", 0.0)
 
     # Determine colors based on type and magnitude
@@ -869,8 +867,8 @@ def _plot_ngc_on_skymap(
             vals = vals.fillna(1.0)
             return numpy.array([getattr(x, "magnitude", x) for x in vals], dtype=float)
 
-        widths_deg = get_dim("Size", "MajAx") / 60.0
-        heights_deg = get_dim("MinAx", "Size") / 60.0
+        widths_deg = get_dim(ObjectTableLabels.SIZE_MAJOR) / 60.0
+        heights_deg = get_dim(ObjectTableLabels.SIZE_MINOR) / 60.0
         pos_angles = get_dim("PosAng")
 
         if is_polar:

--- a/apts/plotting/skymap_polar.py
+++ b/apts/plotting/skymap_polar.py
@@ -341,11 +341,13 @@ def _generate_polar_skymap(
         numpy.any(target_alt.degrees > 0)
     ):
         if target_object_data is not None:
-            width_arcmin = target_object_data.get(ObjectTableLabels.WIDTH, 0)
+            width_arcmin = target_object_data.get(ObjectTableLabels.SIZE_MAJOR, 0)
             width_arcmin = getattr(width_arcmin, "magnitude", width_arcmin)
             width_deg = width_arcmin / 60.0
 
-            height_arcmin = target_object_data.get("Height", width_arcmin)
+            height_arcmin = target_object_data.get(
+                ObjectTableLabels.SIZE_MINOR, width_arcmin
+            )
             height_arcmin = getattr(height_arcmin, "magnitude", height_arcmin)
             height_deg = height_arcmin / 60.0
 
@@ -379,11 +381,13 @@ def _generate_polar_skymap(
     elif coordinate_system == CoordinateSystem.EQUATORIAL:
         target_radius = 90 + target_dec.degrees if is_sh else 90 - target_dec.degrees
         if target_object_data is not None:
-            width_arcmin = target_object_data.get(ObjectTableLabels.WIDTH, 0)
+            width_arcmin = target_object_data.get(ObjectTableLabels.SIZE_MAJOR, 0)
             width_arcmin = getattr(width_arcmin, "magnitude", width_arcmin)
             width_deg = width_arcmin / 60.0
 
-            height_arcmin = target_object_data.get("Height", width_arcmin)
+            height_arcmin = target_object_data.get(
+                ObjectTableLabels.SIZE_MINOR, width_arcmin
+            )
             height_arcmin = getattr(height_arcmin, "magnitude", height_arcmin)
             height_deg = height_arcmin / 60.0
 

--- a/apts/plotting/skymap_zoom.py
+++ b/apts/plotting/skymap_zoom.py
@@ -231,11 +231,13 @@ def _generate_zoom_skymap(
             coordinate_system=coordinate_system,
         )
     if target_object_data is not None:
-        width_arcmin = target_object_data.get(ObjectTableLabels.WIDTH, 0)
+        width_arcmin = target_object_data.get(ObjectTableLabels.SIZE_MAJOR, 0)
         width_arcmin = getattr(width_arcmin, "magnitude", width_arcmin)
         width_deg = width_arcmin / 60.0
 
-        height_arcmin = target_object_data.get("Height", width_arcmin)
+        height_arcmin = target_object_data.get(
+            ObjectTableLabels.SIZE_MINOR, width_arcmin
+        )
         height_arcmin = getattr(height_arcmin, "magnitude", height_arcmin)
         height_deg = height_arcmin / 60.0
 

--- a/tests/unit/test_catalogs.py
+++ b/tests/unit/test_catalogs.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from typing import cast
 from apts.catalogs import Catalogs
+from apts.constants import ObjectTableLabels
 
 
 def test_messier_catalog():
@@ -17,9 +18,9 @@ def test_messier_catalog():
     assert c.iloc[81]["NGC"] == "NGC 3034"
     assert c.iloc[81]["Name"] == "Cigar Galaxy"
     # Andromeda is the biggest galaxy
-    # Sort using magnitude value of Width
+    # Sort using magnitude value of Size Major
     largest_objects = c.sort_values(
-        by="Width",
+        by=ObjectTableLabels.SIZE_MAJOR,
         key=lambda x: cast(pd.Series, x.apply(lambda y: getattr(y, "magnitude", y))),
         ascending=False,
     )
@@ -47,9 +48,9 @@ def test_messier_catalog():
     assert hasattr(c["Distance"].iloc[0], "units")
     assert str(c["Distance"].iloc[0].units) == "light_year"
 
-    assert hasattr(c["Width"].iloc[0], "magnitude")
-    assert hasattr(c["Width"].iloc[0], "units")
-    assert c["Width"].iloc[0].units == "arcminute"
+    assert hasattr(c[ObjectTableLabels.SIZE_MAJOR].iloc[0], "magnitude")
+    assert hasattr(c[ObjectTableLabels.SIZE_MAJOR].iloc[0], "units")
+    assert c[ObjectTableLabels.SIZE_MAJOR].iloc[0].units == "arcminute"
 
     assert hasattr(c["Magnitude"].iloc[0], "magnitude")
     assert hasattr(c["Magnitude"].iloc[0], "units")

--- a/tests/unit/test_messier.py
+++ b/tests/unit/test_messier.py
@@ -43,9 +43,9 @@ class TestMessier(unittest.TestCase):
         self.assertTrue(hasattr(m["Distance"].iloc[0], "units"))
         self.assertEqual(str(m["Distance"].iloc[0].units), "light_year")
 
-        self.assertTrue(hasattr(m["Width"].iloc[0], "magnitude"))
-        self.assertTrue(hasattr(m["Width"].iloc[0], "units"))
-        self.assertEqual(m["Width"].iloc[0].units, "arcminute")
+        self.assertTrue(hasattr(m[ObjectTableLabels.SIZE_MAJOR].iloc[0], "magnitude"))
+        self.assertTrue(hasattr(m[ObjectTableLabels.SIZE_MAJOR].iloc[0], "units"))
+        self.assertEqual(m[ObjectTableLabels.SIZE_MAJOR].iloc[0].units, "arcminute")
 
         self.assertTrue(hasattr(m["Magnitude"].iloc[0], "magnitude"))
         self.assertTrue(hasattr(m["Magnitude"].iloc[0], "units"))

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -475,8 +475,8 @@ class TestObservationPlottingStyles(unittest.TestCase):
             "Altitude": [45 * ureg.deg],  # Using Quantity
             "Azimuth": [180 * ureg.deg],  # Using Quantity
             "Transit": [pd.Timestamp("2023-01-01 22:00:00", tz="UTC")],
-            "Width": [6.0 * ureg.arcmin],  # Using Quantity
-            "Height": [4.0 * ureg.arcmin],  # Using Quantity
+            ObjectTableLabels.SIZE_MAJOR: [6.0 * ureg.arcmin],  # Using Quantity
+            ObjectTableLabels.SIZE_MINOR: [4.0 * ureg.arcmin],  # Using Quantity
         }
         self.mock_messier_df = pd.DataFrame(mock_messier_data)
         # Ensure DataFrame columns with pint Quantities are correctly typed if needed by the method


### PR DESCRIPTION
The user requested to review Messier and NGC catalogs as it seemed Size Major/Minor duplicated Width and Height, and suggested keeping only one.

I have:
1. Standardized `ObjectTableLabels` by removing `WIDTH` and `HEIGHT` and keeping `SIZE_MAJOR` and `SIZE_MINOR`.
2. Refactored the catalog loading logic in `apts/catalogs.py` to populate `SIZE_MAJOR` and `SIZE_MINOR` from the source data and drop all redundant columns ('Width', 'Height', 'Size', 'Size_Minor', 'MajAx', 'MinAx').
3. Updated the NGC lazy loading/restoration logic in `apts/objects/ngc.py` to correctly handle both dimension columns.
4. Updated all plotting modules (`altitude.py`, `skymap_objects.py`, `skymap_polar.py`, `skymap_zoom.py`) to use the standardized labels.
5. Updated unit tests (`test_catalogs.py`, `test_messier.py`, `test_observations.py`) to reflect these changes.
6. Verified that all 663 unit tests pass.

---
*PR created automatically by Jules for task [3252860363798786579](https://jules.google.com/task/3252860363798786579) started by @pozar87*