### PR TITLE
🔍 Optic: Data audit for ZWO ASI174MM Mini

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -480,7 +480,7 @@ class ZwoCamera(Camera):
             "height": 1216,
             "mass": 60,
             "name": "ASI174MM Mini",
-            "optical_length": 6.5,
+            "optical_length": 12.5, # Verified via official ZWO specs (12.5mm backfocus)
             "pixel_size_um": 5.86,
             "quantum_efficiency_pct": 77,
             "read_noise_e": 6.0,
@@ -488,7 +488,7 @@ class ZwoCamera(Camera):
             "sensor_height_mm": 7.1,
             "sensor_width_mm": 11.3,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",
             "type": "type_camera",
             "width": 1936,
         },


### PR DESCRIPTION
I have performed a data audit on the ZWO ASI174MM Mini camera. 

Discovered that its specifications were incorrectly listed with a 6.5mm backfocus and an M42 thread, which likely resulted from a copy-paste of the non-mini version's specs. According to official ZWO technical documentation, the Mini series (cylindrical/1.25" barrel style) has a native backfocus of 12.5mm and uses a CS-mount internal thread/interface.

I have updated `apts/opticalequipment/camera/vendors/zwo.py` to reflect these correct values and verified the fix by instantiating the object and checking its properties. I also ran the relevant unit tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [5740174820509961001](https://jules.google.com/task/5740174820509961001) started by @pozar87*