### PR TITLE
🔍 Optic: Data audit for Sky-Watcher SkyMax 180 Pro

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -679,7 +679,7 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 180,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 52,
+            "central_obstruction_mm": 41,  # Verified via Sky-Watcher USA and Astronomics (41mm secondary mirror)
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 2700,
@@ -855,7 +855,7 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 180,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 52,
+            "central_obstruction_mm": 41,  # Verified via Sky-Watcher USA and Astronomics (41mm secondary mirror)
             "cside_gender": "Male",
             "cside_thread": "SC (Schmidt-Cassegrain)",
             "focal_length_mm": 2700,

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -135,7 +135,7 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         self.assertEqual(scope.get_vendor(), "Sky-Watcher SkyMax 180 Pro")
         self.assertEqual(scope.aperture.to('mm').magnitude, 180)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 2700)
-        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 52)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 41)
         self.assertEqual(scope.mass.to('gram').magnitude, 7800)
 
     def test_star_discovery_150p_specs(self):

--- a/tests/unit/test_skymax_180_audit.py
+++ b/tests/unit/test_skymax_180_audit.py
@@ -1,0 +1,18 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_skymax_180_pro_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_SkyMax_180_Pro()
+    # Audited value: 41mm (approx 23% of 180mm aperture)
+    assert telescope.central_obstruction.magnitude == 41
+    assert telescope.mass.magnitude == 7800
+    assert telescope.aperture.magnitude == 180
+    assert telescope.focal_length.magnitude == 2700
+
+def test_mak_180_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Mak_180()
+    # Audited value: 41mm
+    assert telescope.central_obstruction.magnitude == 41
+    assert telescope.mass.magnitude == 7800
+    assert telescope.aperture.magnitude == 180
+    assert telescope.focal_length.magnitude == 2700


### PR DESCRIPTION
Audited and corrected technical specifications for the Sky-Watcher 180mm Maksutov-Cassegrain telescopes in the `apts` database. The central obstruction was updated from an incorrect/rounded 52mm to the manufacturer-specified 41mm. Verified changes through regression testing and a new dedicated audit test suite.

---
*PR created automatically by Jules for task [5351687812525799966](https://jules.google.com/task/5351687812525799966) started by @pozar87*