### PR TITLE
🔍 Optic: Data audit for ZWO ASI174MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -422,13 +422,21 @@ class ZwoCamera(Camera):
             "brand": "ZWO",
             "cside_gender": "",
             "cside_thread": "",
-            "mass": 60,
+            "full_well_e": 32000,
+            "height": 1216,
+            "mass": 140,  # Verified via official ZWO manual (0.14kg)
             "name": "ASI174MC",
             "optical_length": 6.5,
+            "pixel_size_um": 5.86,
+            "quantum_efficiency_pct": 77,
+            "read_noise_e": 3.5,
             "reversible": False,
+            "sensor_height_mm": 7.1,
+            "sensor_width_mm": 11.3,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",  # Standard for uncooled ASI pancake cameras
             "type": "type_camera",
+            "width": 1936,
         },
         "ZWO_ASI_174MC_Mini": {
             "bf_role": "end",

--- a/tests/unit/test_asi174mc_audit.py
+++ b/tests/unit/test_asi174mc_audit.py
@@ -1,0 +1,36 @@
+import pytest
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.units import get_unit_registry
+from apts.utils import ConnectionType, Gender
+
+def test_asi174mc_audit():
+    # Instantiate the audited camera
+    cam = ZwoCamera.ZWO_ASI_174MC()
+    ureg = get_unit_registry()
+
+    # Verify physical specs
+    assert cam.vendor == "ZWO ASI174MC"
+    assert cam.mass.to(ureg.g).magnitude == 140
+
+    # Verify sensor dimensions
+    assert cam.sensor_width.to(ureg.mm).magnitude == 11.3
+    assert cam.sensor_height.to(ureg.mm).magnitude == 7.1
+
+    # Verify resolution
+    assert cam.width == 1936
+    assert cam.height == 1216
+
+    # Verify pixel size
+    assert cam.pixel_size().to(ureg.micrometer).magnitude == pytest.approx(5.86, rel=1e-3)
+
+    # Verify performance specs
+    assert cam.full_well == 32000
+    assert cam.read_noise == 3.5
+    assert cam.quantum_efficiency == 77
+
+    # Verify connection
+    assert cam.connection_type == ConnectionType.CS
+    assert cam.connection_gender == Gender.FEMALE
+
+    # Verify optical length
+    assert cam.optical_length.to(ureg.mm).magnitude == 6.5


### PR DESCRIPTION
I have audited the specifications for the **ZWO ASI174MC (uncooled)** camera in the `apts` database. 

Key corrections and additions in `apts/opticalequipment/camera/vendors/zwo.py`:
- **Mass:** Corrected from 60g (incorrect placeholder) to 140g.
- **Sensor Specs:** Added missing resolution (1936x1216), pixel size (5.86µm), sensor dimensions (11.3mm x 7.1mm), full well (32000e), read noise (3.5e), and quantum efficiency (77%).
- **Connection:** Updated `tside_thread` to "CS" to align with the uncooled "pancake" body standard and the monochrome counterpart (ASI174MM).

I also added a new unit test `tests/unit/test_asi174mc_audit.py` to verify these audited specifications and ensure they are correctly loaded by the library. Existing hardware tests for ZWO models were also verified.

---
*PR created automatically by Jules for task [17946627241805851305](https://jules.google.com/task/17946627241805851305) started by @pozar87*