### PR TITLE
🔍 Optic: Data audit for Celestron C5 OTA (XLT)

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -343,14 +343,14 @@ class CelestronTelescope(Telescope):
             "name": "C5 OTA (XLT)",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 2720,
+            "mass": 2722, # Verified via Celestron documentation (96 oz) - https://www.celestron.com/products/c5-spotting-scope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 125,
+            "aperture_mm": 127, # Verified via Celestron documentation (127mm / 5") - https://www.celestron.com/products/c5-spotting-scope
             "focal_length_mm": 1250,
             "central_obstruction_mm": 51,
         },

--- a/tests/unit/test_celestron_c5_audit.py
+++ b/tests/unit/test_celestron_c5_audit.py
@@ -1,0 +1,29 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+def test_celestron_c5_ota_xlt_audit():
+    """
+    Audit test for Celestron C5 OTA (XLT) to verify precision specs.
+    Source: https://www.celestron.com/products/c5-spotting-scope
+    """
+    telescope = CelestronTelescope.Celestron_C5_OTA_XLT()
+
+    # Official Aperture: 127mm (5")
+    assert telescope.aperture.magnitude == 127
+
+    # Official Focal Length: 1250mm
+    assert telescope.focal_length.magnitude == 1250
+
+    # Official weight: 96 oz = 2721.55g -> rounded to 2722g in official specs
+    assert telescope.mass.magnitude == 2722
+
+    # Official Secondary Mirror Obstruction: 51mm (2.0")
+    assert telescope.central_obstruction.magnitude == 51
+
+    # Verify vendor string construction
+    assert telescope.get_vendor() == "Celestron C5 OTA (XLT)"
+
+    # Verify focal ratio calculation (stated f/10)
+    # 1250 / 127 = 9.84... but Celestron markets it as f/10.
+    # Physical specs are more important than marketing numbers.
+    assert round(telescope.focal_ratio().magnitude, 1) == 9.8


### PR DESCRIPTION
Audited and corrected the Celestron C5 OTA (XLT) specifications in the `apts` database. Cross-referenced official Celestron documentation to update the aperture to 127mm (5") and mass to 2722g (96 oz). Verified the changes with a new unit test and existing Celestron specs tests.

---
*PR created automatically by Jules for task [4791992357893790049](https://jules.google.com/task/4791992357893790049) started by @pozar87*