### PR TITLE
Fix satellite flyby detection by updating CelesTrak URL

### DIFF
--- a/apts/skyfield_searches/satellites.py
+++ b/apts/skyfield_searches/satellites.py
@@ -54,7 +54,7 @@ def _find_satellite_flybys(
     t1 = ts.utc(end_date)
 
     try:
-        stations_url = "https://celestrak.org/NORAD/elements/stations.txt"
+        stations_url = "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
         # Load TLE file - no ephemeris needed for satellite data
         # Skyfield will cache this file by default
         satellites = load.tle_file(stations_url)

--- a/tests/integration/test_iss_flybys.py
+++ b/tests/integration/test_iss_flybys.py
@@ -122,7 +122,7 @@ class ISSFlybysIntegrationTest(unittest.TestCase):
 
             # Verify the correct URL was called
             mock_tle.assert_called_once_with(
-                "https://celestrak.org/NORAD/elements/stations.txt"
+                "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
             )
 
     def test_iss_name_search(self):

--- a/tests/integration/test_tiangong_flybys.py
+++ b/tests/integration/test_tiangong_flybys.py
@@ -121,7 +121,7 @@ class TiangongFlybysIntegrationTest(unittest.TestCase):
 
             # Verify the correct URL was called
             mock_tle.assert_called_once_with(
-                "https://celestrak.org/NORAD/elements/stations.txt"
+                "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
             )
 
     def test_tiangong_name_search(self):


### PR DESCRIPTION
Updated the CelesTrak stations URL in `apts/skyfield_searches/satellites.py` to use the new GP API with explicit TLE format, ensuring compatibility with Skyfield's TLE parser. Also updated corresponding mocks in integration tests. This fixes the issue where satellite flybys were no longer being detected due to data loading failures.

---
*PR created automatically by Jules for task [2274285293426021461](https://jules.google.com/task/2274285293426021461) started by @pozar87*