### PR TITLE
Support NGC/IC objects in Observation framework

### DIFF
--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -29,6 +29,7 @@ class NGC(Objects):
         sort_by=ObjectTableLabels.TRANSIT,
         star_magnitude_limit=None,
         limiting_magnitude=None,
+        exclude_messier=True,
         **kwargs,
     ) -> pd.DataFrame:
         # Override get_visible to lazily restore skyfield objects BEFORE
@@ -56,6 +57,9 @@ class NGC(Objects):
         )
 
         candidate_mask = self.objects["Magnitude_float"] < max_mag
+
+        if exclude_messier and "M" in self.objects.columns:
+            candidate_mask &= self.objects["M"].isna()
 
         # 2. Restore skyfield_objects for candidates only
         if "skyfield_object" not in self.objects.columns:

--- a/apts/observations/catalogs.py
+++ b/apts/observations/catalogs.py
@@ -103,14 +103,29 @@ class CatalogMixIn:
                 ).astype("string")
             return visible
 
-    def get_visible_ngc(self, **args) -> pd.DataFrame:
-        return self.local_ngc.get_visible(
-            self.conditions,
-            self.start,
-            self.time_limit,
-            limiting_magnitude=self.limiting_magnitude,
-            **args,
-        )
+    def get_visible_ngc(
+        self, language: Optional[str] = None, **args
+    ) -> pd.DataFrame:
+        with language_context(language):
+            from ..i18n import bulk_gettext
+
+            visible = self.local_ngc.get_visible(
+                self.conditions,
+                self.start,
+                self.time_limit,
+                limiting_magnitude=self.limiting_magnitude,
+                **args,
+            )
+            # Optimization: use bulk_gettext (unique value mapping) instead of .apply(gettext_)
+            if "Type" in visible.columns:
+                visible["Type"] = cast(pd.Series, bulk_gettext(visible["Type"])).astype(
+                    "string"
+                )
+            if "Constellation" in visible.columns:
+                visible["Constellation"] = cast(
+                    pd.Series, bulk_gettext(visible["Constellation"])
+                ).astype("string")
+            return visible
 
     def get_visible_planets(
         self, language: Optional[str] = None, **args

--- a/apts/observations/html.py
+++ b/apts/observations/html.py
@@ -33,6 +33,7 @@ class HtmlExportMixIn:
         def get_hourly_weather_analysis(self, language: Optional[str] = None) -> List[dict]: ...
         def get_visible_planets(self, language: Optional[str] = None) -> pd.DataFrame: ...
         def get_visible_messier(self, language: Optional[str] = None) -> pd.DataFrame: ...
+        def get_visible_ngc(self, language: Optional[str] = None) -> pd.DataFrame: ...
 
     def to_html(
         self,
@@ -99,6 +100,7 @@ class HtmlExportMixIn:
 
         visible_planets_df = self.get_visible_planets(language=language)
         messier_df = self.get_visible_messier(language=language)
+        ngc_df = self.get_visible_ngc(language=language)
 
         return {
             "title": "APTS",
@@ -106,10 +108,23 @@ class HtmlExportMixIn:
             "stop": Utils.format_date(self.stop),
             "planets_count": len(visible_planets_df),
             "messier_count": len(messier_df),
+            "ngc_count": len(ngc_df),
             "planets_table": visible_planets_df.drop(columns=["TechnicalName"]).to_html()
             if "TechnicalName" in visible_planets_df.columns
             else visible_planets_df.to_html(),
             "messier_table": messier_df.to_html(),
+            "ngc_table": ngc_df.drop(
+                columns=[
+                    "ra_hours",
+                    "dec_degrees",
+                    "skyfield_object",
+                    "NGC_norm",
+                    "IC_norm",
+                    "Name_norm",
+                    "Magnitude_float",
+                ],
+                errors="ignore",
+            ).to_html(),
             "equipment_table": self.equipment.data().to_html(),
             "place_name": html.escape(self.place.name),
             "lat": np.rad2deg(self.place.lat),

--- a/apts/observations/plotting/celestial.py
+++ b/apts/observations/plotting/celestial.py
@@ -45,6 +45,15 @@ class CelestialPlottingMixIn:
         with language_context(language):
             return self.plot.messier(dark_mode_override=dark_mode_override, **args)
 
+    def plot_ngc(
+        self,
+        dark_mode_override: Optional[bool] = None,
+        language: Optional[str] = None,
+        **args,
+    ):
+        with language_context(language):
+            return self.plot.ngc(dark_mode_override=dark_mode_override, **args)
+
     def plot_planets(
         self,
         dark_mode_override: Optional[bool] = None,

--- a/apts/plotting/altitude/__init__.py
+++ b/apts/plotting/altitude/__init__.py
@@ -1,4 +1,5 @@
 from .messier import generate_plot_messier
 from .planets import generate_plot_planets
+from .ngc import generate_plot_ngc
 
-__all__ = ["generate_plot_messier", "generate_plot_planets"]
+__all__ = ["generate_plot_messier", "generate_plot_planets", "generate_plot_ngc"]

--- a/apts/plotting/altitude/ngc.py
+++ b/apts/plotting/altitude/ngc.py
@@ -1,0 +1,222 @@
+import logging
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+import pandas as pd
+from matplotlib import lines, pyplot
+
+from apts.config import get_dark_mode
+from apts.constants.graphconstants import (
+    get_messier_color,
+    get_plot_style,
+)
+from apts.i18n import gettext_
+from apts.plotting.utils import mark_good_conditions, mark_observation
+from apts.utils.plot import PlotUtils
+from ...constants import ObjectTableLabels
+
+if TYPE_CHECKING:
+    from apts.observations import Observation
+
+logger = logging.getLogger(__name__)
+
+
+def generate_plot_ngc(
+    observation: "Observation", dark_mode_override: Optional[bool] = None, **args
+):
+    if dark_mode_override is not None:
+        effective_dark_mode = dark_mode_override
+    else:
+        effective_dark_mode = get_dark_mode()
+
+    style = get_plot_style(effective_dark_mode)
+
+    ax = args.pop("ax", None)
+    fig = None
+    if ax:
+        fig = ax.figure
+    else:
+        fig, ax = pyplot.subplots(figsize=(18, 12), **args)
+
+    fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+    ax.set_facecolor(style["AXES_FACE_COLOR"])
+
+    try:
+        # Use get_visible_ngc from observation
+        ngc_df = observation.get_visible_ngc().copy()
+
+        if len(ngc_df) == 0:
+            return _generate_empty_ngc_plot(
+                observation, fig, ax, effective_dark_mode, style
+            )
+
+        # Vectorized property extraction to avoid slow iterrows()
+        # Ensure numeric columns are floats to avoid Pint/Quantity overhead
+        for col in [
+            ObjectTableLabels.ALTITUDE,
+            ObjectTableLabels.SIZE_MAJOR,
+            ObjectTableLabels.SIZE_MINOR,
+        ]:
+            if col in ngc_df.columns:
+                ngc_df[col] = [
+                    getattr(x, "magnitude", x) for x in ngc_df[col].values
+                ]
+
+        # Vectorized marker size: marker area (s) as width * height
+        ngc_df["marker_size"] = (
+            ngc_df[ObjectTableLabels.SIZE_MAJOR]
+            * ngc_df[ObjectTableLabels.SIZE_MINOR]
+        ).clip(lower=10) # Ensure markers are visible
+
+        # Determine colors
+        # Type is already translated in get_visible_ngc
+        types = (
+            ngc_df["Type"].fillna("Other")
+            if "Type" in ngc_df.columns
+            else pd.Series("Other", index=ngc_df.index)
+        )
+        ngc_df["color"] = [
+            get_messier_color(t, effective_dark_mode)
+            for t in types
+        ]
+
+        # Filter out objects without a valid transit time in the window
+        plot_df = ngc_df[ngc_df[ObjectTableLabels.TRANSIT].notna()].copy()
+
+        plotted_types = {}
+        if not plot_df.empty:
+            # Single vectorized scatter call for all objects
+            ax.scatter(
+                plot_df[ObjectTableLabels.TRANSIT],
+                plot_df[ObjectTableLabels.ALTITUDE],
+                s=plot_df["marker_size"],
+                marker="o",
+                c=plot_df["color"],
+                alpha=0.7
+            )
+
+            # Annotation loop optimized to avoid iterrows()
+            # Use Name column for annotation
+            for text, x, y in zip(
+                plot_df["Name"],
+                plot_df[ObjectTableLabels.TRANSIT],
+                plot_df[ObjectTableLabels.ALTITUDE],
+            ):
+                ax.annotate(
+                    text,
+                    (x, y),
+                    xytext=(5, 5),
+                    textcoords="offset points",
+                    color=style["TEXT_COLOR"],
+                    fontsize=8,
+                    alpha=0.8
+                )
+
+            # Collect unique types for legend
+            unique_rows = cast(Any, plot_df).drop_duplicates(subset=["Type"])
+            plotted_types = dict(
+                zip(unique_rows["Type"], unique_rows["color"])
+            )
+
+        if observation.start is not None and observation.time_limit is not None:
+            ax.set_xlim(
+                [
+                    observation.start - timedelta(minutes=15),
+                    observation.time_limit + timedelta(minutes=15),
+                ]
+            )
+        ax.set_ylim(0, 90)
+        mark_observation(observation, ax, effective_dark_mode, style)
+        mark_good_conditions(
+            observation,
+            ax,
+            observation.conditions.min_object_altitude,
+            90,
+            effective_dark_mode,
+            style,
+        )
+        PlotUtils.annotate_plot(
+            ax,
+            gettext_("Altitude [°]"),
+            effective_dark_mode,
+            observation.place.local_timezone,
+        )
+
+        _add_ngc_legend(ax, plotted_types, style)
+
+        ax.set_title(gettext_("NGC/IC Objects Altitude"), color=style["TEXT_COLOR"])
+        logger.info(gettext_("Successfully generated NGC plot."))
+        return fig
+
+    except Exception as e:
+        return _handle_ngc_plot_error(fig, ax, e, effective_dark_mode, style)
+
+
+def _generate_empty_ngc_plot(observation, fig, ax, effective_dark_mode, style):
+    if observation.start is not None and observation.time_limit is not None:
+        ax.set_xlim(
+            [
+                observation.start - timedelta(minutes=15),
+                observation.time_limit + timedelta(minutes=15),
+            ]
+        )
+    ax.set_ylim(0, 90)
+    mark_observation(observation, ax, effective_dark_mode, style)
+    mark_good_conditions(
+        observation,
+        ax,
+        observation.conditions.min_object_altitude,
+        90,
+        effective_dark_mode,
+        style,
+    )
+    PlotUtils.annotate_plot(
+        ax,
+        gettext_("Altitude [°]"),
+        effective_dark_mode,
+        observation.place.local_timezone,
+    )
+    ax.set_title(gettext_("NGC/IC Objects Altitude"), color=style["TEXT_COLOR"])
+    logger.info(gettext_("Generated empty NGC plot as no objects are visible."))
+    return fig
+
+
+def _add_ngc_legend(ax, plotted_types, style):
+    legend_handles = [
+        lines.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            label=obj_type,
+            markerfacecolor=color,
+            markersize=10,
+        )
+        for obj_type, color in plotted_types.items()
+    ]
+    ax.legend(handles=legend_handles, title=gettext_("Object Types"))
+    PlotUtils.style_legend(ax, style)
+
+
+def _handle_ngc_plot_error(fig, ax, e, effective_dark_mode, style):
+    logger.error(f"Error generating NGC plot: {e}", exc_info=True)
+    ax.clear()
+    fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
+    ax.set_facecolor(style["AXES_FACE_COLOR"])
+
+    error_text_color = "#FF6B6B" if effective_dark_mode else "red"
+    ax.text(
+        0.5,
+        0.5,
+        gettext_("Error generating NGC plot.\nSee logs for details."),
+        horizontalalignment="center",
+        verticalalignment="center",
+        fontsize=12,
+        color=error_text_color,
+        wrap=True,
+        transform=ax.transAxes,
+    )
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(gettext_("NGC Plot Error"), color=style["TEXT_COLOR"])
+    return fig

--- a/apts/plotting/dispatcher.py
+++ b/apts/plotting/dispatcher.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from .wrappers.objects import (
     plot_messier,
+    plot_ngc,
     plot_planets,
     plot_skymap,
     plot_visible_planets,
@@ -62,6 +63,9 @@ class Plotter:
 
     def messier(self, **args):
         return plot_messier(self.observation, **args)
+
+    def ngc(self, **args):
+        return plot_ngc(self.observation, **args)
 
     def planets(self, **args):
         return plot_planets(self.observation, **args)
@@ -134,6 +138,7 @@ __all__ = [
     "Plotter",
     "NullPlotter",
     "plot_messier",
+    "plot_ngc",
     "plot_planets",
     "plot_weather",
     "plot_clouds",

--- a/apts/plotting/wrappers/objects.py
+++ b/apts/plotting/wrappers/objects.py
@@ -13,6 +13,16 @@ def plot_messier(
     )
 
 
+def plot_ngc(
+    observation: "Observation", dark_mode_override: Optional[bool] = None, **args
+):
+    from ..altitude import generate_plot_ngc
+
+    return generate_plot_ngc(
+        observation, dark_mode_override=dark_mode_override, **args
+    )
+
+
 def plot_planets(
     observation: "Observation", dark_mode_override: Optional[bool] = None, **args
 ):

--- a/apts/templates/notification.html.template
+++ b/apts/templates/notification.html.template
@@ -60,7 +60,7 @@
             </tr>
             <tr>
           <td>Number of visiable objects</td>
-          <td>Solar Objects $planets_count, Messier: $messier_count</td>
+          <td>Solar Objects $planets_count, Messier: $messier_count, NGC: $ngc_count</td>
         </tr>
       </table>
     </div>
@@ -75,6 +75,10 @@
     <div>
       <h2>Messier</h2>
       $messier_table
+    </div>
+    <div>
+      <h2>NGC/IC</h2>
+      $ngc_table
     </div>
     <div>
       <h2>Equipment</h2>

--- a/tests/unit/test_ngc_new_features.py
+++ b/tests/unit/test_ngc_new_features.py
@@ -1,0 +1,52 @@
+
+import pytest
+from datetime import datetime, timezone
+from apts.place import Place
+from apts.equipment.base import Equipment
+from apts.observations.base import Observation
+from apts.conditions import Conditions
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+
+@pytest.fixture
+def observation():
+    place = Place(50.0647, 19.9450, "Krakow", 200)
+    telescope = Sky_watcherTelescope.Sky_Watcher_Explorer_150P()
+    camera = ZwoCamera.ZWO_ASI_178MM()
+    equipment = Equipment()
+    equipment.add_vertex("Telescope", telescope)
+    equipment.add_vertex("Camera", camera)
+    equipment.add_edge("Space", "Telescope")
+    equipment.add_edge("Telescope", "Camera")
+    conditions = Conditions()
+    target_date = datetime(2025, 5, 20, 22, 0, 0, tzinfo=timezone.utc)
+    return Observation(place, equipment, conditions, target_date=target_date)
+
+def test_ngc_support(observation):
+    # Test table support
+    ngc_df = observation.get_visible_ngc()
+    assert ngc_df is not None
+
+    # Test that M column exists and objects with it can be excluded
+    # NGC 224 is M31. Let's check if it's in the full list but not in the excluded list.
+    full_ngc = observation.get_visible_ngc(exclude_messier=False)
+    # We need to find NGC 224 index. In our catalog it's 'NGC0224'
+    m31_ngc = full_ngc[full_ngc['NGC'] == '0224']
+    if not m31_ngc.empty:
+        # It should NOT be in the default list
+        default_ngc = observation.get_visible_ngc(exclude_messier=True)
+        assert '0224' not in default_ngc['NGC'].values
+
+def test_ngc_plotting(observation):
+    import matplotlib.pyplot as plt
+    # Test that plot_ngc doesn't crash
+    fig = observation.plot_ngc()
+    assert fig is not None
+    plt.close(fig)
+
+def test_html_export(observation):
+    html = observation.to_html()
+    assert "NGC/IC" in html
+    assert "ngc_table" not in html # Should be substituted
+    assert "Number of visiable objects" in html
+    assert "NGC:" in html


### PR DESCRIPTION
NGC/IC objects are now supported in the same way as Messier and Solar objects within the Observation framework. This includes:
- Altitude plots for NGC/IC objects.
- Integration into the Plotter dispatcher.
- Inclusion in HTML observation reports.
- Automatic exclusion of Messier objects from NGC lists by default to avoid duplication (can be toggled via `exclude_messier` parameter).
- Polished HTML tables for NGC objects (hiding technical columns).
- New unit tests verifying these features.

---
*PR created automatically by Jules for task [14814804317852550813](https://jules.google.com/task/14814804317852550813) started by @pozar87*