### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Esprit and Evostar series

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -139,7 +139,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 530,
-            "mass": 2920,
+            "mass": 2920,  # Verified via Sky-Watcher Global (2.92 kg OTA Weight)
             "name": "Evolux 82ED",
             "optical_length": 0,
             "reversible": False,
@@ -267,7 +267,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Male",
             "cside_thread": "M54",
             "focal_length_mm": 1050,
-            "mass": 15000,
+            "mass": 14520,  # Verified via Sky-Watcher Global (14.52 kg Tube Weight)
             "name": "Esprit 150ED",
             "optical_length": 0,
             "reversible": False,
@@ -379,7 +379,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Male",
             "cside_thread": "M48",
             "focal_length_mm": 420,
-            "mass": 1950,
+            "mass": 2000,  # Verified via Sky-Watcher Global (2.0 kg OTA Weight)
             "name": "Evostar 72ED",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_audit_v2.py
+++ b/tests/unit/test_sky_watcher_audit_v2.py
@@ -1,0 +1,17 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_esprit_150ed_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Esprit_150ED()
+    assert telescope.get_vendor() == "Sky-Watcher Esprit 150ED"
+    assert telescope.mass.magnitude == 14520
+
+def test_evostar_72ed_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Evostar_72ED()
+    assert telescope.get_vendor() == "Sky-Watcher Evostar 72ED"
+    assert telescope.mass.magnitude == 2000
+
+def test_evolux_82ed_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Evolux_82ED()
+    assert telescope.get_vendor() == "Sky-Watcher Evolux 82ED"
+    assert telescope.mass.magnitude == 2920

--- a/tests/unit/test_skywatcher_audit.py
+++ b/tests/unit/test_skywatcher_audit.py
@@ -23,7 +23,7 @@ def test_skywatcher_esprit_specs():
     esprit150 = Sky_watcherTelescope.Sky_Watcher_Esprit_150ED()
     assert esprit150.aperture.magnitude == 150
     assert esprit150.focal_length.magnitude == 1050
-    assert esprit150.mass.to('g').magnitude == 15000
+    assert esprit150.mass.to('g').magnitude == 14520
 
 def test_skywatcher_quattro_specs():
     # Quattro 150P

--- a/tests/unit/test_stellar_improvements_v4.py
+++ b/tests/unit/test_stellar_improvements_v4.py
@@ -59,17 +59,17 @@ class TestStellarImprovementsV4(unittest.TestCase):
         self.assertEqual(esprit100.focal_length.to("mm").magnitude, 550)
         self.assertEqual(esprit100.mass.to("gram").magnitude, 6300)
 
-        # Evostar 72ED: 72mm, 420mm, 1950g
+        # Evostar 72ED: 72mm, 420mm, 2000g
         evo72 = Sky_watcherTelescope.Sky_Watcher_Evostar_72ED()
         self.assertEqual(evo72.aperture.to("mm").magnitude, 72)
         self.assertEqual(evo72.focal_length.to("mm").magnitude, 420)
-        self.assertEqual(evo72.mass.to("gram").magnitude, 1950)
+        self.assertEqual(evo72.mass.to("gram").magnitude, 2000)
 
-        # Esprit 150ED: 150mm, 1050mm, 15000g
+        # Esprit 150ED: 150mm, 1050mm, 14520g
         esprit150 = Sky_watcherTelescope.Sky_Watcher_Esprit_150ED()
         self.assertEqual(esprit150.aperture.to("mm").magnitude, 150)
         self.assertEqual(esprit150.focal_length.to("mm").magnitude, 1050)
-        self.assertEqual(esprit150.mass.to("gram").magnitude, 15000)
+        self.assertEqual(esprit150.mass.to("gram").magnitude, 14520)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR audits and corrects the technical specifications for several Sky-Watcher telescope models in the `apts` database, specifically targeting the Esprit and Evostar series. Discrepancies in mass/weight were identified by cross-referencing official Sky-Watcher Global documentation and corrected to ensure high precision in astronomical calculations. Unit tests were added to validate the updated specifications.

---
*PR created automatically by Jules for task [17398231014123297612](https://jules.google.com/task/17398231014123297612) started by @pozar87*