### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Traditional Dob 8"

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -1220,14 +1220,14 @@ class Sky_watcherTelescope(Telescope):
             "type": "newtonian_reflector",
         },
         "Sky_Watcher_Traditional_Dob_8": {
-            "aperture_mm": 203,  # Verified via Sky-Watcher USA (8" = 203.2mm)
+            "aperture_mm": 203.2,  # Verified via Sky-Watcher USA (8" = 203.2mm) - https://www.skywatcherusa.com/products/sky-watcher-classic-200p
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 47,
+            "central_obstruction_mm": 48,  # Verified via Sky-Watcher Global/USA (Secondary Mirror Diameter 48mm)
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 1200,
-            "mass": 11000,
+            "mass": 9072,  # Verified via Sky-Watcher USA (20 lbs OTA weight)
             "name": "Traditional Dob 8\"",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_audit.py
+++ b/tests/unit/test_sky_watcher_audit.py
@@ -14,10 +14,10 @@ class TestSkyWatcherAudit(unittest.TestCase):
     def test_traditional_dob_8_specs(self):
         scope = Sky_watcherTelescope.Sky_Watcher_Traditional_Dob_8()
         self.assertEqual(scope.get_vendor(), "Sky-Watcher Traditional Dob 8\"")
-        self.assertEqual(scope.aperture.to('mm').magnitude, 203)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203.2)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
-        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 47)
-        self.assertEqual(scope.mass.to('gram').magnitude, 11000)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 48)
+        self.assertEqual(scope.mass.to('gram').magnitude, 9072)
 
     def test_skyliner_300p_specs(self):
         scope = Sky_watcherTelescope.Sky_Watcher_Skyliner_300P()

--- a/tests/unit/test_sky_watcher_classic_200p_audit.py
+++ b/tests/unit/test_sky_watcher_classic_200p_audit.py
@@ -1,0 +1,19 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+class TestSkyWatcherClassic200PAudit(unittest.TestCase):
+    def test_traditional_dob_8_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Traditional_Dob_8()
+        # Verify basic attributes
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Traditional Dob 8\"")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203.2)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 48)
+        self.assertEqual(scope.mass.to('gram').magnitude, 9072)
+
+        # Verify calculated focal ratio
+        # 1200 / 203.2 = 5.9055118...
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 5.9055, places=4)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited and corrected technical specifications for the Sky-Watcher Traditional Dob 8" (Classic 200P) telescope in `apts/opticalequipment/telescope/vendors/sky_watcher.py`. Updated aperture to 203.2mm, central obstruction to 48mm, and mass to 9072g to match official manufacturer documentation (20 lbs OTA weight). Added a source comment and a new validation test `tests/unit/test_sky_watcher_classic_200p_audit.py`, while updating `tests/unit/test_sky_watcher_audit.py` to ensure data integrity.

---
*PR created automatically by Jules for task [17276320966405199683](https://jules.google.com/task/17276320966405199683) started by @pozar87*