### PR TITLE
Refactor optical equipment port management

### DIFF
--- a/apts/opticalequipment/abstract.py
+++ b/apts/opticalequipment/abstract.py
@@ -62,6 +62,20 @@ class OpticalEquipment:
         self.optical_length = cast(Any, (optical_length or 0) * get_unit_registry().mm)
         self.mass = cast(Any, (mass or 0) * get_unit_registry().gram)
         self.attached_equipment = []
+        self._inputs = []
+        self._outputs = []
+
+    def add_input(self, connection_type, gender=None):
+        """
+        Add an input port to this equipment.
+        """
+        self._inputs.append((connection_type, gender))
+
+    def add_output(self, connection_type, gender=None):
+        """
+        Add an output port to this equipment.
+        """
+        self._outputs.append((connection_type, gender))
 
     def attach(self, equipment: "OpticalEquipment"):
         """
@@ -130,6 +144,15 @@ class OpticalEquipment:
     def _register(self, equipment):
         # Register equipment node
         equipment.add_vertex(self.id(), self)
+
+        # Register all inputs
+        for connection_type, gender in self._inputs:
+            self._register_input(equipment, connection_type, gender)
+
+        # Register all outputs
+        for connection_type, gender in self._outputs:
+            self._register_output(equipment, connection_type, gender)
+
         # Register attached equipment
         for att in self.attached_equipment:
             att.register(equipment)
@@ -190,12 +213,10 @@ class IntermediateOpticalEquipment(OpticalEquipment):
         self.in_gender = in_gender
         self.out_gender = out_gender
 
-    def register(self, equipment):
-        super(IntermediateOpticalEquipment, self)._register(equipment)
         if self.in_connection_type:
-            self._register_input(equipment, self.in_connection_type, self.in_gender)
+            self.add_input(self.in_connection_type, self.in_gender)
         if self.out_connection_type:
-            self._register_output(equipment, self.out_connection_type, self.out_gender)
+            self.add_output(self.out_connection_type, self.out_gender)
 
 
 class OutputOpticalEquipment(OpticalEquipment):

--- a/apts/opticalequipment/barlow/base.py
+++ b/apts/opticalequipment/barlow/base.py
@@ -64,20 +64,18 @@ class Barlow(OpticalEquipment):
         self.t2_output = t2_output
         self.magnification = magnification
 
+        self.add_input(self.connection_type, self.in_gender)
+        self.add_output(self.connection_type, self.out_gender)
+        if self.t2_output:
+            self.add_output(ConnectionType.T2, Gender.MALE)
+
     def register(self, equipment):
         """
         Register barlow lens in optical equipment graph. Barlow node is build out of three vertices:
         barlow node its input and output. Barlow node is automatically connected with them.
         """
         # Add barlow lens node
-        super(Barlow, self)._register(equipment)
-        # Add barlow lens output node and connect it to barlow lens
-        self._register_output(equipment, self.connection_type, self.out_gender)
-        # Add barlow lens input node and connect it to barlow lens
-        self._register_input(equipment, self.connection_type, self.in_gender)
-        # Handling optional T2 output
-        if self.t2_output:
-            self._register_output(equipment, ConnectionType.T2, Gender.MALE)
+        super(Barlow, self).register(equipment)
 
     def __str__(self):
         # Format: <vendor> x<magnification>

--- a/apts/opticalequipment/camera/base.py
+++ b/apts/opticalequipment/camera/base.py
@@ -67,6 +67,8 @@ class Camera(OutputOpticalEquipment):
         else:
             self._pixel_size = None
 
+        self.add_input(self.connection_type, self.connection_gender)
+
     def pixel_size(self) -> Any:
         ureg = get_unit_registry()
         if self._pixel_size is not None:
@@ -127,7 +129,6 @@ class Camera(OutputOpticalEquipment):
 
     def register(self, equipment):
         super()._register(equipment)
-        self._register_input(equipment, self.connection_type, self.connection_gender)
         equipment.add_edge(self.id(), GraphConstants.IMAGE_ID)
 
     def is_visual_output(self):

--- a/apts/opticalequipment/diagonal/base.py
+++ b/apts/opticalequipment/diagonal/base.py
@@ -70,13 +70,14 @@ class Diagonal(IntermediateOpticalEquipment):
         self.is_erecting = is_erecting
         self.t2_output = t2_output
 
+        if self.t2_output:
+            self.add_output(ConnectionType.T2, Gender.MALE)
+
     def register(self, equipment):
         """
         Register diagonal in optical equipment graph.
         """
         super(Diagonal, self).register(equipment)
-        if self.t2_output:
-            self._register_output(equipment, ConnectionType.T2, Gender.MALE)
 
     def __str__(self):
         return f"{self.vendor}"

--- a/apts/opticalequipment/eyepiece/base.py
+++ b/apts/opticalequipment/eyepiece/base.py
@@ -48,6 +48,8 @@ class Eyepiece(OutputOpticalEquipment):
         self._field_of_view = cast(Any, field_of_view * get_unit_registry().deg)
         self.field_stop = cast(Any, field_stop * get_unit_registry().mm) if field_stop is not None else None
 
+        self.add_input(self._connection_type, self._connection_gender)
+
     def _zoom_divider(self):
         return self.focal_length
 
@@ -77,7 +79,6 @@ class Eyepiece(OutputOpticalEquipment):
         ocular node and its input. Ocular node is automatically connected with output IMAGE node.
         """
         super()._register(equipment)
-        self._register_input(equipment, self._connection_type, self._connection_gender)
         equipment.add_edge(self.id(), GraphConstants.EYE_ID)
 
     def __str__(self):

--- a/apts/opticalequipment/filter/base.py
+++ b/apts/opticalequipment/filter/base.py
@@ -72,11 +72,6 @@ class Filter(IntermediateOpticalEquipment):
         self.name = name
         self.transmission = transmission
 
-    def register(self, equipment):
-        """
-        Register filter in optical equipment graph.
-        """
-        super(Filter, self).register(equipment)
 
     def __str__(self):
         return f"{self.name} ({self.vendor})"

--- a/apts/opticalequipment/filter_wheel/base.py
+++ b/apts/opticalequipment/filter_wheel/base.py
@@ -60,8 +60,6 @@ class FilterWheel(IntermediateOpticalEquipment):
     def register(self, equipment):
         super(FilterWheel, self).register(equipment)
         for f in self.filters:
-            # Register filter
-            f.register(equipment)
             # Connect filter wheel node to filter input
             # This allows the optical path to go: Wheel_IN -> Wheel_Node -> Filter_IN -> Filter_Node -> Filter_OUT -> Wheel_OUT
             equipment.add_edge(self.id(), f.in_id(f.in_connection_type))
@@ -127,8 +125,6 @@ class FilterHolder(IntermediateOpticalEquipment):
     def register(self, equipment):
         super(FilterHolder, self).register(equipment)
         for f in self.filters:
-            # Register filter
-            f.register(equipment)
             # Connect filter holder node to filter input
             equipment.add_edge(self.id(), f.in_id(f.in_connection_type))
             # Connect filter output to filter holder output

--- a/apts/opticalequipment/flip_mirror/base.py
+++ b/apts/opticalequipment/flip_mirror/base.py
@@ -51,10 +51,9 @@ class FlipMirror(IntermediateOpticalEquipment):
         from ...utils import ConnectionType, Gender
         self.diagonal_connection_type = diagonal_connection_type or ConnectionType.F_1_25
         self.diagonal_gender = diagonal_gender or Gender.FEMALE
+        self.add_output(self.diagonal_connection_type, self.diagonal_gender)
 
     def register(self, equipment):
         super(FlipMirror, self).register(equipment)
-        # Add additional diagonal output
-        self._register_output(equipment, self.diagonal_connection_type, self.diagonal_gender)
 
     _DATABASE = {}

--- a/apts/opticalequipment/oag/base.py
+++ b/apts/opticalequipment/oag/base.py
@@ -53,8 +53,7 @@ class OAG(IntermediateOpticalEquipment):
         from ...utils import ConnectionType, Gender
         self.guide_connection_type = guide_connection_type or ConnectionType.M42
         self.guide_gender = guide_gender or Gender.MALE
+        self.add_output(self.guide_connection_type, self.guide_gender)
 
     def register(self, equipment):
         super(OAG, self).register(equipment)
-        # Add additional guide output
-        self._register_output(equipment, self.guide_connection_type, self.guide_gender)

--- a/apts/opticalequipment/telescope/base.py
+++ b/apts/opticalequipment/telescope/base.py
@@ -91,6 +91,10 @@ class Telescope(OpticalEquipment):
         self.tube_material = tube_material
         self.backfocus = cast(Any, backfocus * get_unit_registry().mm) if backfocus is not None else None
 
+        self.add_output(self.connection_type, self.connection_gender)
+        if self.t2_output:
+            self.add_output(ConnectionType.T2, Gender.MALE)
+
     def focal_ratio(self):
         return self.focal_length / self.aperture
 
@@ -185,11 +189,8 @@ class Telescope(OpticalEquipment):
         Register telescope in optical equipment graph. Telescope node is build out of two vertices:
         telescope node and its output. Telescope node is automatically connected with SPACE node.
         """
-        super(Telescope, self)._register(equipment)
-        self._register_output(equipment, self.connection_type, self.connection_gender)
+        super(Telescope, self).register(equipment)
         equipment.add_edge(GraphConstants.SPACE_ID, self.id())
-        if self.t2_output:
-            self._register_output(equipment, ConnectionType.T2, Gender.MALE)
 
     def __str__(self):
         return '{} {}/{}'.format(self.get_vendor(), cast(Any, self.aperture).magnitude, cast(Any, self.focal_length).magnitude)

--- a/tests/unit/test_equipment_connections.py
+++ b/tests/unit/test_equipment_connections.py
@@ -1,0 +1,76 @@
+import unittest
+from apts.equipment import Equipment
+from apts.opticalequipment.telescope import Telescope
+from apts.opticalequipment.barlow import Barlow
+from apts.opticalequipment.diagonal import Diagonal
+from apts.opticalequipment.eyepiece import Eyepiece
+from apts.opticalequipment.camera import Camera
+from apts.opticalequipment.oag import OAG
+from apts.utils import ConnectionType, Gender
+from apts.constants import GraphConstants
+
+class TestEquipmentConnections(unittest.TestCase):
+    def test_telescope_t2_output(self):
+        # Telescope with both 1.25" and T2 output
+        t = Telescope(80, 600, "Test Telescope", connection_type=ConnectionType.F_1_25, t2_output=True)
+        e = Equipment()
+        e.register(t)
+
+        # Verify both outputs are registered in the graph
+        out_125 = t.out_id(ConnectionType.F_1_25)
+        out_t2 = t.out_id(ConnectionType.T2)
+
+        self.assertTrue(e.connection_garph.has_node(out_125))
+        self.assertTrue(e.connection_garph.has_node(out_t2))
+
+        # Verify connections from telescope to outputs
+        self.assertTrue(e.connection_garph.has_edge(t.id(), out_125))
+        self.assertTrue(e.connection_garph.has_edge(t.id(), out_t2))
+
+    def test_oag_multiple_outputs(self):
+        # OAG has a main output and a guide output
+        oag = OAG("Test OAG", in_connection_type=ConnectionType.T2, out_connection_type=ConnectionType.T2,
+                  guide_connection_type=ConnectionType.M42)
+        e = Equipment()
+        e.register(oag)
+
+        # Verify all ports
+        in_t2 = oag.in_id(ConnectionType.T2)
+        out_t2 = oag.out_id(ConnectionType.T2)
+        out_m42 = oag.out_id(ConnectionType.M42)
+
+        self.assertTrue(e.connection_garph.has_node(in_t2))
+        self.assertTrue(e.connection_garph.has_node(out_t2))
+        self.assertTrue(e.connection_garph.has_node(out_m42))
+
+        self.assertTrue(e.connection_garph.has_edge(in_t2, oag.id()))
+        self.assertTrue(e.connection_garph.has_edge(oag.id(), out_t2))
+        self.assertTrue(e.connection_garph.has_edge(oag.id(), out_m42))
+
+    def test_path_finding_multiple_outputs(self):
+        # Setup: Telescope (1.25" and T2) -> Barlow (1.25") -> Eyepiece (1.25")
+        #                                  -> Camera (T2)
+        t = Telescope(80, 600, "Test Telescope", connection_type=ConnectionType.F_1_25, t2_output=True)
+        b = Barlow(2, "Test Barlow", connection_type=ConnectionType.F_1_25)
+        ep = Eyepiece(20, "Test Eyepiece", connection_type=ConnectionType.F_1_25)
+        cam = Camera(36, 24, 6000, 4000, "Test Camera", connection_type=ConnectionType.T2)
+
+        e = Equipment()
+        e.register(t)
+        e.register(b)
+        e.register(ep)
+        e.register(cam)
+
+        # Visual paths
+        visual_paths = e._get_paths(GraphConstants.EYE_ID)
+        # 3 paths: NakedEye, Telescope -> Eyepiece and Telescope -> Barlow -> Eyepiece
+        self.assertEqual(len(visual_paths), 3)
+
+        # Imaging paths
+        imaging_paths = e._get_paths(GraphConstants.IMAGE_ID)
+        self.assertEqual(len(imaging_paths), 1) # Telescope (T2) -> Camera
+        self.assertEqual(imaging_paths[0].output, cam)
+        self.assertEqual(imaging_paths[0].telescope, t)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I have refactored the optical equipment connection system to be more flexible and maintainable. 

Previously, handling multiple outputs (like an optional T2 port on a telescope or barlow) was done via hardcoded flags and manual registration in each subclass's `register` method. 

I have introduced a generalized system where:
1. The base `OpticalEquipment` class now maintains `_inputs` and `_outputs` lists.
2. New methods `add_input` and `add_output` allow easy registration of multiple ports.
3. The `_register` method in the base class now automatically iterates over these lists to build the equipment graph.
4. Subclasses like `Telescope`, `Barlow`, `OAG`, and `FlipMirror` have been updated to use this system, significantly simplifying their `register` methods.
5. Backward compatibility is preserved by keeping the existing constructor parameters and mapping them to the new internal lists.

I've also added a new test file `tests/unit/test_equipment_connections.py` which verifies that equipment with multiple ports is correctly represented in the graph and that pathfinding works as expected. All existing tests passed as well.

---
*PR created automatically by Jules for task [13471089005961796585](https://jules.google.com/task/13471089005961796585) started by @pozar87*