### PR TITLE
🔍 Optic: Data audit for SVBony SV503 102ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/svbony.py
+++ b/apts/opticalequipment/telescope/vendors/svbony.py
@@ -54,17 +54,18 @@ class SvbonyTelescope(Telescope):
             "brand": "SVBony",
             "name": "SV503 102ED",
             "type": "type_refractor",
-            "optical_length": 0,
-            "mass": 4000,
+            "optical_length": 101.9, # Verified via Svbony (Back Focus Length)
+            "mass": 5700, # Verified via Svbony (Tube weight with rings)
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"",
+            "cside_gender": "Female",
             "reversible": False,
-            "bf_role": "",
+            "bf_role": "start",
             "aperture_mm": 102,
             "focal_length_mm": 714,
             "central_obstruction_mm": 0,
+            # Source: https://www.svbony.com/products/sv503-102f7-ed-doublet-refractor
         },
         "SVBony_SV550_80ED": {
             "brand": "SVBony",

--- a/tests/unit/test_svbony_specs.py
+++ b/tests/unit/test_svbony_specs.py
@@ -25,7 +25,18 @@ def test_sv503_102ed_specs():
     telescope = SvbonyTelescope.SVBony_SV503_102ED()
     assert telescope.aperture.magnitude == 102
     assert telescope.focal_length.magnitude == 714
-    assert telescope.mass.magnitude == 4000
+    assert telescope.mass.magnitude == 5700
+    assert telescope.central_obstruction.magnitude == 0
+    assert telescope.optical_length.magnitude == 101.9
+    assert telescope.backfocus.magnitude == 101.9
+    assert telescope.connection_type.value == "2"
+    assert telescope.connection_gender.value == "F"
+
+def test_sv503_80_specs():
+    telescope = SvbonyTelescope.SVBony_SV503_80()
+    assert telescope.aperture.magnitude == 80
+    assert telescope.focal_length.magnitude == 560
+    assert telescope.mass.magnitude == 3000
     assert telescope.central_obstruction.magnitude == 0
 
 def test_sv550_60_specs():
@@ -63,9 +74,3 @@ def test_sv48p_102_specs():
     assert telescope.mass.magnitude == 3400
     assert telescope.central_obstruction.magnitude == 0
 
-def test_sv503_80_specs():
-    telescope = SvbonyTelescope.SVBony_SV503_80()
-    assert telescope.aperture.magnitude == 80
-    assert telescope.focal_length.magnitude == 560
-    assert telescope.mass.magnitude == 3000
-    assert telescope.central_obstruction.magnitude == 0


### PR DESCRIPTION
I have audited and corrected the specifications for the **SVBony SV503 102ED** refractor telescope in the `apts` database.

### Corrections made:
- **Mass:** Updated from 4000g to **5700g** (matching the official 5.7kg specification with rings).
- **Backfocus:** Set `optical_length` to **101.9mm** and `bf_role` to `'start'`, as documented by the manufacturer.
- **Connection:** Corrected `cside_thread` to **'2"'** and `cside_gender` to **'Female'**, which is the standard visual back for this telescope.
- **Documentation:** Added a source URL comment pointing to the official product page.

### Verification:
- Modified `tests/unit/test_svbony_specs.py` to assert these precise values.
- Ran the unit tests using `python3 -m pytest tests/unit/test_svbony_specs.py`, and all 10 tests passed.
- Verified object instantiation and property loading with a custom script.

I also ensured that no existing data was removed, preserving the integrity of other SVBony models in the database.

---
*PR created automatically by Jules for task [15188313016323030823](https://jules.google.com/task/15188313016323030823) started by @pozar87*