### PR TITLE
🔍 Optic: Data audit for Sky-Watcher SkyMax 127

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -649,8 +649,8 @@ class Sky_watcherTelescope(Telescope):
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 39,
             "cside_gender": "Female",
-            "cside_thread": "1.25\"",
-            "focal_length_mm": 1500,
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Included 2" diagonal) - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
+            "focal_length_mm": 1540,  # Verified via Sky-Watcher USA - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
             "mass": 3400,
             "name": "Mak-127",
             "optical_length": 0,
@@ -809,8 +809,8 @@ class Sky_watcherTelescope(Telescope):
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 39,
             "cside_gender": "Female",
-            "cside_thread": "1.25\"",
-            "focal_length_mm": 1500,
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Included 2" diagonal) - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
+            "focal_length_mm": 1540,  # Verified via Sky-Watcher USA - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
             "mass": 3400,
             "name": "SkyMax 127",
             "optical_length": 0,
@@ -825,8 +825,8 @@ class Sky_watcherTelescope(Telescope):
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 39,
             "cside_gender": "Female",
-            "cside_thread": "2\"",
-            "focal_length_mm": 1500,
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Included 2" diagonal) - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
+            "focal_length_mm": 1540,  # Verified via Sky-Watcher USA - https://www.skywatcherusa.com/products/sky-watcher-skymax-127
             "mass": 3400,
             "name": "SkyMax 127 AZ-GTi",
             "optical_length": 0,

--- a/tests/unit/test_sky_watcher_skymax_127_audit.py
+++ b/tests/unit/test_sky_watcher_skymax_127_audit.py
@@ -1,0 +1,24 @@
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+from apts.utils import ConnectionType
+
+def test_skymax_127_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_SkyMax_127()
+    # Audited value: 1540mm focal length, 127mm aperture, 2" thread
+    assert telescope.focal_length.magnitude == 1540
+    assert telescope.aperture.magnitude == 127
+    assert telescope.connection_type == ConnectionType.F_2
+
+def test_mak_127_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_Mak_127()
+    # Audited value: 1540mm focal length
+    assert telescope.focal_length.magnitude == 1540
+    assert telescope.aperture.magnitude == 127
+    assert telescope.connection_type == ConnectionType.F_2
+
+def test_skymax_127_az_gti_specs():
+    telescope = Sky_watcherTelescope.Sky_Watcher_SkyMax_127_AZ_GTi()
+    # Audited value: 1540mm focal length
+    assert telescope.focal_length.magnitude == 1540
+    assert telescope.aperture.magnitude == 127
+    assert telescope.connection_type == ConnectionType.F_2

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -110,7 +110,7 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         scope = Sky_watcherTelescope.Sky_Watcher_SkyMax_127()
         self.assertEqual(scope.get_vendor(), "Sky-Watcher SkyMax 127")
         self.assertEqual(scope.aperture.to('mm').magnitude, 127)
-        self.assertEqual(scope.focal_length.to('mm').magnitude, 1500)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1540)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 39)
         self.assertEqual(scope.mass.to('gram').magnitude, 3400)
 
@@ -118,7 +118,7 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         scope = Sky_watcherTelescope.Sky_Watcher_SkyMax_127_AZ_GTi()
         self.assertEqual(scope.get_vendor(), "Sky-Watcher SkyMax 127 AZ-GTi")
         self.assertEqual(scope.aperture.to('mm').magnitude, 127)
-        self.assertEqual(scope.focal_length.to('mm').magnitude, 1500)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1540)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 39)
         self.assertEqual(scope.mass.to('gram').magnitude, 3400)
 


### PR DESCRIPTION
Audited and corrected the specifications for the Sky-Watcher SkyMax 127 telescope series in `apts/opticalequipment/telescope/vendors/sky_watcher.py`.
- Updated `focal_length_mm` from 1500 to 1540.
- Updated `cside_thread` from "1.25\"" to "2\"" (reflecting the USA model's included 2-inch diagonal and visual back).
- Added source documentation links in comments.
- Created `tests/unit/test_sky_watcher_skymax_127_audit.py` for verification.
- Updated `tests/unit/test_sky_watcher_specs.py` to reflect the new accurate values.
All relevant tests passed.

---
*PR created automatically by Jules for task [16055509906883319641](https://jules.google.com/task/16055509906883319641) started by @pozar87*