### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Explorer 130P

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -439,11 +439,11 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 130,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 34.5,
+            "central_obstruction_mm": 40,  # Verified via Sky-Watcher Global (Secondary Mirror Diameter 40mm) - http://skywatcher.com/product/p130neq2/
             "cside_gender": "Female",
             "cside_thread": "1.25\"",
             "focal_length_mm": 650,
-            "mass": 3660,
+            "mass": 3000,  # Verified via APM Telescopes (Tube Weight 3kg) - https://www.apm-telescopes.net/en/skywatcher-explorer-130p-eq-2-newtonian-reflector
             "name": "Explorer 130P",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_explorer_130p_specs.py
+++ b/tests/unit/test_explorer_130p_specs.py
@@ -7,8 +7,10 @@ class TestExplorer130P(unittest.TestCase):
         self.assertEqual(scope.get_vendor(), "Sky-Watcher Explorer 130P")
         self.assertEqual(scope.aperture.to('mm').magnitude, 130)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 650)
-        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 34.5)
-        self.assertEqual(scope.mass.to('gram').magnitude, 3660)
+        # Updated to 40mm
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 40)
+        # Updated to 3000g
+        self.assertEqual(scope.mass.to('gram').magnitude, 3000)
         self.assertEqual(scope.focal_ratio().magnitude, 650/130)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Audited and corrected the Sky-Watcher Explorer 130P entry in the telescope database.

Changes:
- Corrected `central_obstruction_mm` to 40mm based on official Sky-Watcher Global documentation for the 130mm f/5 Newtonian (P130NEQ2).
- Corrected `mass` to 3000g to align with official OTA weight specifications.
- Added source comments for data provenance.
- Updated the existing validation test `tests/unit/test_explorer_130p_specs.py` to reflect these accurate physical specifications.

This update ensures that optical calculations (like effective aperture and resolution) for this popular beginner telescope are based on precise hardware data.

---
*PR created automatically by Jules for task [8571951710143405659](https://jules.google.com/task/8571951710143405659) started by @pozar87*