### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Quattro 200P

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -724,14 +724,14 @@ class Sky_watcherTelescope(Telescope):
             "type": "newtonian_reflector",
         },
         "Sky_Watcher_Quattro_200P": {
-            "aperture_mm": 205,
+            "aperture_mm": 205,  # Verified via Sky-Watcher USA (205mm / 8.07") - https://www.skywatcherusa.com/products/sky-watcher-quattro-200p-imaging-newtonian-8-205-mm
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 70,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "central_obstruction_mm": 70,  # Verified via Sky-Watcher Global (Secondary Mirror Diameter 70mm)
+            "cside_gender": "Female",
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (2-inch dual-speed Crayford focuser)
             "focal_length_mm": 800,
-            "mass": 9500,
+            "mass": 9500,  # Verified via Sky-Watcher Global (9.5 kg Tube Weight)
             "name": "Quattro 200P",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_quattro_200p_audit.py
+++ b/tests/unit/test_sky_watcher_quattro_200p_audit.py
@@ -1,0 +1,24 @@
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils import ConnectionType
+
+def test_sky_watcher_quattro_200p_audit():
+    """
+    Audit for Sky-Watcher Quattro 200P Imaging Newtonian.
+    Source: https://www.skywatcherusa.com/products/sky-watcher-quattro-200p-imaging-newtonian-8-205-mm
+    """
+    telescope = Sky_watcherTelescope.Sky_Watcher_Quattro_200P()
+
+    # Official name and brand
+    assert telescope.get_vendor() == "Sky-Watcher Quattro 200P"
+
+    # Physical specs
+    assert telescope.aperture.magnitude == 205
+    assert telescope.focal_length.magnitude == 800
+    assert telescope.mass.magnitude == 9500
+    assert telescope.central_obstruction.magnitude == 70
+
+    # Connection type (2" Female visual back/focuser)
+    assert telescope.connection_type == ConnectionType.F_2
+
+    # Calculated specs
+    assert telescope.focal_ratio().magnitude == 800 / 205


### PR DESCRIPTION
I have audited, verified, and corrected the specifications for the Sky-Watcher Quattro 200P (Imaging Newtonian 8") telescope in the `apts` database.

Key changes:
- Updated `cside_thread` to `"2\""` and `cside_gender` to `"Female"` in `apts/opticalequipment/telescope/vendors/sky_watcher.py` to accurately reflect the 2" dual-speed Crayford focuser.
- Verified and added source comments for aperture (205mm), focal length (800mm), central obstruction (70mm), and mass (9500g) based on official Sky-Watcher USA and Global documentation.
- Added a new validation test `tests/unit/test_sky_watcher_quattro_200p_audit.py` to ensure the entry remains accurate and instantiates correctly.

Verification was performed using official manufacturer data: https://www.skywatcherusa.com/products/sky-watcher-quattro-200p-imaging-newtonian-8-205-mm

---
*PR created automatically by Jules for task [7101844772426286850](https://jules.google.com/task/7101844772426286850) started by @pozar87*