### PR TITLE
Fix object visibility calculations regression

### DIFF
--- a/apts/objects/messier.py
+++ b/apts/objects/messier.py
@@ -67,15 +67,24 @@ class Messier(Objects):
 
     def get_skyfield_object(self, obj):
         """Get skyfield object with caching when possible."""
-        if hasattr(obj, "name") and obj.name in self.objects.index:
-            return self.get_skyfield_object_cached(obj.name)
+        # Identify object ID from namedtuple (Index) or Series (name)
+        obj_id = getattr(obj, "Index", getattr(obj, "name", None))
 
-        if "skyfield_object" in obj:
+        if obj_id is not None and obj_id in self.objects.index:
+            return self.get_skyfield_object_cached(obj_id)
+
+        # Fallback: check for pre-calculated skyfield_object
+        if hasattr(obj, "skyfield_object"):
+            return getattr(obj, "skyfield_object")
+        if isinstance(obj, dict) and "skyfield_object" in obj:
             return obj["skyfield_object"]
 
-        # Reconstruct if possible
-        if "ra_hours" in obj and "dec_degrees" in obj:
-            return self.fixed_body(obj["ra_hours"], obj["dec_degrees"])
+        # Reconstruct if possible (using attributes or dictionary keys)
+        ra = getattr(obj, "ra_hours", obj.get("ra_hours") if isinstance(obj, dict) else None)
+        dec = getattr(obj, "dec_degrees", obj.get("dec_degrees") if isinstance(obj, dict) else None)
+
+        if ra is not None and dec is not None:
+            return self.fixed_body(ra, dec)
 
         return None
 

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -176,16 +176,17 @@ class NGC(Objects):
                 dec_degrees=obj["dec_degrees"].to_numpy(),
             )
 
-        # Case 2: Individual object (Series or dict)
-        if "skyfield_object" in obj and pd.notna(obj["skyfield_object"]):
-            return obj["skyfield_object"]
+        # Case 2: Individual object (Series, dict, or namedtuple)
+        sky_obj = getattr(obj, "skyfield_object", obj.get("skyfield_object") if isinstance(obj, dict) else None)
+        if sky_obj is not None and pd.notna(sky_obj):
+            return sky_obj
 
         # Reconstruct if missing (lazy loading or unpickled)
-        if "ra_hours" in obj and "dec_degrees" in obj:
-            sky_obj = self.fixed_body(obj["ra_hours"], obj["dec_degrees"])
-            # If obj is a Series from self.objects, we might want to cache it back
-            # However, we're in a read-only context here (obj might be a copy)
-            return sky_obj
+        ra = getattr(obj, "ra_hours", obj.get("ra_hours") if isinstance(obj, dict) else None)
+        dec = getattr(obj, "dec_degrees", obj.get("dec_degrees") if isinstance(obj, dict) else None)
+
+        if ra is not None and dec is not None:
+            return self.fixed_body(ra, dec)
 
         return None
 

--- a/apts/objects/solar_objects.py
+++ b/apts/objects/solar_objects.py
@@ -69,14 +69,24 @@ class SolarObjects(Objects):
 
     def get_skyfield_object(self, obj):
         """Get skyfield object with caching when possible."""
-        name_to_use = (
-            obj.get("TechnicalName") or obj.get("Name") if isinstance(obj, dict) else
-            getattr(obj, "TechnicalName", getattr(obj, "Name", None))
-        )
-        try:
-            return self._get_skyfield_object_cached(name_to_use)
-        except (ValueError, KeyError):
-            return None
+        # Try to identify the object name from namedtuple, Series, or dict
+        name_to_use = getattr(obj, "TechnicalName", getattr(obj, "Name", None))
+
+        if name_to_use is None and isinstance(obj, dict):
+            name_to_use = obj.get("TechnicalName") or obj.get("Name")
+
+        if name_to_use is not None:
+            try:
+                return self._get_skyfield_object_cached(name_to_use)
+            except (ValueError, KeyError):
+                pass
+
+        # Fallback: check for pre-calculated skyfield_object attribute
+        sky_obj = getattr(obj, "skyfield_object", None)
+        if sky_obj is None and isinstance(obj, dict):
+            sky_obj = obj.get("skyfield_object")
+
+        return sky_obj if sky_obj is not None and pd.notna(sky_obj) else None
 
     def _prepare_observer(self, calculation_date):
         """Prepares the observer and time for computation."""

--- a/apts/objects/stars.py
+++ b/apts/objects/stars.py
@@ -57,12 +57,17 @@ class Stars(Objects):
         return computed_df
 
     def get_skyfield_object(self, obj):
-        if "skyfield_object" in obj:
+        if hasattr(obj, "skyfield_object"):
+            return getattr(obj, "skyfield_object")
+        if isinstance(obj, dict) and "skyfield_object" in obj:
             return obj["skyfield_object"]
 
         # Reconstruct if possible
-        if "ra_hours" in obj and "dec_degrees" in obj:
-            return self.fixed_body(obj["ra_hours"], obj["dec_degrees"])
+        ra = getattr(obj, "ra_hours", obj.get("ra_hours") if isinstance(obj, dict) else None)
+        dec = getattr(obj, "dec_degrees", obj.get("dec_degrees") if isinstance(obj, dict) else None)
+
+        if ra is not None and dec is not None:
+            return self.fixed_body(ra, dec)
 
         return None
 


### PR DESCRIPTION
Restore Messier and Solar object visibility calculations by ensuring `get_skyfield_object` correctly identifies and retrieves objects from various input types (Series, NamedTuples, dicts). This fixes a regression caused by the transition to `itertuples()` for performance optimization.

---
*PR created automatically by Jules for task [13291144452184030473](https://jules.google.com/task/13291144452184030473) started by @pozar87*