### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Explorer 150P

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -459,7 +459,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Female",
             "cside_thread": "1.25\"",
             "focal_length_mm": 750,
-            "mass": 5900,
+            "mass": 4930,  # Verified via Sky-Watcher Global and Wex Photo Video (4.93 kg OTA weight)
             "name": "Explorer 150P",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -207,6 +207,14 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
         self.assertEqual(scope.mass.to('gram').magnitude, 2600)
 
+    def test_explorer_150p_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Explorer_150P()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Explorer 150P")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 150)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 750)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 47)
+        self.assertEqual(scope.mass.to('gram').magnitude, 4930)
+
     def test_evostar_150ed_specs(self):
         scope = Sky_watcherTelescope.Sky_Watcher_Evostar_150ED()
         self.assertEqual(scope.mass.to('gram').magnitude, 9500)


### PR DESCRIPTION
Audited and corrected the technical specifications for the Sky-Watcher Explorer 150P telescope. The mass was updated from 5900g to 4930g to align with official manufacturer documentation for the BKP1507 OTA. Added a specific unit test in `tests/unit/test_sky_watcher_specs.py` to ensure data integrity.

---
*PR created automatically by Jules for task [9691332644989432802](https://jules.google.com/task/9691332644989432802) started by @pozar87*