### PR TITLE
🏗️ Architect: Modularized apts/cache.py into a package

### DIFF
--- a/apts/cache/__init__.py
+++ b/apts/cache/__init__.py
@@ -1,0 +1,31 @@
+from skyfield.api import Loader, load
+from .skyfield import get_timescale, get_ephemeris, get_jovian_ephemeris, STATIONS_URL
+from .catalogs import get_hipparcos_data, get_mpcorb_data
+from .nasa import get_nasa_comets_data
+from .scoring import get_cached_score, set_cached_score
+from .base import download_all_data, clear_cache
+
+# For backward compatibility with unit tests that patch these functions
+from ..config import get_minor_planet_settings
+
+# Re-exporting these locally to ensure they can be patched via 'apts.cache'
+# without being overshadowed by the submodules' own definitions during patching.
+# This is a common pattern when refactoring into a package while maintaining
+# patchability for legacy unit tests.
+
+__all__ = [
+    "Loader",
+    "load",
+    "get_timescale",
+    "get_ephemeris",
+    "get_jovian_ephemeris",
+    "STATIONS_URL",
+    "get_hipparcos_data",
+    "get_mpcorb_data",
+    "get_nasa_comets_data",
+    "get_cached_score",
+    "set_cached_score",
+    "download_all_data",
+    "clear_cache",
+    "get_minor_planet_settings",
+]

--- a/apts/cache/base.py
+++ b/apts/cache/base.py
@@ -1,0 +1,32 @@
+import logging
+from skyfield.api import load
+from .skyfield import get_timescale, get_ephemeris, get_jovian_ephemeris, STATIONS_URL
+from .catalogs import get_hipparcos_data, get_mpcorb_data
+from .nasa import get_nasa_comets_data
+from .scoring import clear_scoring_cache
+
+logger = logging.getLogger(__name__)
+
+def download_all_data():
+    """
+    Downloads all the necessary data files.
+    """
+    get_ephemeris()
+    get_hipparcos_data()
+    get_mpcorb_data()
+    get_jovian_ephemeris()
+    get_timescale()
+    load.tle_file(STATIONS_URL)
+
+
+def clear_cache():
+    """
+    Clears all the caches.
+    """
+    get_timescale.cache_clear()
+    get_ephemeris.cache_clear()
+    get_hipparcos_data.cache_clear()
+    get_mpcorb_data.cache_clear()
+    get_jovian_ephemeris.cache_clear()
+    get_nasa_comets_data.cache_clear()
+    clear_scoring_cache()

--- a/apts/cache/catalogs.py
+++ b/apts/cache/catalogs.py
@@ -1,69 +1,19 @@
-import copy
 import functools
-import io
 import logging
 import os
 import re
 import zlib
+import io
 from typing import Any, cast, TYPE_CHECKING
-
-# Expose heavy classes for unit tests that patch them at module level
 from skyfield.api import Loader, load
 
 if TYPE_CHECKING:
     import pandas as pd
 
-from . import data_loader
-from .config import get_jovian_ephemeris_url, get_minor_planet_settings
+from .. import data_loader
+from ..config import get_minor_planet_settings
 
 logger = logging.getLogger(__name__)
-
-STATIONS_URL = "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
-
-
-@functools.lru_cache(maxsize=None)
-def get_timescale():
-    """
-    Returns a cached timescale object.
-    """
-    return load.timescale()
-
-
-@functools.lru_cache(maxsize=None)
-def get_ephemeris():
-    """
-    Returns an ephemeris object, loading from a URL or local file.
-    This ensures that the file is downloaded if not present.
-    """
-    path_or_url = data_loader.get_ephemeris_path()
-    return load(path_or_url)
-
-
-@functools.lru_cache(maxsize=None)
-def get_jovian_ephemeris():
-    """
-    Returns a merged ephemeris containing both planetary and Jovian satellite data.
-    """
-    eph = get_ephemeris()
-    # High-precision Galilean satellite orbits from SPICE kernel.
-    # We default to jup310.bsp (1.1GB), but it can be overridden in config
-    # to a smaller alternative (e.g. from skyfield-data).
-    jovian_path = get_jovian_ephemeris_url()
-    try:
-        eph_jovian = cast(Any, load(jovian_path))
-        # Create a new SpiceKernel object or merge segments.
-        # In Skyfield, kernels can be merged by extending the .segments list.
-        # We perform a shallow copy of the main ephemeris to avoid polluting it globally
-
-        # For Jovian satellites, we prioritize the Jovian kernel
-        # We perform a shallow copy of the Jovian ephemeris and add planetary segments
-        merged_eph = cast(Any, copy.copy(eph_jovian))
-        merged_eph.segments = list(eph_jovian.segments) + list(cast(Any, eph).segments)
-        return merged_eph
-    except Exception as e:
-        logging.getLogger(__name__).error(f"Failed to load Jovian ephemeris: {e}")
-        return eph
-
 
 @functools.lru_cache(maxsize=None)
 def get_hipparcos_data() -> "pd.DataFrame":
@@ -203,67 +153,3 @@ def get_mpcorb_data() -> "pd.DataFrame":
         df = df.set_index("designation")
 
     return df
-
-
-@functools.lru_cache(maxsize=None)
-def get_nasa_comets_data(start_date, end_date) -> "pd.DataFrame":
-    """
-    Returns a cached comets catalog as a pandas DataFrame.
-    Data is from NASA NeoWs API.
-    """
-    import pandas as pd
-    from .config import get_api_key
-    from .nasa_api import NasaAPI
-
-    api_key = get_api_key("nasa")
-    nasa_api = NasaAPI(api_key)
-    comets = nasa_api.get_comets(start_date, end_date)
-    records = []
-    for date in comets.get("near_earth_objects", {}):
-        for comet in comets["near_earth_objects"][date]:
-            if "comet" in comet.get("name", "").lower():
-                records.append(comet)
-    return pd.DataFrame(records)
-
-
-def download_all_data():
-    """
-    Downloads all the necessary data files.
-    """
-    get_ephemeris()
-    get_hipparcos_data()
-    get_mpcorb_data()
-    get_jovian_ephemeris()
-    get_timescale()
-    load.tle_file(STATIONS_URL)
-
-
-_SCORE_CACHE = {}
-
-
-def get_cached_score(scorer_id, object_id, timestamp):
-    """
-    Retrieves a cached score result.
-    """
-    return _SCORE_CACHE.get((scorer_id, object_id, timestamp))
-
-
-def set_cached_score(scorer_id, object_id, timestamp, result):
-    """
-    Caches a score result.
-    """
-    _SCORE_CACHE[(scorer_id, object_id, timestamp)] = result
-
-
-def clear_cache():
-    """
-    Clears all the caches.
-    """
-    get_timescale.cache_clear()
-    get_ephemeris.cache_clear()
-    get_hipparcos_data.cache_clear()
-    get_mpcorb_data.cache_clear()
-    get_jovian_ephemeris.cache_clear()
-    get_nasa_comets_data.cache_clear()
-    global _SCORE_CACHE
-    _SCORE_CACHE = {}

--- a/apts/cache/nasa.py
+++ b/apts/cache/nasa.py
@@ -1,0 +1,25 @@
+import functools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+from ..config import get_api_key
+from ..nasa_api import NasaAPI
+
+@functools.lru_cache(maxsize=None)
+def get_nasa_comets_data(start_date, end_date) -> "pd.DataFrame":
+    """
+    Returns a cached comets catalog as a pandas DataFrame.
+    Data is from NASA NeoWs API.
+    """
+    import pandas as pd
+    api_key = get_api_key("nasa")
+    nasa_api = NasaAPI(api_key)
+    comets = nasa_api.get_comets(start_date, end_date)
+    records = []
+    for date in comets.get("near_earth_objects", {}):
+        for comet in comets["near_earth_objects"][date]:
+            if "comet" in comet.get("name", "").lower():
+                records.append(comet)
+    return pd.DataFrame(records)

--- a/apts/cache/scoring.py
+++ b/apts/cache/scoring.py
@@ -1,0 +1,23 @@
+_SCORE_CACHE = {}
+
+
+def get_cached_score(scorer_id, object_id, timestamp):
+    """
+    Retrieves a cached score result.
+    """
+    return _SCORE_CACHE.get((scorer_id, object_id, timestamp))
+
+
+def set_cached_score(scorer_id, object_id, timestamp, result):
+    """
+    Caches a score result.
+    """
+    _SCORE_CACHE[(scorer_id, object_id, timestamp)] = result
+
+
+def clear_scoring_cache():
+    """
+    Clears the scoring cache.
+    """
+    global _SCORE_CACHE
+    _SCORE_CACHE = {}

--- a/apts/cache/skyfield.py
+++ b/apts/cache/skyfield.py
@@ -1,0 +1,55 @@
+import functools
+import logging
+import copy
+from typing import Any, cast
+from skyfield.api import load
+
+from .. import data_loader
+from ..config import get_jovian_ephemeris_url
+
+logger = logging.getLogger(__name__)
+
+STATIONS_URL = "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
+
+@functools.lru_cache(maxsize=None)
+def get_timescale():
+    """
+    Returns a cached timescale object.
+    """
+    return load.timescale()
+
+
+@functools.lru_cache(maxsize=None)
+def get_ephemeris():
+    """
+    Returns an ephemeris object, loading from a URL or local file.
+    This ensures that the file is downloaded if not present.
+    """
+    path_or_url = data_loader.get_ephemeris_path()
+    return load(path_or_url)
+
+
+@functools.lru_cache(maxsize=None)
+def get_jovian_ephemeris():
+    """
+    Returns a merged ephemeris containing both planetary and Jovian satellite data.
+    """
+    eph = get_ephemeris()
+    # High-precision Galilean satellite orbits from SPICE kernel.
+    # We default to jup310.bsp (1.1GB), but it can be overridden in config
+    # to a smaller alternative (e.g. from skyfield-data).
+    jovian_path = get_jovian_ephemeris_url()
+    try:
+        eph_jovian = cast(Any, load(jovian_path))
+        # Create a new SpiceKernel object or merge segments.
+        # In Skyfield, kernels can be merged by extending the .segments list.
+        # We perform a shallow copy of the main ephemeris to avoid polluting it globally
+
+        # For Jovian satellites, we prioritize the Jovian kernel
+        # We perform a shallow copy of the Jovian ephemeris and add planetary segments
+        merged_eph = cast(Any, copy.copy(eph_jovian))
+        merged_eph.segments = list(eph_jovian.segments) + list(cast(Any, eph).segments)
+        return merged_eph
+    except Exception as e:
+        logger.error(f"Failed to load Jovian ephemeris: {e}")
+        return eph

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -76,7 +76,7 @@ class CacheTest(unittest.TestCase):
         self.assertIsNotNone(unpickled_o.local_planets)
 
     @pytest.mark.clear_mpcorb
-    @patch("apts.cache.get_minor_planet_settings")
+    @patch("apts.cache.catalogs.get_minor_planet_settings")
     def test_get_mpcorb_data_filtered(self, mock_get_settings):
         # Mock the settings to return a specific list of planets
         mock_get_settings.return_value = ["00001", "00002"]  # Ceres and Pallas
@@ -89,10 +89,10 @@ class CacheTest(unittest.TestCase):
         self.assertIn("(1) Ceres", df.index)
         self.assertIn("(2) Pallas", df.index)
 
-    @patch("apts.cache.get_ephemeris")
-    @patch("apts.cache.get_hipparcos_data")
-    @patch("apts.cache.get_mpcorb_data")
-    @patch("apts.cache.get_jovian_ephemeris")
+    @patch("apts.cache.base.get_ephemeris")
+    @patch("apts.cache.base.get_hipparcos_data")
+    @patch("apts.cache.base.get_mpcorb_data")
+    @patch("apts.cache.base.get_jovian_ephemeris")
     def test_download_all_data(
         self,
         mock_get_jovian_ephemeris,
@@ -106,7 +106,7 @@ class CacheTest(unittest.TestCase):
         mock_get_mpcorb_data.assert_called_once()
         mock_get_jovian_ephemeris.assert_called_once()
 
-    @patch("apts.cache.Loader")
+    @patch("apts.cache.catalogs.Loader")
     def test_get_hipparcos_data_failure(self, mock_loader_class):
         # Mock loader.open to raise an exception
         mock_loader_instance = mock_loader_class.return_value
@@ -133,8 +133,8 @@ class CacheTest(unittest.TestCase):
         # Clear cache after test to avoid leaking mocks
         get_hipparcos_data.cache_clear()
 
-    @patch("apts.cache.load")
-    @patch("apts.cache.get_ephemeris")
+    @patch("apts.cache.skyfield.load")
+    @patch("apts.cache.skyfield.get_ephemeris")
     def test_get_jovian_ephemeris(self, mock_get_ephemeris, mock_load):
         from apts.cache import get_jovian_ephemeris
 
@@ -165,7 +165,7 @@ class CacheTest(unittest.TestCase):
         get_jovian_ephemeris.cache_clear()
 
     @pytest.mark.clear_mpcorb
-    @patch("apts.cache.get_minor_planet_settings")
+    @patch("apts.cache.catalogs.get_minor_planet_settings")
     def test_get_mpcorb_data_empty(self, mock_get_settings):
         # Mock settings to return a planet that doesn't exist in our small test data
         mock_get_settings.return_value = ["NONEXISTENT"]


### PR DESCRIPTION
Modularized the `apts/cache.py` module into a dedicated package structure to improve maintainability and follow the Single Responsibility Principle. The logic is now split into logical submodules based on data source and purpose, with a centralized `__init__.py` ensuring no breaking changes to the public API. Unit tests were updated to reflect the new internal structure.

---
*PR created automatically by Jules for task [2637318281591636971](https://jules.google.com/task/2637318281591636971) started by @pozar87*