### PR TITLE
Add horizontal and vertical flip options to Jovian moon plot

### DIFF
--- a/apts/observations/plotting/celestial.py
+++ b/apts/observations/plotting/celestial.py
@@ -78,12 +78,32 @@ class CelestialPlottingMixIn:
         self,
         plot_date: Optional[datetime] = None,
         dark_mode_override: Optional[bool] = None,
+        flip_horizontally: Optional[bool] = None,
+        flip_vertically: Optional[bool] = None,
         language: Optional[str] = None,
         **args,
     ):
+        """
+        Generates and displays a visualization of Jupiter and its Galilean moons.
+
+        Args:
+            plot_date (Optional[datetime]): The specific date and time for the visualization.
+            dark_mode_override (Optional[bool]): If set, overrides the system's dark mode setting.
+            flip_horizontally (Optional[bool]): If True, the plot's horizontal axis is inverted.
+            flip_vertically (Optional[bool]): If True, the plot's vertical axis is inverted.
+            language (Optional[str]): Language for translation.
+            **args: Additional keyword arguments to pass to the plotting function, including `equipment_id` and `zoom_arcmin`.
+
+        Returns:
+            A matplotlib Figure object.
+        """
         with language_context(language):
             return self.plot.jovian_moons(
-                plot_date=plot_date, dark_mode_override=dark_mode_override, **args
+                plot_date=plot_date,
+                dark_mode_override=dark_mode_override,
+                flip_horizontally=flip_horizontally,
+                flip_vertically=flip_vertically,
+                **args,
             )
 
     def plot_skymap(

--- a/apts/plotting/jovian_moons.py
+++ b/apts/plotting/jovian_moons.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional, cast
 
 import numpy as np
+import pandas as pd
 from matplotlib import figure, pyplot
 from matplotlib.patches import Circle, Ellipse
 
@@ -26,6 +27,8 @@ def generate_plot_jovian_moons(
     plot_date: Optional[datetime] = None,
     dark_mode_override: Optional[bool] = None,
     zoom_arcmin: float = 20.0,
+    flipped_horizontally: bool = False,
+    flipped_vertically: bool = False,
     **kwargs,
 ) -> figure.Figure:
     """
@@ -36,6 +39,8 @@ def generate_plot_jovian_moons(
         plot_date: Specific date/time for the visualization. Defaults to observation middle.
         dark_mode_override: Override for dark mode.
         zoom_arcmin: Field of view in arcminutes. Defaults to 20.0.
+        flipped_horizontally: Whether to flip the plot horizontally.
+        flipped_vertically: Whether to flip the plot vertically.
         **kwargs: Additional arguments for matplotlib (e.g., figsize).
 
     Returns:
@@ -161,6 +166,27 @@ def generate_plot_jovian_moons(
     ax.set_ylim(-limit, limit)
     ax.set_aspect("equal")
 
+    if flipped_horizontally:
+        ax.invert_xaxis()
+    if flipped_vertically:
+        ax.invert_yaxis()
+
+    if flipped_horizontally or flipped_vertically:
+        flip_str = gettext_("Flipped") + " "
+        if flipped_horizontally:
+            flip_str += "H"
+        if flipped_vertically:
+            flip_str += "V"
+        ax.text(
+            0.05,
+            0.95,
+            flip_str,
+            transform=ax.transAxes,
+            fontsize=12,
+            verticalalignment="top",
+            color=style["TEXT_COLOR"],
+        )
+
     ax.set_xlabel(gettext_("Relative RA (arcsec)"), color=style["TEXT_COLOR"])
     ax.set_ylabel(gettext_("Relative Dec (arcsec)"), color=style["TEXT_COLOR"])
 
@@ -177,3 +203,55 @@ def generate_plot_jovian_moons(
         spine.set_color(style["AXES_EDGE_COLOR"])
 
     return fig
+
+
+def plot_jovian_moons(
+    observation: "Observation",
+    plot_date: Optional[datetime] = None,
+    dark_mode_override: Optional[bool] = None,
+    zoom_arcmin: float = 20.0,
+    equipment_id: Optional[int] = None,
+    flip_horizontally: Optional[bool] = None,
+    flip_vertically: Optional[bool] = None,
+    **kwargs,
+) -> figure.Figure:
+    """
+    High-level function to plot Jovian moons with support for flipping and equipment lookup.
+    """
+    flipped_horizontally = False
+    flipped_vertically = False
+
+    if equipment_id is not None:
+        # Check if equipment has data method, otherwise assume it's already a DataFrame
+        equipment_data = cast(
+            pd.DataFrame,
+            observation.equipment.data()
+            if hasattr(observation.equipment, "data")
+            else observation.equipment,
+        )
+        if (
+            equipment_data is not None
+            and not equipment_data.empty
+            and "ID" in equipment_data.columns
+            and equipment_id in equipment_data["ID"].values
+        ):
+            row = equipment_data.loc[equipment_data["ID"] == equipment_id]
+            if "Flipped Horizontally" in row.columns:
+                flipped_horizontally = row["Flipped Horizontally"].iloc[0]
+            if "Flipped Vertically" in row.columns:
+                flipped_vertically = row["Flipped Vertically"].iloc[0]
+
+    if flip_horizontally is not None:
+        flipped_horizontally = flip_horizontally
+    if flip_vertically is not None:
+        flipped_vertically = flip_vertically
+
+    return generate_plot_jovian_moons(
+        observation,
+        plot_date=plot_date,
+        dark_mode_override=dark_mode_override,
+        zoom_arcmin=zoom_arcmin,
+        flipped_horizontally=flipped_horizontally,
+        flipped_vertically=flipped_vertically,
+        **kwargs,
+    )

--- a/apts/plotting/wrappers/objects.py
+++ b/apts/plotting/wrappers/objects.py
@@ -71,8 +71,8 @@ def plot_sun_and_moon_path(
 def plot_jovian_moons(
     observation: "Observation", dark_mode_override: Optional[bool] = None, **args
 ):
-    from ..jovian_moons import generate_plot_jovian_moons
+    from ..jovian_moons import plot_jovian_moons as base_plot_jovian_moons
 
-    return generate_plot_jovian_moons(
+    return base_plot_jovian_moons(
         observation, dark_mode_override=dark_mode_override, **args
     )

--- a/tests/plotting/test_plot_jovian_moons.py
+++ b/tests/plotting/test_plot_jovian_moons.py
@@ -1,0 +1,110 @@
+import matplotlib
+matplotlib.use("Agg")
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+import pytz
+import numpy as np
+
+from apts.plotting.jovian_moons import generate_plot_jovian_moons, plot_jovian_moons
+from apts.observations import Observation
+from apts.place import Place
+from apts.equipment import Equipment
+from skyfield.api import load
+
+@pytest.fixture
+def mock_observation():
+    place = Place(lat=50.0, lon=20.0, elevation=200, name="Krakow")
+    equipment = Equipment()
+    observation = Observation(place=place, equipment=equipment)
+    # Use a real Time object from skyfield
+    ts = load.timescale()
+    observation.effective_date = ts.utc(2025, 2, 18)
+    return observation
+
+def test_generate_plot_jovian_moons_flipping(mock_observation):
+    with patch("apts.plotting.jovian_moons.pyplot.subplots") as mock_subplots:
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_subplots.return_value = (mock_fig, mock_ax)
+
+        # Mock other dependencies to avoid errors
+        with patch("apts.plotting.jovian_moons.get_jovian_ephemeris"), \
+             patch("apts.plotting.jovian_moons.JovianSearchContext") as mock_ctx_cls, \
+             patch("apts.plotting.jovian_moons.JovianMoonState"):
+
+            mock_ctx = mock_ctx_cls.return_value
+            mock_ctx.moon_map = {}
+            mock_ctx.jupiter = MagicMock()
+
+            # Mock the observer.at(t).observe(jupiter) chain
+            mock_j_obs = MagicMock()
+            mock_j_obs.radec.return_value = (MagicMock(radians=0), MagicMock(degrees=0), MagicMock(km=700000000))
+
+            # Since observer is an object, we need to mock its methods
+            mock_observer = MagicMock()
+            mock_observation.place.observer = mock_observer
+            mock_observer.at.return_value.observe.return_value.apparent.return_value = mock_j_obs
+
+            # 1. Test no flipping
+            generate_plot_jovian_moons(mock_observation, flipped_horizontally=False, flipped_vertically=False)
+            mock_ax.invert_xaxis.assert_not_called()
+            mock_ax.invert_yaxis.assert_not_called()
+
+            mock_ax.reset_mock()
+
+            # 2. Test horizontal flipping
+            generate_plot_jovian_moons(mock_observation, flipped_horizontally=True, flipped_vertically=False)
+            mock_ax.invert_xaxis.assert_called_once()
+            mock_ax.invert_yaxis.assert_not_called()
+
+            mock_ax.reset_mock()
+
+            # 3. Test vertical flipping
+            generate_plot_jovian_moons(mock_observation, flipped_horizontally=False, flipped_vertically=True)
+            mock_ax.invert_xaxis.assert_not_called()
+            mock_ax.invert_yaxis.assert_called_once()
+
+            mock_ax.reset_mock()
+
+            # 4. Test both flips
+            generate_plot_jovian_moons(mock_observation, flipped_horizontally=True, flipped_vertically=True)
+            mock_ax.invert_xaxis.assert_called_once()
+            mock_ax.invert_yaxis.assert_called_once()
+
+def test_plot_jovian_moons_equipment_detection(mock_observation):
+    # Mock equipment data
+    equipment_data = pd.DataFrame([
+        {"ID": 1, "Flipped Horizontally": True, "Flipped Vertically": False},
+        {"ID": 2, "Flipped Horizontally": False, "Flipped Vertically": True}
+    ])
+
+    with patch.object(mock_observation.equipment, "data", return_value=equipment_data), \
+         patch("apts.plotting.jovian_moons.generate_plot_jovian_moons") as mock_generate:
+
+        # 1. Detect ID 1
+        plot_jovian_moons(mock_observation, equipment_id=1)
+        args, kwargs = mock_generate.call_args
+        assert bool(kwargs["flipped_horizontally"]) == True
+        assert bool(kwargs["flipped_vertically"]) == False
+
+        # 2. Detect ID 2
+        plot_jovian_moons(mock_observation, equipment_id=2)
+        args, kwargs = mock_generate.call_args
+        assert bool(kwargs["flipped_horizontally"]) == False
+        assert bool(kwargs["flipped_vertically"]) == True
+
+        # 3. Explicit override should take precedence (flip_horizontally=False)
+        plot_jovian_moons(mock_observation, equipment_id=1, flip_horizontally=False)
+        args, kwargs = mock_generate.call_args
+        assert bool(kwargs["flipped_horizontally"]) == False
+        # Flipped Vertically should still be taken from equipment if not overridden,
+        # but here it is False in equipment ID 1 anyway.
+        assert bool(kwargs["flipped_vertically"]) == False
+
+        # 4. Explicit override should take precedence (flip_vertically=True)
+        plot_jovian_moons(mock_observation, equipment_id=1, flip_vertically=True)
+        args, kwargs = mock_generate.call_args
+        assert bool(kwargs["flipped_horizontally"]) == True
+        assert bool(kwargs["flipped_vertically"]) == True


### PR DESCRIPTION
This change introduces the ability to flip the Jovian moon visualization horizontally and vertically. This is particularly useful for simulating what will be seen through various telescope and eyepiece/diagonal configurations.

Key features:
1. **Manual Flipping**: Users can explicitly set `flip_horizontally` or `flip_vertically` when calling `plot_jovian_moons`.
2. **Automatic Detection**: If an `equipment_id` is provided, the function will automatically detect the correct orientation based on the equipment configuration (e.g., whether a star diagonal is used).
3. **Visual Feedback**: The plot now includes a text indicator (e.g., "Flipped H", "Flipped HV") when inversion is active.
4. **API Consistency**: The new arguments follow the pattern used in the `skymap` plotting functions.

Tests have been added to ensure that:
- Manual flips correctly invert the axes.
- Equipment-based detection correctly pulls flip settings from the equipment dataframe.
- Explicit manual overrides take precedence over equipment settings.

---
*PR created automatically by Jules for task [15950462788895776585](https://jules.google.com/task/15950462788895776585) started by @pozar87*