### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Traditional Dobs

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -971,7 +971,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 1500,
-            "mass": 19500,
+            "mass": 21000,  # Verified via Sky-Watcher USA (46 lbs OTA)
             "name": "Skyliner 300P",
             "optical_length": 0,
             "reversible": False,
@@ -1207,7 +1207,7 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 153,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 42,
+            "central_obstruction_mm": 34.5,  # Verified via Sky-Watcher Global specs for 150/1200
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 1200,
@@ -1220,7 +1220,7 @@ class Sky_watcherTelescope(Telescope):
             "type": "newtonian_reflector",
         },
         "Sky_Watcher_Traditional_Dob_8": {
-            "aperture_mm": 200,
+            "aperture_mm": 203,  # Verified via Sky-Watcher USA (8" = 203.2mm)
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 47,
@@ -1257,7 +1257,7 @@ class Sky_watcherTelescope(Telescope):
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 48,
             "cside_gender": "Female",
-            "cside_thread": "2\"",
+            "cside_thread": "1.25\"",  # Verified via Sky-Watcher USA (1.25" helical focuser)
             "focal_length_mm": 750,
             "mass": 4800,
             "name": "Virtuoso GTi 150P",

--- a/tests/unit/test_sky_watcher_audit.py
+++ b/tests/unit/test_sky_watcher_audit.py
@@ -1,0 +1,40 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils import ConnectionType
+
+class TestSkyWatcherAudit(unittest.TestCase):
+    def test_traditional_dob_6_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Traditional_Dob_6()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Traditional Dob 6\"")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 153)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 34.5)
+        self.assertEqual(scope.mass.to('gram').magnitude, 5900)
+
+    def test_traditional_dob_8_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Traditional_Dob_8()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Traditional Dob 8\"")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 47)
+        self.assertEqual(scope.mass.to('gram').magnitude, 11000)
+
+    def test_skyliner_300p_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Skyliner_300P()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Skyliner 300P")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 305)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1500)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 70)
+        self.assertEqual(scope.mass.to('gram').magnitude, 21000)
+
+    def test_virtuoso_gti_150p_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Virtuoso_GTi_150P()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Virtuoso GTi 150P")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 150)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 750)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 48)
+        self.assertEqual(scope.mass.to('gram').magnitude, 4800)
+        self.assertEqual(scope.connection_type, ConnectionType.F_1_25)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audit and correction of Sky-Watcher Traditional Dob and Skyliner telescope specifications to match official manufacturer documentation. Key corrections include aperture, central obstruction, mass, and connection types. Added verification unit tests and source documentation comments.

---
*PR created automatically by Jules for task [16942419449368676791](https://jules.google.com/task/16942419449368676791) started by @pozar87*