### PR TITLE
🔍 Optic: Data audit for Sky-Watcher SkyMax 102 AZ-GTi

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -793,7 +793,7 @@ class Sky_watcherTelescope(Telescope):
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 31,
             "cside_gender": "Female",
-            "cside_thread": "2\"",
+            "cside_thread": "1.25\"",  # Verified via Sky-Watcher USA documentation (1.25" visual back) - https://www.skywatcherusa.com/products/sky-watcher-skymax-102
             "focal_length_mm": 1300,
             "mass": 2200,
             "name": "SkyMax 102 AZ-GTi",

--- a/tests/unit/test_skymax_102_azgti_audit.py
+++ b/tests/unit/test_skymax_102_azgti_audit.py
@@ -1,0 +1,12 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils.equipment import ConnectionType
+
+class TestSkyMax102AZGTiAudit(unittest.TestCase):
+    def test_skymax_102_azgti_connection(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_SkyMax_102_AZ_GTi()
+        # Verify that the connection type is 1.25"
+        self.assertEqual(scope.connection_type, ConnectionType.F_1_25)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audit and correction of the Sky-Watcher SkyMax 102 AZ-GTi telescope specifications. The `cside_thread` attribute was corrected from `"2\""` to `"1.25\""` based on official Sky-Watcher USA documentation. A validation test suite was added to ensure the fix is correctly integrated.

---
*PR created automatically by Jules for task [18383071821595623675](https://jules.google.com/task/18383071821595623675) started by @pozar87*