### PR TITLE
🏗️ Architect: Modularized observations report package

### DIFF
--- a/apts/observations/base.py
+++ b/apts/observations/base.py
@@ -7,7 +7,7 @@ from skyfield.api import Time
 from ..conditions import Conditions
 from .catalogs import CatalogMixIn
 from .events import EventsMixIn
-from .html import HtmlExportMixIn
+from .report import HtmlExportMixIn
 from .plotting import PlottingMixIn
 from .weather import WeatherAnalysisMixIn
 from .window import ObservationWindow

--- a/apts/observations/report/__init__.py
+++ b/apts/observations/report/__init__.py
@@ -1,0 +1,3 @@
+from .base import HtmlExportMixIn
+
+__all__ = ["HtmlExportMixIn"]

--- a/apts/observations/report/base.py
+++ b/apts/observations/report/base.py
@@ -1,0 +1,25 @@
+import logging
+from string import Template
+from typing import Optional
+
+from ...i18n import language_context
+from .templates import ReportTemplateMixIn
+from .data import ReportDataMixIn
+
+logger = logging.getLogger(__name__)
+
+class HtmlExportMixIn(ReportTemplateMixIn, ReportDataMixIn):
+    def to_html(
+        self,
+        custom_template=None,
+        css=None,
+        language: Optional[str] = None,
+    ):
+        with language_context(language):
+            template_content = self._load_template(custom_template)
+            if css:
+                template_content = self._inject_css(template_content, css)
+
+            template = Template(template_content)
+            data = self._prepare_html_data(language)
+            return str(template.substitute(data))

--- a/apts/observations/report/data.py
+++ b/apts/observations/report/data.py
@@ -1,8 +1,5 @@
 import html
 import logging
-import re
-from importlib import resources
-from string import Template
 from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
@@ -10,20 +7,14 @@ import pandas as pd
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from ..place import Place
-    from ..equipment.base import Equipment
+    from ...place import Place
+    from ...equipment.base import Equipment
 
-from ..i18n import language_context
-from ..utils import Utils
+from ...utils import Utils
 
 logger = logging.getLogger(__name__)
 
-
-class HtmlExportMixIn:
-    NOTIFICATION_TEMPLATE = resources.files("apts").joinpath(
-        "templates/notification.html.template"
-    )
-
+class ReportDataMixIn:
     if TYPE_CHECKING:
         start: Optional["datetime"]
         stop: Optional["datetime"]
@@ -34,51 +25,6 @@ class HtmlExportMixIn:
         def get_visible_planets(self, language: Optional[str] = None) -> pd.DataFrame: ...
         def get_visible_messier(self, language: Optional[str] = None) -> pd.DataFrame: ...
         def get_visible_ngc(self, language: Optional[str] = None) -> pd.DataFrame: ...
-
-    def to_html(
-        self,
-        custom_template=None,
-        css=None,
-        language: Optional[str] = None,
-    ):
-        with language_context(language):
-            template_content = self._load_template(custom_template)
-            if css:
-                template_content = self._inject_css(template_content, css)
-
-            template = Template(template_content)
-            data = self._prepare_html_data(language)
-            return str(template.substitute(data))
-
-    def _load_template(self, custom_template) -> str:
-        if custom_template:
-            # Security: restrict to allowed template extensions and prevent path traversal.
-            str_template = str(custom_template)
-            if ".." in str_template:
-                raise ValueError("Path traversal detected in custom template path.")
-
-            if not str_template.lower().endswith((".template", ".html", ".htm")):
-                raise ValueError(
-                    "Only .template, .html, or .htm files are allowed as custom templates."
-                )
-            with open(custom_template, "r", encoding="utf-8") as f:
-                return f.read()
-        else:
-            return self.NOTIFICATION_TEMPLATE.read_text(encoding="utf-8")
-
-    def _inject_css(self, template_content: str, css: str) -> str:
-        # Sanitize CSS to prevent breaking out of <style> block.
-        sanitized_css = re.sub(r"</style\s*/?>", "", str(css), flags=re.IGNORECASE)
-        # Escape '$' to '$$' to prevent string.Template from interpreting it as a variable.
-        sanitized_css = sanitized_css.replace("$", "$$")
-        style_end_pos = template_content.find("</style>")
-        if style_end_pos != -1:
-            return (
-                template_content[:style_end_pos]
-                + sanitized_css
-                + template_content[style_end_pos:]
-            )
-        return template_content
 
     def _prepare_html_data(self, language: Optional[str] = None) -> dict:
         hourly_weather = self.get_hourly_weather_analysis(language=language)

--- a/apts/observations/report/templates.py
+++ b/apts/observations/report/templates.py
@@ -1,0 +1,40 @@
+import re
+import logging
+from importlib import resources
+
+logger = logging.getLogger(__name__)
+
+class ReportTemplateMixIn:
+    NOTIFICATION_TEMPLATE = resources.files("apts").joinpath(
+        "templates/notification.html.template"
+    )
+
+    def _load_template(self, custom_template) -> str:
+        if custom_template:
+            # Security: restrict to allowed template extensions and prevent path traversal.
+            str_template = str(custom_template)
+            if ".." in str_template:
+                raise ValueError("Path traversal detected in custom template path.")
+
+            if not str_template.lower().endswith((".template", ".html", ".htm")):
+                raise ValueError(
+                    "Only .template, .html, or .htm files are allowed as custom templates."
+                )
+            with open(custom_template, "r", encoding="utf-8") as f:
+                return f.read()
+        else:
+            return self.NOTIFICATION_TEMPLATE.read_text(encoding="utf-8")
+
+    def _inject_css(self, template_content: str, css: str) -> str:
+        # Sanitize CSS to prevent breaking out of <style> block.
+        sanitized_css = re.sub(r"</style\s*/?>", "", str(css), flags=re.IGNORECASE)
+        # Escape '$' to '$$' to prevent string.Template from interpreting it as a variable.
+        sanitized_css = sanitized_css.replace("$", "$$")
+        style_end_pos = template_content.find("</style>")
+        if style_end_pos != -1:
+            return (
+                template_content[:style_end_pos]
+                + sanitized_css
+                + template_content[style_end_pos:]
+            )
+        return template_content


### PR DESCRIPTION
Decomposed the `apts/observations/html.py` God Mixin into a modular `apts/observations/report/` package. Logic is separated into specialized mixins: `ReportTemplateMixIn` (template management and CSS injection in `templates.py`) and `ReportDataMixIn` (data preparation and HTML-safe sanitization in `data.py`). The public API `HtmlExportMixIn` is recomposed in `base.py` and re-exported via `__init__.py` for backward compatibility. This refactor follows the Single Responsibility Principle by decoupling reporting data preparation from HTML rendering and template management.

---
*PR created automatically by Jules for task [5444488049178390505](https://jules.google.com/task/5444488049178390505) started by @pozar87*