### PR TITLE
Add solar objects to target selector

### DIFF
--- a/apts/discovery.py
+++ b/apts/discovery.py
@@ -18,18 +18,23 @@ class DiscoveryService:
     def get_top_picks(place, equipment_path, catalogs, date=None, strategy=FilterStrategy.BROADBAND, limit=20):
         """
         Returns a ranked list of objects sorted by the Multi-Factor Score.
-        Focuses on the Messier catalog for optimal performance and quality.
+        Includes Messier and Solar objects.
         """
         from .objects.messier import Messier
+        from .objects.solar_objects import SolarObjects
 
         scorer = SuitabilityScorer(place, equipment_path, filter_strategy=strategy)
 
-        # Focus on Messier catalog for performance and high-quality results
-        # We use the Messier object to ensure tranzit/altitude are computed
+        # 1. Messier catalog
         messier_obj = Messier(place, catalogs)
         messier_obj.compute(calculation_date=date)
 
-        combined_df = messier_obj.objects
+        # 2. Solar objects
+        solar_obj = SolarObjects(place)
+        solar_obj.compute(calculation_date=date)
+
+        # Combine both for scoring
+        combined_df = pd.concat([messier_obj.objects, solar_obj.objects], ignore_index=True)
 
         # Filtering for reasonable visibility (optional optimization)
         # For now, we'll score everything, but typically you'd filter by magnitude or altitude first

--- a/apts/objects/solar_objects.py
+++ b/apts/objects/solar_objects.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from ..cache import get_mpcorb_data
-from ..constants import ObjectTableLabels
+from ..constants import ObjectTableLabels, DSOType
 from ..utils import MINOR_PLANET_NAMES, planetary
 from .objects import Objects
 
@@ -216,8 +216,17 @@ class SolarObjects(Objects):
                 elongs.append(np.nan)
 
         computed_df[ObjectTableLabels.MAGNITUDE] = mags
-        computed_df["Magnitude_float"] = mags
+        # Fill missing magnitudes with a very high value (e.g. 99) for scoring
+        mags_float = [m if pd.notna(m) else 99 for m in mags]
+        computed_df["Magnitude_float"] = mags_float
         computed_df[ObjectTableLabels.SIZE] = sizes
+
+        # Populate SIZE_MAJOR and SIZE_MINOR in arcminutes for SuitabilityScorer
+        # ephem returns size in arcseconds.
+        sizes_arcmin = [s / 60.0 if s is not None else 0 for s in sizes]
+        computed_df[ObjectTableLabels.SIZE_MAJOR] = sizes_arcmin
+        computed_df[ObjectTableLabels.SIZE_MINOR] = sizes_arcmin
+
         computed_df[ObjectTableLabels.PHASE] = phases
         computed_df["skyfield_object"] = sky_objs
         computed_df["ra_hours"] = ras
@@ -227,6 +236,9 @@ class SolarObjects(Objects):
         computed_df[ObjectTableLabels.DEC] = decs
         computed_df[ObjectTableLabels.DISTANCE] = dists
         computed_df[ObjectTableLabels.ELONGATION] = elongs
+
+        # DSO_TYPE is used in top_picks
+        computed_df[ObjectTableLabels.DSO_TYPE] = DSOType.OTHER
 
         if not skip_transits:
             # Use fast vectorized geometric approximation for transits, rise, set, and altitude.

--- a/apts/optics/utils.py
+++ b/apts/optics/utils.py
@@ -116,10 +116,21 @@ class OpticsUtils:
         focal_length: focal length in mm
         """
         import numpy as np
-        from ..constants import astronomy
 
-        obj_major_deg = object_size[0] / 60.0
-        obj_minor_deg = object_size[1] / 60.0
+        # Handle potential pint.Quantity objects in object_size
+        obj_major_arcmin = (
+            object_size[0].magnitude
+            if hasattr(object_size[0], "magnitude")
+            else object_size[0]
+        )
+        obj_minor_arcmin = (
+            object_size[1].magnitude
+            if hasattr(object_size[1], "magnitude")
+            else object_size[1]
+        )
+
+        obj_major_deg = obj_major_arcmin / 60.0
+        obj_minor_deg = obj_minor_arcmin / 60.0
 
         # FOV in degrees = 2 * arctan(sensor_size / (2 * focal_length))
         fov_w_deg = np.degrees(2 * np.arctan(sensor_size[0] / (2 * focal_length)))

--- a/apts/scoring.py
+++ b/apts/scoring.py
@@ -135,7 +135,7 @@ class SuitabilityScorer:
             from .optics.utils import OpticsUtils
             object_size = (target_row[ObjectTableLabels.SIZE_MAJOR], target_row[ObjectTableLabels.SIZE_MINOR])
             # Handle NaNs in object size
-            if np.isnan(object_size[0]):
+            if pd.isna(object_size[0]):
                 s_fov = 0
             else:
                 sensor_size = (


### PR DESCRIPTION
This change enables the target selector (DiscoveryService) to include and rank solar system objects (planets, Sun, Moon) alongside Messier objects. 

Key changes:
1.  **apts/discovery.py**: Modified `get_top_picks` to fetch, compute, and concatenate `SolarObjects` with `Messier` objects for scoring.
2.  **apts/objects/solar_objects.py**: 
    - Added `SIZE_MAJOR` and `SIZE_MINOR` columns (converted from ephem's arcseconds to arcminutes).
    - Set default `DSO_TYPE` to `DSOType.OTHER`.
    - Improved `Magnitude_float` population with a fallback for missing values.
    - Moved `DSOType` import to module level.
3.  **apts/scoring.py**: Switched to `pd.isna()` for object size checks to handle mixed types safely.
4.  **apts/optics/utils.py**: Updated `calculate_fov_ratio` to robustly extract magnitudes from `pint.Quantity` objects.

Verified with custom discovery script and unit tests (`test_solar_objects.py`, `test_planning_features.py`).

---
*PR created automatically by Jules for task [1504211106429950756](https://jules.google.com/task/1504211106429950756) started by @pozar87*