### PR TITLE
Implement automatic elevation fetching via Open-Meteo API

### DIFF
--- a/apts/api.py
+++ b/apts/api.py
@@ -14,7 +14,7 @@ def get_events(
     lon: float,
     start_date: datetime,
     end_date: datetime,
-    elevation: int = 300,
+    elevation: Optional[int] = None,
     events_to_calculate: Optional[List[EventType]] = None,
 ):
     place = Place(lat=lat, lon=lon, elevation=elevation)

--- a/apts/config.py
+++ b/apts/config.py
@@ -255,6 +255,29 @@ def get_light_pollution_settings() -> dict:
     return settings
 
 
+def get_place_settings() -> dict:
+    """
+    Reads the place settings from the [place] section.
+
+    Returns:
+        dict: A dictionary of place settings.
+    """
+    settings = {
+        "use_online_elevation_api": True,
+        "default_elevation": 300,
+    }
+
+    if config.has_section("place"):
+        if config.has_option("place", "use_online_elevation_api"):
+            settings["use_online_elevation_api"] = config.getboolean(
+                "place", "use_online_elevation_api"
+            )
+        if config.has_option("place", "default_elevation"):
+            settings["default_elevation"] = config.getint("place", "default_elevation")
+
+    return settings
+
+
 def get_jovian_ephemeris_url() -> str:
     """
     Reads the Jovian ephemeris URL from the [data] section.

--- a/apts/place/base.py
+++ b/apts/place/base.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from dateutil import tz
 
+from ..config import get_place_settings
+from .elevation import get_elevation
+
 if TYPE_CHECKING:
     from ..light_pollution import LightPollution
     from ..weather import Weather
@@ -38,7 +41,7 @@ class Place(PlaceImagingMixIn, PlacePathsMixIn, PlaceTimesMixIn):
         lat,
         lon,
         name="",
-        elevation=300,
+        elevation=None,
         date=datetime.datetime.now(datetime.UTC),
     ):
         self.ts = get_timescale()
@@ -52,6 +55,16 @@ class Place(PlaceImagingMixIn, PlacePathsMixIn, PlaceTimesMixIn):
         self._lat_decimal = lat
         self._lon_decimal = lon
         self.name = name
+
+        # Handle elevation
+        if elevation is None:
+            settings = get_place_settings()
+            if settings.get("use_online_elevation_api", True):
+                elevation = get_elevation(lat, lon)
+
+            if elevation is None:
+                elevation = settings.get("default_elevation", 300)
+
         self.elevation = elevation
         self.location = Topos(
             latitude_degrees=lat, longitude_degrees=lon, elevation_m=float(elevation)

--- a/apts/place/elevation.py
+++ b/apts/place/elevation.py
@@ -1,0 +1,30 @@
+import logging
+from ..utils.network import get_session
+
+logger = logging.getLogger(__name__)
+
+
+def get_elevation(lat: float, lon: float) -> float | None:
+    """
+    Fetches elevation for a given latitude and longitude using the Open-Meteo Elevation API.
+    Returns elevation in meters or None if fetching fails.
+    """
+    url = "https://api.open-meteo.com/v1/elevation"
+    params = {"latitude": lat, "longitude": lon}
+    try:
+        with get_session().get(url, params=params, timeout=10) as resp:
+            if resp.ok:
+                data = resp.json()
+                elevation_list = data.get("elevation", [])
+                if elevation_list:
+                    elevation = float(elevation_list[0])
+                    logger.debug(f"Fetched elevation {elevation} for {lat}, {lon}")
+                    return elevation
+            else:
+                logger.warning(
+                    f"Failed to fetch elevation from API: {resp.status_code}"
+                )
+    except Exception as e:
+        logger.warning(f"Error fetching elevation from API: {e}")
+
+    return None

--- a/examples/apts.ini
+++ b/examples/apts.ini
@@ -85,6 +85,14 @@ cache_size = 128
 [api_keys]
 nasa_api_key = DEMO_KEY
 
+[place]
+# Automatic elevation fetching settings
+# If use_online_elevation_api is true, apts will try to fetch elevation from Open-Meteo API
+# if it is not provided when creating a Place object.
+use_online_elevation_api = true
+# Default elevation to use if fetching fails or is disabled.
+default_elevation = 300
+
 [data]
 # Jovian Ephemeris for moon events calculation.
 # Default is jup365.bsp (~1.1GB, 1600-2600) which contains Galilean moons.

--- a/tests/unit/test_api_facade.py
+++ b/tests/unit/test_api_facade.py
@@ -28,7 +28,7 @@ class TestApi(unittest.TestCase):
         )
 
         # Verify calls
-        mock_place_class.assert_called_once_with(lat=52.2, lon=21.0, elevation=300)
+        mock_place_class.assert_called_once_with(lat=52.2, lon=21.0, elevation=None)
         mock_equipment_class.assert_called_once()
         mock_observation_class.assert_called_once_with(mock_place, mock_equipment)
 

--- a/tests/unit/test_elevation.py
+++ b/tests/unit/test_elevation.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from apts.place.elevation import get_elevation
+from apts.place import Place
+
+class TestElevation(unittest.TestCase):
+
+    @patch("apts.place.elevation.get_session")
+    def test_get_elevation_success(self, mock_get_session):
+        # Mock the response from the API
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"elevation": [123.4]}
+        mock_get_session.return_value.get.return_value.__enter__.return_value = mock_response
+
+        elevation = get_elevation(50.0, 20.0)
+        self.assertEqual(elevation, 123.4)
+
+    @patch("apts.place.elevation.get_session")
+    def test_get_elevation_failure(self, mock_get_session):
+        # Mock a failed response
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status_code = 404
+        mock_get_session.return_value.get.return_value.__enter__.return_value = mock_response
+
+        elevation = get_elevation(50.0, 20.0)
+        self.assertIsNone(elevation)
+
+    @patch("apts.place.base.get_elevation")
+    @patch("apts.place.base.get_place_settings")
+    def test_place_init_with_auto_elevation(self, mock_get_settings, mock_get_elevation):
+        # Mock settings to enable auto elevation
+        mock_get_settings.return_value = {
+            "use_online_elevation_api": True,
+            "default_elevation": 300
+        }
+        mock_get_elevation.return_value = 567.8
+
+        place = Place(lat=50.0, lon=20.0)
+        self.assertEqual(place.elevation, 567.8)
+        mock_get_elevation.assert_called_once_with(50.0, 20.0)
+
+    @patch("apts.place.base.get_elevation")
+    @patch("apts.place.base.get_place_settings")
+    def test_place_init_with_auto_elevation_failure_fallback(self, mock_get_settings, mock_get_elevation):
+        # Mock settings to enable auto elevation but API fails
+        mock_get_settings.return_value = {
+            "use_online_elevation_api": True,
+            "default_elevation": 300
+        }
+        mock_get_elevation.return_value = None
+
+        place = Place(lat=50.0, lon=20.0)
+        self.assertEqual(place.elevation, 300)
+
+    @patch("apts.place.base.get_elevation")
+    @patch("apts.place.base.get_place_settings")
+    def test_place_init_with_disabled_auto_elevation(self, mock_get_settings, mock_get_elevation):
+        # Mock settings to disable auto elevation
+        mock_get_settings.return_value = {
+            "use_online_elevation_api": False,
+            "default_elevation": 400
+        }
+
+        place = Place(lat=50.0, lon=20.0)
+        self.assertEqual(place.elevation, 400)
+        mock_get_elevation.assert_not_called()
+
+    def test_place_init_with_provided_elevation(self):
+        # If elevation is provided, it should use it and not call the API
+        with patch("apts.place.base.get_elevation") as mock_get_elevation:
+            place = Place(lat=50.0, lon=20.0, elevation=800)
+            self.assertEqual(place.elevation, 800)
+            mock_get_elevation.assert_not_called()


### PR DESCRIPTION
This change adds support for automatically fetching a location's elevation using the Open-Meteo Elevation API if it's not explicitly provided during Place initialization. It includes a new configuration section [place] to control this behavior and set a fallback default elevation. The feature is integrated into the core Place class and the public API facade, with comprehensive unit tests provided.

---
*PR created automatically by Jules for task [13667540110756298771](https://jules.google.com/task/13667540110756298771) started by @pozar87*