### PR TITLE
🔍 Optic: Data audit for ZWO ASI224MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -745,12 +745,12 @@ class ZwoCamera(Camera):
             "cside_thread": "",
             "full_well_e": 19200,
             "height": 976,
-            "mass": 60,
+            "mass": 100, # Verified via official ZWO specs (0.1kg)
             "name": "ASI224MC",
             "optical_length": 12.5,
             "pixel_size_um": 3.75,
             "quantum_efficiency_pct": 80,
-            "read_noise_e": 0.75,
+            "read_noise_e": 0.8, # Verified via official high-gain specs (0.8e)
             "reversible": False,
             "sensor_height_mm": 3.6,
             "sensor_width_mm": 4.8,
@@ -758,7 +758,7 @@ class ZwoCamera(Camera):
             "tside_thread": "CS",
             "type": "type_camera",
             "width": 1304,
-        },
+        }, # Verified via manufacturer product page: https://www.zwoastro.com/product/asi224mc/
         "ZWO_ASI_2400MC_Pro": {
             "bf_role": "end",
             "brand": "ZWO",

--- a/tests/unit/test_zwo_specs.py
+++ b/tests/unit/test_zwo_specs.py
@@ -59,5 +59,12 @@ class TestZwoUpdates(unittest.TestCase):
         self.assertEqual(cam.quantum_efficiency, 91)
         self.assertEqual(cam.optical_length.to('mm').magnitude, 6.5)
 
+    def test_asi224_specs(self):
+        cam = ZwoCamera.ZWO_ASI_224MC()
+        self.assertEqual(cam.mass.to('gram').magnitude, 100)
+        self.assertEqual(cam.read_noise, 0.8)
+        self.assertEqual(cam.quantum_efficiency, 80)
+        self.assertEqual(cam.full_well, 19200)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As the 'Optic' 🔍 agent, I have audited and corrected the specifications for the ZWO ASI224MC camera in the database.

Changes:
- Corrected the mass from 60g (which mistakenly matched the 'Mini' series weight) to 100g (0.1kg) as per official ZWO documentation.
- Refined the read noise value to 0.8e to align with the manufacturer's stated minimum high-gain specification.
- Added a source comment and URL to the official ZWO product page in `apts/opticalequipment/camera/vendors/zwo.py`.
- Added a new unit test `test_asi224_specs` in `tests/unit/test_zwo_specs.py` to ensure these values are correctly parsed and maintained.

All relevant hardware and data integrity tests were executed and passed.

---
*PR created automatically by Jules for task [13779593280071133640](https://jules.google.com/task/13779593280071133640) started by @pozar87*