### PR TITLE
Fix FOV score calculation and add unit tests

### DIFF
--- a/apts/optics/utils.py
+++ b/apts/optics/utils.py
@@ -117,25 +117,52 @@ class OpticsUtils:
         sensor_size: tuple (width, height) in mm
         focal_length: focal length in mm
         """
-        # Handle potential pint.Quantity objects in object_size
-        obj_major_arcmin = (
-            object_size[0].magnitude
-            if hasattr(object_size[0], "magnitude")
-            else object_size[0]
-        )
-        obj_minor_arcmin = (
-            object_size[1].magnitude
-            if hasattr(object_size[1], "magnitude")
-            else object_size[1]
-        )
 
-        # Convert to float and handle None/NaN
-        if hasattr(obj_major_arcmin, "__iter__") and not isinstance(obj_major_arcmin, (str, bytes)):
-            obj_major_arcmin = np.array(obj_major_arcmin, dtype=float)
-            obj_minor_arcmin = np.array(obj_minor_arcmin, dtype=float)
-        else:
-            obj_major_arcmin = float(obj_major_arcmin or 0)
-            obj_minor_arcmin = float(obj_minor_arcmin or 0)
+        def _get_magnitude(data):
+            if hasattr(data, "to"):
+                # It's a Quantity (scalar or array-wrapped)
+                return data.to("arcminute").magnitude
+            if isinstance(data, (np.ndarray, list, tuple)):
+                # If we have a list of Quantities, np.array() might try to be too smart
+                # and fail if they are heterogeneous or have different units.
+                # Let's handle it by checking if it's a list/tuple and converting elements
+                if isinstance(data, (list, tuple)):
+                    # Check if any element is a Quantity
+                    if any(hasattr(v, "to") for v in data):
+                        return np.array(
+                            [
+                                (
+                                    v.to("arcminute").magnitude
+                                    if hasattr(v, "to")
+                                    else float(v or 0)
+                                )
+                                for v in data
+                            ],
+                            dtype=float,
+                        )
+
+                data_array = np.array(data)
+                # Check if it contains Quantities (object dtype)
+                if data_array.dtype == object and len(data_array) > 0:
+                    # Check first element to see if it's a Quantity
+                    if hasattr(data_array[0], "to"):
+                        return np.array(
+                            [
+                                (
+                                    v.to("arcminute").magnitude
+                                    if hasattr(v, "to")
+                                    else float(v or 0)
+                                )
+                                for v in data_array
+                            ],
+                            dtype=float,
+                        )
+                return data_array.astype(float)
+            return float(data or 0)
+
+        # Handle potential pint.Quantity objects in object_size
+        obj_major_arcmin = _get_magnitude(object_size[0])
+        obj_minor_arcmin = _get_magnitude(object_size[1])
 
         obj_major_deg = obj_major_arcmin / 60.0
         obj_minor_deg = obj_minor_arcmin / 60.0

--- a/tests/unit/test_fov_scoring.py
+++ b/tests/unit/test_fov_scoring.py
@@ -1,0 +1,70 @@
+import pytest
+import numpy as np
+import pandas as pd
+from apts.optics.utils import OpticsUtils
+from apts.units import get_unit_registry
+
+ureg = get_unit_registry()
+
+def test_calculate_fov_ratio_scalar_float():
+    ratio = OpticsUtils.calculate_fov_ratio((60, 30), (22.2, 14.8), 750)
+    assert isinstance(ratio, (float, np.float64))
+    # 60 arcmin = 1 deg.
+    # FOV width = 2 * arctan(22.2 / 1500) = 1.6958 deg
+    # Ratio = 1 / 1.6958 * 100 = 58.96
+    assert ratio == pytest.approx(58.96, rel=1e-3)
+
+def test_calculate_fov_ratio_scalar_quantity():
+    ratio = OpticsUtils.calculate_fov_ratio(
+        (1 * ureg.degree, 30 * ureg.arcminute),
+        (22.2, 14.8),
+        750
+    )
+    assert ratio == pytest.approx(58.96, rel=1e-3)
+
+def test_calculate_fov_ratio_array_float():
+    ratios = OpticsUtils.calculate_fov_ratio(
+        (np.array([60, 120]), np.array([30, 60])),
+        (22.2, 14.8),
+        750
+    )
+    assert len(ratios) == 2
+    assert ratios[0] == pytest.approx(58.96, rel=1e-3)
+    assert ratios[1] == pytest.approx(117.93, rel=1e-3)
+
+def test_calculate_fov_ratio_array_quantities():
+    # This is the case that was failing
+    major = np.array([60 * ureg.arcminute, 120 * ureg.arcminute], dtype=object)
+    minor = np.array([30 * ureg.arcminute, 60 * ureg.arcminute], dtype=object)
+    ratios = OpticsUtils.calculate_fov_ratio(
+        (major, minor),
+        (22.2, 14.8),
+        750
+    )
+    assert len(ratios) == 2
+    assert ratios[0] == pytest.approx(58.96, rel=1e-3)
+    assert ratios[1] == pytest.approx(117.93, rel=1e-3)
+
+def test_calculate_fov_ratio_quantity_wrapping_array():
+    major = np.array([60, 120]) * ureg.arcminute
+    minor = np.array([30, 60]) * ureg.arcminute
+    ratios = OpticsUtils.calculate_fov_ratio(
+        (major, minor),
+        (22.2, 14.8),
+        750
+    )
+    assert len(ratios) == 2
+    assert ratios[0] == pytest.approx(58.96, rel=1e-3)
+    assert ratios[1] == pytest.approx(117.93, rel=1e-3)
+
+def test_calculate_fov_ratio_mixed_list():
+    major = [60 * ureg.arcminute, 120] # 120 assumed arcmin if raw float
+    minor = [30, 60 * ureg.arcminute]
+    ratios = OpticsUtils.calculate_fov_ratio(
+        (major, minor),
+        (22.2, 14.8),
+        750
+    )
+    assert len(ratios) == 2
+    assert ratios[0] == pytest.approx(58.96, rel=1e-3)
+    assert ratios[1] == pytest.approx(117.93, rel=1e-3)


### PR DESCRIPTION
The FOV score calculation in the discovery service was returning 0 for most objects. This was traced back to `OpticsUtils.calculate_fov_ratio` incorrectly handling collections of `pint.Quantity` objects. When `np.array(..., dtype=float)` was called on an array of Pint quantities, they were implicitly converted to floats in Pint's base unit (radians) instead of the expected arcminutes.

I introduced a `_get_magnitude` helper function within `calculate_fov_ratio` that explicitly converts each element to arcminutes and then extracts the magnitude. This function handles scalars, Quantities, numpy arrays of floats or Quantities, and mixed lists.

Verified the fix with a reproduction script showing correct FOV ratios and non-zero scores for targets like M31 and M42. Added unit tests to ensure continued robustness across different input formats.

---
*PR created automatically by Jules for task [16885755896177801943](https://jules.google.com/task/16885755896177801943) started by @pozar87*