### PR TITLE
🔍 Optic: Data audit for Celestron 6-inch SCT

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -23,7 +23,7 @@ class CelestronTelescope(Telescope):
             "name": "Advanced VX 6 SCT",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -167,7 +167,7 @@ class CelestronTelescope(Telescope):
             "name": "Astro-Fi 6 SCT",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -375,39 +375,7 @@ class CelestronTelescope(Telescope):
             "name": "C6-A XLT (OTA)",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
-            "tside_thread": "",
-            "tside_gender": "",
-            "cside_thread": "SC (Schmidt-Cassegrain)",
-            "cside_gender": "Male",
-            "reversible": False,
-            "bf_role": "",
-            "aperture_mm": 150,
-            "focal_length_mm": 1500,
-            "central_obstruction_mm": 56,
-        },
-        "Celestron_C6_EdgeHD": {
-            "brand": "Celestron",
-            "name": "C6 EdgeHD",
-            "type": "catadioptric",
-            "optical_length": 0,
-            "mass": 4540,
-            "tside_thread": "",
-            "tside_gender": "",
-            "cside_thread": "SC (Schmidt-Cassegrain)",
-            "cside_gender": "Male",
-            "reversible": False,
-            "bf_role": "",
-            "aperture_mm": 150,
-            "focal_length_mm": 1500,
-            "central_obstruction_mm": 56,
-        },
-        "Celestron_C6_EdgeHD_OTA": {
-            "brand": "Celestron",
-            "name": "C6 EdgeHD OTA",
-            "type": "catadioptric",
-            "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -423,7 +391,7 @@ class CelestronTelescope(Telescope):
             "name": "C6 OTA",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -439,7 +407,7 @@ class CelestronTelescope(Telescope):
             "name": "C6 SCT",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -791,7 +759,7 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 6SE",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 3600,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -823,7 +791,7 @@ class CelestronTelescope(Telescope):
             "name": "NexStar Evolution 6",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -1015,7 +983,7 @@ class CelestronTelescope(Telescope):
             "name": "StarBright XLT C6-A-XLT",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4540,
+            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -1224,14 +1192,6 @@ class CelestronTelescope(Telescope):
     @classmethod
     def Celestron_C6_A_XLT_OTA(cls):
         return cls.from_database(cls._DATABASE['Celestron_C6_A_XLT_OTA'])
-
-    @classmethod
-    def Celestron_C6_EdgeHD(cls):
-        return cls.from_database(cls._DATABASE['Celestron_C6_EdgeHD'])
-
-    @classmethod
-    def Celestron_C6_EdgeHD_OTA(cls):
-        return cls.from_database(cls._DATABASE['Celestron_C6_EdgeHD_OTA'])
 
     @classmethod
     def Celestron_C6_OTA(cls):

--- a/tests/unit/test_celestron_c6_audit.py
+++ b/tests/unit/test_celestron_c6_audit.py
@@ -1,0 +1,26 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+class TestCelestronC6Audit(unittest.TestCase):
+    def test_nexstar_6se_mass(self):
+        scope = CelestronTelescope.Celestron_NexStar_6SE()
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+
+    def test_advanced_vx_6_sct_mass(self):
+        scope = CelestronTelescope.Celestron_Advanced_VX_6_SCT()
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+
+    def test_astro_fi_6_sct_mass(self):
+        scope = CelestronTelescope.Celestron_Astro_Fi_6_SCT()
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+
+    def test_nexstar_evolution_6_mass(self):
+        scope = CelestronTelescope.Celestron_NexStar_Evolution_6()
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+
+    def test_c6_sct_mass(self):
+        scope = CelestronTelescope.Celestron_C6_SCT()
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_celestron_ota_specs.py
+++ b/tests/unit/test_celestron_ota_specs.py
@@ -40,7 +40,7 @@ class TestCelestronOTASpecs(unittest.TestCase):
         self.assertEqual(scope.aperture.to('mm').magnitude, 150)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 1500)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 56)
-        self.assertEqual(scope.mass.to('gram').magnitude, 4540)
+        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
 
     def test_c8_ota_specs(self):
         scope = CelestronTelescope.Celestron_C8_OTA()


### PR DESCRIPTION
Audited and corrected the Celestron 6-inch Schmidt-Cassegrain (SCT) telescope entries in the `apts` database. Cross-referenced official manufacturer documentation at Celestron.com to verify the OTA mass (10 lbs / 4536g) and identified that the "EdgeHD" series does not include a 6-inch model.

### Changes:
- **Accuracy Update:** Corrected `mass` from 3600g (rounded/incorrect) and 4540g (rounded) to 4536g for `Celestron_NexStar_6SE`, `Celestron_Advanced_VX_6_SCT`, and related models.
- **Cleanup:** Removed `Celestron_C6_EdgeHD` and `Celestron_C6_EdgeHD_OTA` entries as they do not exist in the manufacturer's catalog.
- **Documentation:** Added "# Verified via Celestron.com (10 lbs OTA weight)" comments to relevant entries.
- **Testing:** Updated `tests/unit/test_celestron_ota_specs.py` and added a new comprehensive test file `tests/unit/test_celestron_c6_audit.py` to ensure data integrity.

All 14 unit tests in the affected area passed.

---
*PR created automatically by Jules for task [8072106475109355528](https://jules.google.com/task/8072106475109355528) started by @pozar87*