### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Virtuoso GTi 130P

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -1239,11 +1239,11 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 130,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 34.5,
+            "central_obstruction_mm": 40,  # Verified via Sky-Watcher USA (Secondary Diameter 40mm) - https://www.skywatcherusa.com/products/virtuoso-gti-130p
             "cside_gender": "Female",
             "cside_thread": "1.25\"",
             "focal_length_mm": 650,
-            "mass": 3250,
+            "mass": 2948,  # Verified via Sky-Watcher USA (6.5 lbs OTA weight)
             "name": "Virtuoso GTi 130P",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_virtuoso_gti_130p_audit.py
+++ b/tests/unit/test_virtuoso_gti_130p_audit.py
@@ -1,0 +1,20 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_virtuoso_gti_130p_audit():
+    """
+    Verify the audited specifications for Sky-Watcher Virtuoso GTi 130P.
+    Reference: https://www.skywatcherusa.com/products/virtuoso-gti-130p
+    """
+    telescope = Sky_watcherTelescope.Sky_Watcher_Virtuoso_GTi_130P()
+
+    # In Telescope.from_database, vendor is constructed as f"{brand} {name}"
+    assert telescope.get_vendor() == "Sky-Watcher Virtuoso GTi 130P"
+    assert telescope.aperture.to('mm').magnitude == 130
+    assert telescope.focal_length.to('mm').magnitude == 650
+    # Central obstruction: 40mm
+    assert telescope.central_obstruction.to('mm').magnitude == 40
+    # Mass: 2948g (6.5 lbs)
+    assert telescope.mass.to('gram').magnitude == 2948
+    # Focal ratio: f/5
+    assert telescope.focal_ratio().magnitude == 5.0


### PR DESCRIPTION
Audited and corrected the Sky-Watcher Virtuoso GTi 130P in the database. Updated central obstruction and mass based on official manufacturer specifications. Added a validation unit test.

---
*PR created automatically by Jules for task [7063797825031686688](https://jules.google.com/task/7063797825031686688) started by @pozar87*