### PR TITLE
🏗️ Architect: Modularized Telescope Class and Extracted Calculations

### DIFF
--- a/apts/opticalequipment/telescope/__init__.py
+++ b/apts/opticalequipment/telescope/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
-from .base import TelescopeType, TubeMaterial, Telescope
+from .enums import TelescopeType, TubeMaterial
+from .base import Telescope
 import pkgutil
 import importlib
 import os

--- a/apts/opticalequipment/telescope/base.py
+++ b/apts/opticalequipment/telescope/base.py
@@ -1,28 +1,13 @@
-from enum import Enum
 from typing import Any, Optional, cast
 
 import numpy
 
-from ...constants import GraphConstants, astronomy
+from .enums import TelescopeType, TubeMaterial
+from ...constants import GraphConstants
+from ...optics.calculations import telescope as telescope_calc
 from ...units import get_unit_registry
 from ...utils import ConnectionType
 from ..base import OpticalEquipment
-
-
-class TelescopeType(Enum):
-    REFRACTOR = "refractor"
-    NEWTONIAN_REFLECTOR = "newtonian_reflector"
-    SCHMIDT_CASSEGRAIN = "schmidt_cassegrain"
-    MAKSUTOV_CASSEGRAIN = "maksutov_cassegrain"
-    CATADIOPTRIC = "catadioptric"
-
-
-class TubeMaterial(Enum):
-    ALUMINUM = 2.31e-05
-    CARBON_FIBER = 5e-07
-    STEEL = 1.2e-05
-    BRASS = 1.9e-05
-    GLASS_FIBER = 8e-06
 
 
 class Telescope(OpticalEquipment):
@@ -191,10 +176,8 @@ class Telescope(OpticalEquipment):
         https://en.wikipedia.org/wiki/Dawes%27_limit
         :return: limit in arcsecond
         """
-        return (
-            round((11.6 / self.aperture.to("cm")).magnitude, 3)
-            * get_unit_registry().arcsecond
-        )
+        aperture_mm = self.aperture.to("mm").magnitude
+        return telescope_calc.calculate_dawes_limit(aperture_mm) * get_unit_registry().arcsecond
 
     def rayleigh_limit(self, wavelength_nm: float | int = 550):
         """
@@ -205,11 +188,8 @@ class Telescope(OpticalEquipment):
         :param wavelength_nm: wavelength in nanometers (default 550nm for green light)
         :return: limit in arcsecond
         """
-        wavelength_m = wavelength_nm * 1e-9
-        aperture_m = self.aperture.to("m").magnitude
-        limit_rad = 1.22 * wavelength_m / aperture_m
-        limit_arcsec = limit_rad * astronomy.RAD_TO_ARCSEC
-        return round(limit_arcsec, 3) * get_unit_registry().arcsecond
+        aperture_mm = self.aperture.to("mm").magnitude
+        return telescope_calc.calculate_rayleigh_limit(aperture_mm, wavelength_nm) * get_unit_registry().arcsecond
 
     def limiting_magnitude(self):
         """
@@ -217,7 +197,9 @@ class Telescope(OpticalEquipment):
         Uses effective aperture diameter for better accuracy when central obstruction is present.
         :return: range in magnitude
         """
-        return 7.7 + 5 * numpy.log10(self.effective_aperture().to("cm").magnitude)
+        aperture_mm = self.aperture.to("mm").magnitude
+        central_obstruction_mm = self.central_obstruction.to("mm").magnitude
+        return telescope_calc.calculate_limiting_magnitude(aperture_mm, central_obstruction_mm)
 
     def light_grasp_ratio(self, other_aperture):
         """
@@ -236,7 +218,8 @@ class Telescope(OpticalEquipment):
         Above this limit, the image usually becomes blurry and loses contrast due to diffraction.
         Source: Sidgwick, J. B. (1971), "Amateur Astronomer's Handbook".
         """
-        return float(self.aperture.magnitude * 2.0)
+        aperture_mm = self.aperture.to("mm").magnitude
+        return telescope_calc.calculate_highest_useful_magnification(aperture_mm)
 
     def lowest_useful_magnification(self, pupil_diameter_mm: float = 7.0) -> float:
         """
@@ -246,7 +229,8 @@ class Telescope(OpticalEquipment):
         in an exit pupil larger than the eye, wasting gathered light.
         Source: Sidgwick, J. B. (1971), "Amateur Astronomer's Handbook".
         """
-        return float(self.aperture.magnitude / pupil_diameter_mm)
+        aperture_mm = self.aperture.to("mm").magnitude
+        return telescope_calc.calculate_lowest_useful_magnification(aperture_mm, pupil_diameter_mm)
 
     def min_useful_zoom(self):
         """

--- a/apts/opticalequipment/telescope/enums.py
+++ b/apts/opticalequipment/telescope/enums.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class TelescopeType(Enum):
+    REFRACTOR = "refractor"
+    NEWTONIAN_REFLECTOR = "newtonian_reflector"
+    SCHMIDT_CASSEGRAIN = "schmidt_cassegrain"
+    MAKSUTOV_CASSEGRAIN = "maksutov_cassegrain"
+    CATADIOPTRIC = "catadioptric"
+
+
+class TubeMaterial(Enum):
+    ALUMINUM = 2.31e-05
+    CARBON_FIBER = 5e-07
+    STEEL = 1.2e-05
+    BRASS = 1.9e-05
+    GLASS_FIBER = 8e-06

--- a/apts/optics/calculations/telescope.py
+++ b/apts/optics/calculations/telescope.py
@@ -1,0 +1,65 @@
+import numpy as np
+from ...constants import astronomy
+
+def calculate_dawes_limit(aperture_mm: float) -> float:
+    """
+    Calculate the maximum resolving power of a telescope using the Dawes' Limit formula.
+    https://en.wikipedia.org/wiki/Dawes%27_limit
+
+    :param aperture_mm: aperture in mm
+    :return: limit in arcseconds
+    """
+    if aperture_mm <= 0:
+        return 0.0
+    # Formula: 11.6 / aperture_cm
+    return round(11.6 / (aperture_mm / 10.0), 3)
+
+def calculate_rayleigh_limit(aperture_mm: float, wavelength_nm: float = 550) -> float:
+    """
+    Calculate the maximum resolving power of a telescope using the Rayleigh Limit formula.
+    θ = 1.22 * λ / D
+    Where λ is the wavelength and D is the aperture.
+    https://en.wikipedia.org/wiki/Angular_resolution
+
+    :param aperture_mm: aperture in mm
+    :param wavelength_nm: wavelength in nanometers (default 550nm for green light)
+    :return: limit in arcseconds
+    """
+    if aperture_mm <= 0:
+        return 0.0
+    wavelength_m = wavelength_nm * 1e-9
+    aperture_m = aperture_mm * 1e-3
+    limit_rad = 1.22 * wavelength_m / aperture_m
+    limit_arcsec = limit_rad * astronomy.RAD_TO_ARCSEC
+    return round(limit_arcsec, 3)
+
+def calculate_limiting_magnitude(aperture_mm: float, central_obstruction_mm: float = 0.0) -> float:
+    """
+    Calculate a telescope's approximate limiting magnitude.
+    Uses effective aperture diameter for better accuracy when central obstruction is present.
+
+    :param aperture_mm: aperture in mm
+    :param central_obstruction_mm: central obstruction in mm
+    :return: limiting magnitude
+    """
+    effective_aperture_mm = np.sqrt(aperture_mm**2 - central_obstruction_mm**2)
+    if effective_aperture_mm <= 0:
+        return 0.0
+    # Formula: 7.7 + 5 * log10(aperture_cm)
+    return 7.7 + 5 * np.log10(effective_aperture_mm / 10.0)
+
+def calculate_highest_useful_magnification(aperture_mm: float) -> float:
+    """
+    Calculate the theoretical highest useful magnification for the telescope.
+    Rule of thumb: 2.0x aperture in mm.
+    """
+    return float(aperture_mm * 2.0)
+
+def calculate_lowest_useful_magnification(aperture_mm: float, pupil_diameter_mm: float = 7.0) -> float:
+    """
+    Calculate the theoretical lowest useful magnification for the telescope.
+    Formula: aperture / pupil_diameter.
+    """
+    if pupil_diameter_mm <= 0:
+        return 0.0
+    return float(aperture_mm / pupil_diameter_mm)


### PR DESCRIPTION
Decomposed the `apts/opticalequipment/telescope/base.py` module to improve separation of concerns.
- Extracted `TelescopeType` and `TubeMaterial` enums to `enums.py`.
- Moved optical and physical property formulas (Dawes, Rayleigh, limiting magnitude, magnification limits) to a new utility module `apts/optics/calculations/telescope.py` as pure functions.
- Refactored the `Telescope` class to delegate to these utilities.
- Updated `__init__.py` to maintain backward compatibility by re-exporting the extracted symbols.
- Verified via unit tests for specifications and magnification limits.

---
*PR created automatically by Jules for task [7302414588537541040](https://jules.google.com/task/7302414588537541040) started by @pozar87*