### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Quattro 300P

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -763,7 +763,7 @@ class Sky_watcherTelescope(Telescope):
             "cside_gender": "Male",
             "cside_thread": "M48",
             "focal_length_mm": 1200,
-            "mass": 23000,
+            "mass": 21800,  # Verified via Altair Astro technical specs (21.8 kg Tube Weight - https://altairastro.com/sky-watcher-quattro-300p-512-p.asp)
             "name": "Quattro 300P",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_quattro_300p_audit.py
+++ b/tests/unit/test_sky_watcher_quattro_300p_audit.py
@@ -1,0 +1,11 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_sky_watcher_quattro_300p_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Quattro_300P()
+    assert telescope.get_vendor() == "Sky-Watcher Quattro 300P"
+    assert telescope.aperture.magnitude == 305
+    assert telescope.focal_length.magnitude == 1200
+    assert telescope.mass.magnitude == 21800 # Corrected to 21.8 kg per Altair Astro technical specs
+    assert telescope.central_obstruction.magnitude == 102
+    assert telescope.focal_ratio().magnitude == 1200 / 305

--- a/tests/unit/test_skywatcher_audit.py
+++ b/tests/unit/test_skywatcher_audit.py
@@ -51,5 +51,5 @@ def test_skywatcher_quattro_specs():
     q300 = Sky_watcherTelescope.Sky_Watcher_Quattro_300P()
     assert q300.aperture.magnitude == 305
     assert q300.focal_length.magnitude == 1200
-    assert q300.mass.to('g').magnitude == 23000
+    assert q300.mass.to('g').magnitude == 21800
     assert q300.central_obstruction.magnitude == 102


### PR DESCRIPTION
This PR audits and corrects the technical specifications for the Sky-Watcher Quattro 300P (12" f/4 Imaging Newtonian) in the `apts` database.

### Changes:
- Updated the `mass` value for `Sky_Watcher_Quattro_300P` in `apts/opticalequipment/telescope/vendors/sky_watcher.py` from `23000` to `21800` (21.8 kg) based on official technical documentation from Altair Astro and Harrison Telescopes.
- Added a verification comment with the source URL to the telescope entry.
- Implemented a new validation test suite `tests/unit/test_sky_watcher_quattro_300p_audit.py` to ensure the corrected data is accurate and correctly loaded.

### Verification:
- Ran `pytest tests/unit/test_sky_watcher_quattro_300p_audit.py tests/unit/test_sky_watcher_specs.py`.
- All 30 tests passed.
- Calculated focal ratio in the test matches the expected physical ratio ($1200 / 305 \approx 3.93$).

---
*PR created automatically by Jules for task [13590857278431059189](https://jules.google.com/task/13590857278431059189) started by @pozar87*