### PR TITLE
Add planet name to stationary point event description

### DIFF
--- a/apts/skyfield_searches/planets.py
+++ b/apts/skyfield_searches/planets.py
@@ -158,13 +158,14 @@ def find_stationary_points(observer, planet_name, start_date, end_date):
     times, codes = almanac.find_discrete(t0, t1, ra_state)
 
     events = []
+    simple_name = planetary.get_simple_name(planet_name)
     for t, code in zip(times, codes):
         direction = "Stationary (Direct)" if code == 1 else "Stationary (Retrograde)"
         events.append(
             {
                 "date": t.utc_datetime(),
-                "event": direction,
-                "object": planetary.get_simple_name(planet_name),
+                "event": f"{simple_name} {direction}",
+                "object": simple_name,
                 "type": "Planet Stationary Point",
             }
         )

--- a/tests/unit/test_stationary_points.py
+++ b/tests/unit/test_stationary_points.py
@@ -20,7 +20,7 @@ class TestStationaryPoints(unittest.TestCase):
         # Check for Mars stationary point
         mars_stationary = df[df['object'] == 'Mars']
         self.assertFalse(mars_stationary.empty)
-        self.assertIn('Stationary', mars_stationary.iloc[0]['event'])
+        self.assertIn('Mars Stationary', mars_stationary.iloc[0]['event'])
         # Precise date is Feb 24
         self.assertEqual(mars_stationary.iloc[0]['date'].day, 24)
 


### PR DESCRIPTION
The planet name is now included in the event description for stationary point events. For example, instead of "Stationary (Direct)", the event will now be "Mars Stationary (Direct)". This was achieved by updating `find_stationary_points` in `apts/skyfield_searches/planets.py` and adjusting the corresponding unit tests.

---
*PR created automatically by Jules for task [10999029054260176751](https://jules.google.com/task/10999029054260176751) started by @pozar87*