### PR TITLE
Fix horizon application in horizontal skymaps

### DIFF
--- a/apts/plotting/skymap_polar.py
+++ b/apts/plotting/skymap_polar.py
@@ -108,10 +108,10 @@ def _generate_polar_skymap(
         # Get the visibility mask for a range of altitudes at each azimuth
         # In a polar plot, r = 90 - altitude. We want to find the boundary altitude.
         # For the simple case, the boundary is the horizon altitude.
-        if observation.conditions.horizon_file:
+        if observation.conditions.horizon_file or observation.conditions.horizon_content:
             horizon_alt = observation.conditions.horizon.get_altitude(az_deg)
             r_outer_good = 90 - horizon_alt
-            
+
             ax.fill_between(
                 theta,
                 0,
@@ -184,7 +184,9 @@ def _generate_polar_skymap(
                     ),
                 )
 
-        if not observation.conditions.horizon_file and not (
+        if not (
+            observation.conditions.horizon_file or observation.conditions.horizon_content
+        ) and not (
             float(observation.conditions.min_object_azimuth) == 0.0
             and float(observation.conditions.max_object_azimuth) == 360.0
         ):

--- a/apts/plotting/skymap_zoom.py
+++ b/apts/plotting/skymap_zoom.py
@@ -93,7 +93,7 @@ def _generate_zoom_skymap(
         ax.set_aspect("equal", adjustable="box")
 
         # Plot horizon line if available
-        if observation.conditions.horizon_file:
+        if observation.conditions.horizon_file or observation.conditions.horizon_content:
             az_view = numpy.linspace(
                 target_az.degrees - half_zoom, target_az.degrees + half_zoom, 100
             )


### PR DESCRIPTION
The issue was caused by a logic check that only looked for `horizon_file` to decide whether to render a detailed horizon in horizontal coordinate system skymaps (polar and zoom). If the horizon data was provided as a string via `horizon_content` (which happens when using the library programmatically or after certain loading operations), the detailed horizon would be skipped in these maps.

I have updated the following files to include `horizon_content` in the check:
- `apts/plotting/skymap_polar.py`
- `apts/plotting/skymap_zoom.py`

I verified the fix by creating a reproduction script that uses `horizon_content` and confirmed that the detailed horizon now correctly appears in both all-sky polar and zoomed-in horizontal skymaps. I also ran the full unit test suite (663 tests) to ensure no regressions.

---
*PR created automatically by Jules for task [1608791814367535384](https://jules.google.com/task/1608791814367535384) started by @pozar87*