### PR TITLE
🔍 Optic: Data audit for Celestron NexStar 6SE

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -759,7 +759,7 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 6SE",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
+            "mass": 3629, # Verified via Celestron.com (8 lbs OTA weight - https://www.celestron.com/products/nexstar-6se-computerized-telescope)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",

--- a/tests/unit/test_celestron_c6_audit.py
+++ b/tests/unit/test_celestron_c6_audit.py
@@ -4,7 +4,7 @@ from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
 class TestCelestronC6Audit(unittest.TestCase):
     def test_nexstar_6se_mass(self):
         scope = CelestronTelescope.Celestron_NexStar_6SE()
-        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+        self.assertEqual(scope.mass.to('gram').magnitude, 3629)
 
     def test_advanced_vx_6_sct_mass(self):
         scope = CelestronTelescope.Celestron_Advanced_VX_6_SCT()


### PR DESCRIPTION
Audit and correction of the Celestron NexStar 6SE telescope specifications in the apts database.
- Corrected mass in `apts/opticalequipment/telescope/vendors/celestron.py` from 4536g to 3629g (8 lbs OTA weight).
- Added official source URL in code comment.
- Updated `tests/unit/test_celestron_c6_audit.py` to assert the correct 3629g mass.
- Verified aperture (150mm), focal length (1500mm), and central obstruction (56mm) against manufacturer specs.

---
*PR created automatically by Jules for task [13761444970938324096](https://jules.google.com/task/13761444970938324096) started by @pozar87*