### PR TITLE
Implement twilight fallback for high-latitude observations

### DIFF
--- a/apts/observations/base.py
+++ b/apts/observations/base.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 from skyfield.api import Time
 
 from ..conditions import Conditions
+from ..constants.twilight import Twilight
 from .catalogs import CatalogMixIn
 from .events import EventsMixIn
 from .html import HtmlExportMixIn
@@ -54,6 +55,25 @@ class Observation(
         else:
             self._init_window_legacy()
 
+        # Fallback for effective_date if it couldn't be determined (e.g. polar day/night)
+        if self.effective_date is None:
+            if target_date:
+                if isinstance(target_date, datetime):
+                    self.effective_date = self.place.ts.utc(target_date)
+                else:
+                    self.effective_date = self.place.ts.utc(
+                        datetime.combine(target_date, datetime.min.time()).replace(
+                            tzinfo=self.place.local_timezone
+                        )
+                    )
+            else:
+                self.effective_date = self.place.date
+
+        if self.observation_local_time is None:
+            self.observation_local_time = self.effective_date.astimezone(
+                self.place.local_timezone
+            )
+
         # Normalize start and stop dates for the observation window
         if self.start is not None and self.stop is not None:
             self.start, self.stop = self._normalize_window(
@@ -81,26 +101,60 @@ class Observation(
             start_time  # Use start_time as local observation time
         )
 
+    def _find_best_observation_window(self, target_date=None):
+        """
+        Attempts to find sunset and sunrise times using the requested twilight.
+        If the requested twilight is not reached (common at high latitudes),
+        it falls back to less strict twilights.
+        """
+        requested_twilight = self.conditions.twilight
+
+        # Define the priority of twilights (strictest to least strict)
+        twilight_priority = [
+            Twilight.ASTRONOMICAL,
+            Twilight.NAUTICAL,
+            Twilight.CIVIL,
+            None,  # Actual sunset/sunrise
+        ]
+
+        # Find where to start based on requested twilight
+        try:
+            start_idx = twilight_priority.index(requested_twilight)
+        except ValueError:
+            # Fallback if somehow an unknown twilight is passed
+            start_idx = 0
+
+        for i in range(start_idx, len(twilight_priority)):
+            twilight = twilight_priority[i]
+            start = self.place.sunset_time(target_date=target_date, twilight=twilight)
+            if start:
+                stop = self.place.sunrise_time(
+                    start_search_from=start, twilight=twilight
+                )
+                if stop:
+                    if twilight != requested_twilight:
+                        logger.warning(
+                            f"Could not determine observation window for {self.place.name} "
+                            f"with requested twilight '{requested_twilight.value}'. "
+                            f"Falling back to '{twilight.value if twilight else 'sunset/sunrise'}'. "
+                        )
+                    return start, stop
+        return None, None
+
     def _init_window_from_target_date(self, target_date):
         if self.sun_observation:
             self.start = self.place.sunrise_time(target_date=target_date)
             self.stop = self.place.sunset_time(target_date=target_date)
         else:
-            self.start = self.place.sunset_time(
-                target_date=target_date, twilight=self.conditions.twilight
+            self.start, self.stop = self._find_best_observation_window(
+                target_date=target_date
             )
-            if self.start:
-                self.stop = self.place.sunrise_time(
-                    start_search_from=self.start, twilight=self.conditions.twilight
-                )
-            else:
-                self.stop = None
 
         if self.start is None or self.stop is None:
             logger.warning(
                 f"Could not determine observation window for {self.place.name} "
-                f"on {target_date} with twilight '{self.conditions.twilight.value}'. "
-                "Sun may be always up or down."
+                f"on {target_date} with twilight '{self.conditions.twilight.value}' "
+                "or any less strict twilights. Sun may be always up or down."
             )
         else:
             if self.conditions.start_time:
@@ -132,19 +186,20 @@ class Observation(
 
     def _init_window_legacy(self):
         # Legacy behavior: use place.date
-        self.effective_date = self.place.date
         if self.sun_observation:
             self.start = self.place.sunrise_time()
             self.stop = self.place.sunset_time()
         else:
-            self.start = self.place.sunset_time(twilight=self.conditions.twilight)
-            if self.start:
-                self.stop = self.place.sunrise_time(
-                    start_search_from=self.start, twilight=self.conditions.twilight
-                )
-            else:
-                self.stop = None
-        self.observation_local_time = self.start
+            self.start, self.stop = self._find_best_observation_window()
+
+        if self.start:
+            self.effective_date = self.place.ts.utc(self.start)
+            self.observation_local_time = self.start
+        else:
+            self.effective_date = self.place.date
+            self.observation_local_time = self.effective_date.astimezone(
+                self.place.local_timezone
+            )
 
     def _normalize_window(self, start, stop):
         # If the stop time is earlier than the start time, it means the observation

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -191,6 +191,70 @@ class TestObservationInitialization(unittest.TestCase):
         self.assertEqual(observation.time_limit, observation.stop)
 
 
+class TestObservationTwilightFallback(unittest.TestCase):
+    def setUp(self):
+        self.place = MagicMock()
+        self.place.name = "High Lat Place"
+        self.place.local_timezone = datetime.timezone.utc
+        self.place.ts = MagicMock()
+        self.place.ts.utc.side_effect = lambda dt: dt
+        self.equipment = MagicMock()
+        self.target_date = datetime.date(2025, 6, 21)
+
+    def test_fallback_mechanism(self):
+        """Test that observation falls back to less strict twilights."""
+        # Arrange: simulate Astronomical and Nautical not reached, but Civil reached.
+        def side_effect(target_date=None, start_search_from=None, twilight=None, horizon_degrees=-0.8333):
+            if twilight == Twilight.ASTRONOMICAL:
+                return None
+            if twilight == Twilight.NAUTICAL:
+                return None
+            if twilight == Twilight.CIVIL:
+                if "rise" in str(self.place.sunrise_time.call_args) or (start_search_from and "rise" in str(self.place.sunrise_time.call_args)): # This is a bit hacky due to how MagicMock records calls
+                     return pd.Timestamp("2025-06-22 02:00:00", tz="UTC")
+                return pd.Timestamp("2025-06-21 22:00:00", tz="UTC")
+            return pd.Timestamp("2025-06-21 20:00:00", tz="UTC")
+
+        self.place.sunset_time.side_effect = [None, None, pd.Timestamp("2025-06-21 22:00:00", tz="UTC")]
+        self.place.sunrise_time.side_effect = [pd.Timestamp("2025-06-22 02:00:00", tz="UTC")]
+
+        conditions = Conditions(twilight=Twilight.ASTRONOMICAL)
+
+        # Act
+        observation = Observation(
+            place=self.place,
+            equipment=self.equipment,
+            conditions=conditions,
+            target_date=self.target_date,
+        )
+
+        # Assert
+        self.assertEqual(observation.start, pd.Timestamp("2025-06-21 22:00:00", tz="UTC"))
+        self.assertEqual(observation.stop, pd.Timestamp("2025-06-22 02:00:00", tz="UTC"))
+        # Verify fallback occurred (Astronomical -> Nautical -> Civil)
+        self.assertEqual(self.place.sunset_time.call_count, 3)
+
+    def test_effective_date_set_when_no_window(self):
+        """Test that effective_date is set even if no twilight window is found."""
+        # Arrange: simulate all twilights returning None (polar day)
+        self.place.sunset_time.return_value = None
+        conditions = Conditions(twilight=Twilight.ASTRONOMICAL)
+
+        # Act
+        observation = Observation(
+            place=self.place,
+            equipment=self.equipment,
+            conditions=conditions,
+            target_date=self.target_date,
+        )
+
+        # Assert
+        self.assertIsNone(observation.start)
+        self.assertIsNone(observation.stop)
+        self.assertIsNotNone(observation.effective_date)
+        self.assertIsNotNone(observation.observation_local_time)
+
+
 class TestObservationTemplate(unittest.TestCase):
     def setUp(self):
         # Start patcher to avoid Redis connection errors in CI


### PR DESCRIPTION
I noticed a problem where users at high latitudes might never experience a specific twilight level (like nautical) during summer months, leading to a failure to determine an observation window.

I've implemented a fallback mechanism in the `Observation` class. If the requested twilight level isn't reached, it will automatically try less strict levels (Astronomical -> Nautical -> Civil -> Sunset/Sunrise) until a window is found.

Additionally, I ensured that `effective_date` and `observation_local_time` are always set to a sensible value (midnight of the target date) even if no sunset/sunrise occurs at all (polar day/night). This allows other astronomical calculations that depend on these dates to proceed.

I've also added comprehensive unit tests to `tests/unit/test_observations.py` covering these scenarios.

---
*PR created automatically by Jules for task [10615691542867616486](https://jules.google.com/task/10615691542867616486) started by @pozar87*