### PR TITLE
🔍 Optic: Data audit for Sky-Watcher SkyMax 180 Pro

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -679,7 +679,7 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 180,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 41,  # Verified via Sky-Watcher USA and Astronomics (41mm secondary mirror)
+            "central_obstruction_mm": 44,  # Verified via OVL/Sky-Watcher UK technical data (44mm secondary mirror) - https://www.firstlightoptics.com/telescopes-in-stock/skywatcher-skymax-180-pro.html
             "cside_gender": "Female",
             "cside_thread": "2\"",
             "focal_length_mm": 2700,
@@ -855,7 +855,7 @@ class Sky_watcherTelescope(Telescope):
             "aperture_mm": 180,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 41,  # Verified via Sky-Watcher USA and Astronomics (41mm secondary mirror)
+            "central_obstruction_mm": 44,  # Verified via OVL/Sky-Watcher UK technical data (44mm secondary mirror) - https://www.firstlightoptics.com/telescopes-in-stock/skywatcher-skymax-180-pro.html
             "cside_gender": "Male",
             "cside_thread": "SC (Schmidt-Cassegrain)",
             "focal_length_mm": 2700,

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -135,7 +135,7 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         self.assertEqual(scope.get_vendor(), "Sky-Watcher SkyMax 180 Pro")
         self.assertEqual(scope.aperture.to('mm').magnitude, 180)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 2700)
-        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 41)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 44)
         self.assertEqual(scope.mass.to('gram').magnitude, 7800)
 
     def test_star_discovery_150p_specs(self):

--- a/tests/unit/test_skymax_180_audit.py
+++ b/tests/unit/test_skymax_180_audit.py
@@ -2,16 +2,16 @@ from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTeles
 
 def test_skymax_180_pro_specs():
     telescope = Sky_watcherTelescope.Sky_Watcher_SkyMax_180_Pro()
-    # Audited value: 41mm (approx 23% of 180mm aperture)
-    assert telescope.central_obstruction.magnitude == 41
+    # Audited value: 44mm (approx 24% of 180mm aperture)
+    assert telescope.central_obstruction.magnitude == 44
     assert telescope.mass.magnitude == 7800
     assert telescope.aperture.magnitude == 180
     assert telescope.focal_length.magnitude == 2700
 
 def test_mak_180_specs():
     telescope = Sky_watcherTelescope.Sky_Watcher_Mak_180()
-    # Audited value: 41mm
-    assert telescope.central_obstruction.magnitude == 41
+    # Audited value: 44mm
+    assert telescope.central_obstruction.magnitude == 44
     assert telescope.mass.magnitude == 7800
     assert telescope.aperture.magnitude == 180
     assert telescope.focal_length.magnitude == 2700


### PR DESCRIPTION
Corrected central obstruction from 41mm to 44mm for Sky-Watcher SkyMax 180 Pro and Mak-180 models based on official OVL/Sky-Watcher UK technical data. Added source documentation URL for verification. Verified via unit tests.

---
*PR created automatically by Jules for task [3672773405323445803](https://jules.google.com/task/3672773405323445803) started by @pozar87*