### PR TITLE
🔍 Optic: Data audit for Askar FMA 180 Pro

### DIFF
--- a/apts/opticalequipment/telescope/vendors/askar.py
+++ b/apts/opticalequipment/telescope/vendors/askar.py
@@ -231,16 +231,17 @@ class AskarTelescope(Telescope):
             "name": "FMA 180 Pro",
             "type": "type_refractor",
             "optical_length": 0,
-            "mass": 395,
+            "mass": 800, # Verified via Sharpstar/Askar official specs (800g for Pro version)
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M42",
+            "cside_thread": "M48", # Verified via Sharpstar/Askar official specs (M48x0.75 male)
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
             "aperture_mm": 40,
             "focal_length_mm": 180,
             "central_obstruction_mm": 0,
+            # Source: https://www.sharpstar-optics.com/Products_1/69.html
         },
         "Askar_FMA_230": {
             "brand": "Askar",

--- a/tests/unit/test_askar_audit.py
+++ b/tests/unit/test_askar_audit.py
@@ -1,0 +1,16 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.askar import AskarTelescope
+from apts.utils import ConnectionType
+
+class TestAskarAudit(unittest.TestCase):
+    def test_fma180_pro_specs(self):
+        # Official specs: 40mm aperture, 180mm focal length, 800g mass, M48 camera thread
+        scope = AskarTelescope.Askar_FMA_180_Pro()
+        self.assertEqual(scope.aperture.to('mm').magnitude, 40)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 180)
+        self.assertEqual(scope.mass.to('gram').magnitude, 800)
+        self.assertEqual(scope.connection_type, ConnectionType.M48)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Corrected mass from 395g to 800g and camera-side thread from M42 to M48 for the Askar FMA 180 Pro telescope, following official manufacturer documentation. Added a unit test to verify the specifications.

---
*PR created automatically by Jules for task [2882643680811244250](https://jules.google.com/task/2882643680811244250) started by @pozar87*