### PR TITLE
Improve planet alignment discovery and visibility-aware detection

### DIFF
--- a/apts/skyfield_searches/planets.py
+++ b/apts/skyfield_searches/planets.py
@@ -389,6 +389,12 @@ def find_greatest_elongations(observer, start_date, end_date):
     return events
 
 def find_planet_alignments(observer, start_date, end_date):
+    """
+    Finds planetary alignments (multiple planets close together in ecliptic longitude).
+    Takes into account visibility from the observer's location to highlight "planet parades".
+    """
+    from datetime import timedelta
+
     ts = get_timescale()
     t_start = ts.utc(start_date)
     t_end = ts.utc(end_date)
@@ -403,7 +409,9 @@ def find_planet_alignments(observer, start_date, end_date):
         "neptune barycenter",
     ]
     planet_objs = [(p, planetary.get_skyfield_obj(p)) for p in planets]
-    earth = get_ephemeris()["earth"]
+    eph = get_ephemeris()
+    earth = eph["earth"]
+    sun = planetary.get_skyfield_obj("sun")
 
     # Thresholds for different numbers of planets
     thresholds = {
@@ -414,25 +422,34 @@ def find_planet_alignments(observer, start_date, end_date):
         7: 150,
     }
 
-    # We'll check every day.
-    num_days = int(t_end - t_start) + 1
-    if num_days <= 0:
+    # Use 1-hour steps to find best visibility and alignment
+    duration_days = float(t_end - t_start)
+    if duration_days <= 0:
         return []
 
-    t_utc = cast(Any, t_start.utc_datetime())
-    times = ts.utc(
-        t_utc.year,
-        t_utc.month,
-        t_utc.day + np.arange(num_days),
-    )
+    num_steps = int(duration_days * 24) + 1
+    t_list = [
+        t_start.utc_datetime() + timedelta(hours=i) for i in range(num_steps)
+    ]
+    times = ts.from_datetimes(t_list)
 
-    # Pre-calculate longitudes for all planets at all times
+    # Pre-calculate longitudes, altitudes and sun altitude vectorized
     longitudes = []
+    altitudes = []
     for _, obj in planet_objs:
+        # Longitudes are geocentric ecliptic
         lons = cast(Any, earth).at(times).observe(obj).ecliptic_latlon()[1].degrees
         longitudes.append(lons)
 
+        # Altitudes are topocentric (from observer)
+        alts = observer.at(times).observe(obj).apparent().altaz()[0].degrees
+        altitudes.append(alts)
+
     longitudes = np.array(longitudes)  # (n_planets, n_times)
+    altitudes = np.array(altitudes)  # (n_planets, n_times)
+
+    sun_alts = observer.at(times).observe(sun).apparent().altaz()[0].degrees
+    is_dark = sun_alts < -6
 
     def get_best_k_and_arc(lons_at_t):
         sorted_indices = np.argsort(lons_at_t)
@@ -461,46 +478,90 @@ def find_planet_alignments(observer, start_date, end_date):
 
         return best_k, best_arc, best_indices
 
-    daily_results = []
+    # Calculate stats for every hour
+    step_results = []
     for i in range(len(times)):
         k, arc, indices = get_best_k_and_arc(longitudes[:, i])
-        daily_results.append((k, arc, indices))
+
+        # Count visible planets among those in the alignment
+        visible_in_alignment = 0
+        visible_indices = []
+        if k >= 3:
+            for idx in indices:
+                if altitudes[idx, i] > 0 and is_dark[i]:
+                    visible_in_alignment += 1
+                    visible_indices.append(idx)
+
+        step_results.append(
+            {
+                "k": k,
+                "arc": arc,
+                "indices": indices,
+                "num_visible": visible_in_alignment,
+                "visible_indices": visible_indices,
+            }
+        )
+
+    # Aggregate to daily results to maintain consistent grouping
+    from collections import defaultdict
+
+    by_day = defaultdict(list)
+    for i, res in enumerate(step_results):
+        day = times[i].utc_datetime().date()
+        by_day[day].append((times[i], res))
+
+    daily_results = []
+    sorted_days = sorted(by_day.keys())
+    for day in sorted_days:
+        day_steps = by_day[day]
+        # Best day means: max k, then max num_visible, then min arc
+        best_step = max(
+            day_steps, key=lambda x: (x[1]["k"], x[1]["num_visible"], -x[1]["arc"])
+        )
+        daily_results.append(best_step)
 
     events = []
     i = 0
     while i < len(daily_results):
-        if daily_results[i][0] >= 3:
+        if daily_results[i][1]["k"] >= 3:
             # Start of an alignment period
             start_i = i
-            while i < len(daily_results) and daily_results[i][0] >= 3:
+            while i < len(daily_results) and daily_results[i][1]["k"] >= 3:
                 i += 1
             end_i = i
 
-            # Find the best day in [start_i, end_i)
-            # "Best" means max k, then min arc
+            # Find the best representative day in the window
             window = daily_results[start_i:end_i]
-            max_k_in_window = max(w[0] for w in window)
+            best_day_tuple = max(
+                window, key=lambda x: (x[1]["k"], x[1]["num_visible"], -x[1]["arc"])
+            )
 
-            best_j = -1
-            min_arc = 360
-            for j, (k, arc, _) in enumerate(window):
-                if k == max_k_in_window:
-                    if arc < min_arc:
-                        min_arc = arc
-                        best_j = j
+            t_best, res = best_day_tuple
+            k = res["k"]
+            arc = res["arc"]
+            indices = res["indices"]
+            num_visible = res["num_visible"]
+            visible_indices = res["visible_indices"]
 
-            best_i = start_i + best_j
-            k, arc, indices = daily_results[best_i]
             aligned_planets = [
                 planetary.get_simple_name(planets[idx]) for idx in indices
             ]
+            visible_names = [
+                planetary.get_simple_name(planets[idx]) for idx in visible_indices
+            ]
+
+            event_label = f"Alignment of {k} planets"
+            if num_visible >= 3:
+                event_label += f" ({num_visible} visible)"
 
             events.append(
                 {
-                    "date": times[best_i].utc_datetime(),
-                    "event": f"Alignment of {k} planets",
+                    "date": t_best.utc_datetime(),
+                    "event": event_label,
                     "planets": aligned_planets,
+                    "visible_planets": visible_names,
                     "arc_degrees": arc,
+                    "num_visible": num_visible,
                 }
             )
         else:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -306,13 +306,13 @@ class EventsTest(unittest.TestCase):
         alignment_events = events_df[events_df["type"] == "Planet Alignment"]
         self.assertGreaterEqual(len(alignment_events), 1)
 
-        # Check if it correctly identified the number of planets
-        # The Feb 28 alignment has 7 planets
+        # The Feb 28 alignment has 7 planets, and 6 are visible from Warsaw
         feb_28_alignment = alignment_events[
             cast(Any, alignment_events["date"]).dt.day == 28
         ]
         self.assertEqual(len(feb_28_alignment), 1)
         self.assertIn("7 planets", cast(Any, feb_28_alignment).iloc[0]["event"])
+        self.assertIn("6 visible", cast(Any, feb_28_alignment).iloc[0]["event"])
         self.assertEqual(cast(Any, feb_28_alignment).iloc[0]["rarity"], 5)
 
         # Check planets involved
@@ -324,6 +324,16 @@ class EventsTest(unittest.TestCase):
         self.assertIn("Saturn", planets_involved)
         self.assertIn("Uranus", planets_involved)
         self.assertIn("Neptune", planets_involved)
+
+        # Check visible planets
+        visible_planets = cast(Any, feb_28_alignment).iloc[0]["visible_planets"]
+        self.assertEqual(len(visible_planets), 6)
+        self.assertIn("Mercury", visible_planets)
+        self.assertIn("Venus", visible_planets)
+        self.assertIn("Jupiter", visible_planets)
+        self.assertIn("Saturn", visible_planets)
+        self.assertIn("Uranus", visible_planets)
+        self.assertIn("Neptune", visible_planets)
 
     @patch("apts.events.coordinator.get_event_settings")
     def test_calculate_culminations(self, mock_get_event_settings):


### PR DESCRIPTION
I have improved the planetary alignment discovery logic to better identify "planet parades" by taking into account the visibility of planets from the observer's location. The discovery process now checks hourly intervals to find the moment of maximum visibility (dark sky and planets above the horizon) for each day in an alignment period. I also added a comprehensive unit test for the great planetary alignment on February 28, 2026, which correctly identifies that 6 out of 7 aligned planets are visible from Warsaw.

---
*PR created automatically by Jules for task [16602708114213253204](https://jules.google.com/task/16602708114213253204) started by @pozar87*