### PR TITLE
🔍 Optic: Data audit for ZWO ASI Mini series

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -179,7 +179,7 @@ class ZwoCamera(Camera):
             "height": 960,
             "mass": 60,
             "name": "ASI120MM Mini",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "pixel_size_um": 3.75,
             "quantum_efficiency_pct": 80,
             "read_noise_e": 4.0,
@@ -438,7 +438,7 @@ class ZwoCamera(Camera):
             "height": 1216,
             "mass": 65,
             "name": "ASI174MC Mini",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "pixel_size_um": 5.86,
             "quantum_efficiency_pct": 77,
             "read_noise_e": 6.0,
@@ -480,7 +480,7 @@ class ZwoCamera(Camera):
             "height": 1216,
             "mass": 60,
             "name": "ASI174MM Mini",
-            "optical_length": 12.5, # Verified via official ZWO specs (12.5mm backfocus)
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "pixel_size_um": 5.86,
             "quantum_efficiency_pct": 77,
             "read_noise_e": 6.0,
@@ -713,7 +713,7 @@ class ZwoCamera(Camera):
             "height": 1080,
             "mass": 60,
             "name": "ASI220MM Mini",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "pixel_size_um": 4.0,
             "quantum_efficiency_pct": 92,
             "read_noise_e": 0.6,
@@ -732,7 +732,7 @@ class ZwoCamera(Camera):
             "cside_thread": "",
             "mass": 60,
             "name": "ASI220MM Mini (for ASIAir)",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "reversible": False,
             "tside_gender": "Female",
             "tside_thread": "CS",
@@ -1030,7 +1030,7 @@ class ZwoCamera(Camera):
             "cside_thread": "",
             "mass": 70,
             "name": "ASI290MC Mini",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "reversible": False,
             "tside_gender": "Female",
             "tside_thread": "CS",
@@ -1058,7 +1058,7 @@ class ZwoCamera(Camera):
             "height": 1080,
             "mass": 60,
             "name": "ASI290MM Mini",
-            "optical_length": 12.5,
+            "optical_length": 8.5, # Verified via official ZWO specs: https://www.zwoastro.com/product/mini-cameras/
             "pixel_size_um": 2.9,
             "quantum_efficiency_pct": 80,
             "read_noise_e": 1.0,

--- a/tests/unit/test_zwo_backfocus_audit.py
+++ b/tests/unit/test_zwo_backfocus_audit.py
@@ -43,6 +43,6 @@ def test_zwo_uncooled_planetary_remains_short():
     assert cam.optical_length.to("mm").magnitude == 12.5
 
 def test_zwo_mini_remains_short():
-    # Mini cameras are typically 12.5mm or 8.5mm depending on model
+    # Mini cameras have a native backfocus of 8.5mm
     cam = ZwoCamera.ZWO_ASI_120MM_Mini()
-    assert cam.optical_length.to("mm").magnitude == 12.5
+    assert cam.optical_length.to("mm").magnitude == 8.5


### PR DESCRIPTION
This PR audits and corrects the backfocus (optical length) for the ZWO ASI Mini camera series in the `apts` database.

### 💡 Fix
- Updated `optical_length` from **12.5mm** to **8.5mm** for the following models:
  - ZWO ASI120MM Mini
  - ZWO ASI174MC Mini
  - ZWO ASI174MM Mini
  - ZWO ASI220MM Mini
  - ZWO ASI220MM Mini (for ASIAir)
  - ZWO ASI290MC Mini
  - ZWO ASI290MM Mini
- Updated `tests/unit/test_zwo_backfocus_audit.py` to reflect the corrected specification.

### 🎯 Source
- Verified via official ZWO Mini series mechanical drawings and technical specifications: [ZWO Mini Cameras](https://www.zwoastro.com/product/mini-cameras/)
- The native backfocus from the sensor to the front of the 1.25" camera body is 8.5mm. An earlier incorrect value of 12.5mm likely included the length of a 1.25" extender, but for database accuracy and compatibility (especially with OAGs), the native body backfocus is the correct metric.

---
*PR created automatically by Jules for task [9699002339785582515](https://jules.google.com/task/9699002339785582515) started by @pozar87*