### PR TITLE
🔍 Optic: Data audit for Celestron EdgeHD 8"

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -448,7 +448,7 @@ class CelestronTelescope(Telescope):
             "bf_role": "",
             "aperture_mm": 203.2,
             "focal_length_mm": 2032,
-            "central_obstruction_mm": 69,
+            "central_obstruction_mm": 64, # Verified via official Celestron documentation (64mm / 31% obstruction) - https://www.celestron.com/products/edgehd-8-optical-tube-assembly-cge-dovetail
         },
         "Celestron_C8_EdgeHD_OTA": {
             "brand": "Celestron",
@@ -464,7 +464,7 @@ class CelestronTelescope(Telescope):
             "bf_role": "",
             "aperture_mm": 203.2,
             "focal_length_mm": 2032,
-            "central_obstruction_mm": 69,
+            "central_obstruction_mm": 64, # Verified via official Celestron documentation (64mm / 31% obstruction) - https://www.celestron.com/products/edgehd-8-optical-tube-assembly-cge-dovetail
         },
         "Celestron_C8_OTA": {
             "brand": "Celestron",

--- a/tests/unit/test_celestron_c8_edgehd_audit.py
+++ b/tests/unit/test_celestron_c8_edgehd_audit.py
@@ -1,0 +1,26 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+class TestCelestronC8EdgeHDAudit(unittest.TestCase):
+    def test_c8_edgehd_specs(self):
+        scope = CelestronTelescope.Celestron_C8_EdgeHD()
+        self.assertEqual(scope.get_vendor(), "Celestron C8 EdgeHD")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203.2)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 2032)
+        # Expected corrected value
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 64)
+        self.assertEqual(scope.mass.to('gram').magnitude, 6350)
+        self.assertEqual(scope.focal_ratio().magnitude, 10.0)
+
+    def test_c8_edgehd_ota_specs(self):
+        scope = CelestronTelescope.Celestron_C8_EdgeHD_OTA()
+        self.assertEqual(scope.get_vendor(), "Celestron C8 EdgeHD OTA")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203.2)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 2032)
+        # Expected corrected value
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 64)
+        self.assertEqual(scope.mass.to('gram').magnitude, 6350)
+        self.assertEqual(scope.focal_ratio().magnitude, 10.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited and corrected the central obstruction specification for the Celestron EdgeHD 8" telescope. The previous value of 69mm was identified as incorrect/rounded; official manufacturer documentation specifies a 64mm obstruction (31% of the 203.2mm aperture).

Changes:
- Updated `central_obstruction_mm` to 64 in `apts/opticalequipment/telescope/vendors/celestron.py` for both standard and OTA entries.
- Added verification comments with source URLs.
- Implemented `tests/unit/test_celestron_c8_edgehd_audit.py` to ensure ongoing data integrity.
- Verified that all related tests pass.

---
*PR created automatically by Jules for task [1516091774217466629](https://jules.google.com/task/1516091774217466629) started by @pozar87*