### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Black Diamond ED80

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -149,13 +149,13 @@ class Sky_watcherTelescope(Telescope):
          'cside_gender': 'Female',
          'cside_thread': 'M48',
          'focal_length_mm': 600,
-         'mass': 2600,
+         'mass': 2470,
          'name': 'Black Diamond ED80',
          'optical_length': 0,
          'reversible': False,
          'tside_gender': '',
          'tside_thread': '',
-         'type': 'type_refractor'}, # Verified via Sky-Watcher official specs
+         'type': 'type_refractor'}, # Verified via Sky-Watcher official specs (2.47 kg OTA) http://skywatcher.com/product/bk-80ed-otaw/
         'Sky_Watcher_Equinox_100': {'aperture_mm': 100,
          'bf_role': '',
          'brand': 'Sky-Watcher',

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -40,7 +40,7 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         self.assertEqual(scope.aperture.to('mm').magnitude, 80)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 600)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
-        self.assertEqual(scope.mass.to('gram').magnitude, 2600)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2470)
 
     def test_equinox_100_specs(self):
         scope = Sky_watcherTelescope.Sky_Watcher_Equinox_100()


### PR DESCRIPTION
Audited and corrected the specifications for the Sky-Watcher Black Diamond ED80 telescope.

💡 Fix: Corrected mass from 2600g to 2470g (2.47kg).
🎯 Source: Official Sky-Watcher Global product page (http://skywatcher.com/product/bk-80ed-otaw/).

The correction was verified against manufacturer documentation and the internal test suite (`tests/unit/test_sky_watcher_specs.py`) was updated to ensure continued compliance.

---
*PR created automatically by Jules for task [13421211376048701744](https://jules.google.com/task/13421211376048701744) started by @pozar87*