### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Traditional Dob 10"

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -1175,11 +1175,11 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 254,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 58,
+            "central_obstruction_mm": 64,  # Verified via Sky-Watcher USA (https://www.skywatcherusa.com/products/sky-watcher-classic-250p)
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 1200,
-            "mass": 12500,
+            "mass": 12700,  # Verified via Sky-Watcher USA (28 lbs OTA weight)
             "name": "Traditional Dob 10\"",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_10_inch_audit.py
+++ b/tests/unit/test_sky_watcher_10_inch_audit.py
@@ -1,0 +1,21 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+class TestSkyWatcher10InchAudit(unittest.TestCase):
+    def test_traditional_dob_10_audit(self):
+        # Verified via Sky-Watcher USA (https://www.skywatcherusa.com/products/sky-watcher-classic-250p)
+        scope = Sky_watcherTelescope.Sky_Watcher_Traditional_Dob_10()
+
+        # In current version of apts, vendor is set in from_database as f"{brand} {name}"
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Traditional Dob 10\"")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 254)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 64)
+        self.assertEqual(scope.mass.to('gram').magnitude, 12700)
+
+        # Verify focal ratio (1200 / 254 ≈ 4.724)
+        # In apts, focal_ratio is a method, not a property
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 4.7244, places=4)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR audits and corrects the specifications for the Sky-Watcher Traditional Dob 10" (Classic 250P) telescope.

Key changes:
- Corrected `central_obstruction_mm` from 58 to 64 (Verified via official documentation).
- Corrected `mass` from 12500g to 12700g (28 lbs OTA weight as specified by Sky-Watcher USA).
- Added source documentation in comments.
- Implemented a new validation test suite `tests/unit/test_sky_watcher_10_inch_audit.py` to ensure data integrity.

All relevant tests passed (44 total).

---
*PR created automatically by Jules for task [6402878198935215065](https://jules.google.com/task/6402878198935215065) started by @pozar87*