### PR TITLE
🔍 Optic: Data audit for Takahashi FSQ-106ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/takahashi.py
+++ b/apts/opticalequipment/telescope/vendors/takahashi.py
@@ -21,16 +21,16 @@ class TakahashiTelescope(Telescope):
         },
         "Takahashi_FSQ_106ED": {
             "brand": "Takahashi",
-            "name": "FSQ-106ED",
+            "name": "FSQ-106EDX4",
             "type": "type_refractor",
-            "optical_length": 0,
-            "mass": 6800,
+            "optical_length": 178,  # Verified via Takahashi Europe (178mm metal back distance)
+            "mass": 7000,  # Verified via Takahashi Europe (7.0kg for EDX4 OTA)
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M82",
+            "cside_thread": "M92",  # Verified via Takahashi Europe (Oversized focuser for EDX4)
             "cside_gender": "Male",
             "reversible": False,
-            "bf_role": "",
+            "bf_role": "start",
             "aperture_mm": 106,
             "focal_length_mm": 530,
             "central_obstruction_mm": 0,

--- a/tests/unit/test_takahashi_fsq106_audit.py
+++ b/tests/unit/test_takahashi_fsq106_audit.py
@@ -1,0 +1,33 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.takahashi import TakahashiTelescope
+
+def test_takahashi_fsq106_specs():
+    """
+    Test the audited specifications for the Takahashi FSQ-106ED (EDX4).
+    """
+    telescope = TakahashiTelescope.Takahashi_FSQ_106ED()
+
+    # Assert mass (7000g = 7.0kg)
+    # Mass is stored as a Pint Quantity in grams
+    assert telescope.mass.magnitude == 7000
+    assert str(telescope.mass.units) == 'gram'
+
+    # Assert aperture and focal length
+    assert telescope.aperture.magnitude == 106
+    assert telescope.focal_length.magnitude == 530
+
+    # Assert focal ratio (f/5)
+    assert telescope.focal_ratio() == 5.0
+
+    # Assert backfocus (metal back distance)
+    # In the database it is stored as optical_length (178)
+    # and bf_role="start" means it is assigned to self.backfocus
+    assert telescope.backfocus.magnitude == 178
+    assert telescope.optical_length.magnitude == 178
+
+    # Assert connection type
+    from apts.utils import ConnectionType
+    assert telescope.connection_type == ConnectionType.M92
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/test_takahashi_specs.py
+++ b/tests/unit/test_takahashi_specs.py
@@ -15,7 +15,7 @@ class TestTakahashiSpecs(unittest.TestCase):
         telescope = TakahashiTelescope.Takahashi_FSQ_106ED()
         self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 106)
         self.assertEqual(telescope.focal_length.to(get_unit_registry().mm).magnitude, 530)
-        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 6800)
+        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 7000)
         self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 0)
         self.assertEqual(telescope.focal_ratio().magnitude, 5.0)
 


### PR DESCRIPTION
This PR audits and corrects the specifications for the Takahashi FSQ-106ED telescope in the `apts` database. By cross-referencing official Takahashi Europe documentation, I have updated the entry to reflect the current FSQ-106EDX4 model, which includes a heavier OTA mass (7.0kg), a larger M92 focuser thread, and a defining 178mm metal back distance (backfocus). A new unit test ensures these values are correctly loaded and utilized by the library.

---
*PR created automatically by Jules for task [12646231667560160557](https://jules.google.com/task/12646231667560160557) started by @pozar87*