### PR TITLE
🔍 Optic: Data audit for Celestron 5-inch SCT Series

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -158,7 +158,7 @@ class CelestronTelescope(Telescope):
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 127, # Verified via Celestron.com (5" aperture = 127mm) - https://www.celestron.com/products/c5-spotting-scope
+            "aperture_mm": 125, # Verified via Celestron.com (125mm / 4.92") - https://www.celestron.com/products/astro-fi-5-schmidt-cassegrain-telescope
             "focal_length_mm": 1250,
             "central_obstruction_mm": 51,
         },
@@ -366,7 +366,7 @@ class CelestronTelescope(Telescope):
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 127, # Verified via Celestron.com (5" aperture = 127mm) - https://www.celestron.com/products/c5-spotting-scope
+            "aperture_mm": 125, # Verified via Celestron.com (125mm / 4.92") - https://www.celestron.com/products/nexstar-5se-computerized-telescope
             "focal_length_mm": 1250,
             "central_obstruction_mm": 51,
         },
@@ -750,7 +750,7 @@ class CelestronTelescope(Telescope):
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 127, # Verified via Celestron.com (5" aperture = 127mm) - https://www.celestron.com/products/c5-spotting-scope
+            "aperture_mm": 125, # Verified via Celestron.com (125mm / 4.92") - https://www.celestron.com/products/nexstar-5se-computerized-telescope
             "focal_length_mm": 1250,
             "central_obstruction_mm": 51,
         },

--- a/tests/unit/test_celestron_c5_audit.py
+++ b/tests/unit/test_celestron_c5_audit.py
@@ -1,55 +1,47 @@
 import unittest
-import pytest
 from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
 
 class TestCelestronC5Audit(unittest.TestCase):
     def test_c5_ota_xlt_specs(self):
+        """
+        The C5 Spotting Scope variant is officially 127mm.
+        Source: https://www.celestron.com/products/c5-spotting-scope
+        """
         scope = CelestronTelescope.Celestron_C5_OTA_XLT()
         self.assertEqual(scope.aperture.to('mm').magnitude, 127.0)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)
+        # 1250 / 127 = 9.84...
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 9.84, places=2)
 
     def test_c5_sct_specs(self):
+        """
+        Standard C5 SCT is officially 125mm.
+        Source: https://www.celestron.com/products/nexstar-5se-computerized-telescope
+        """
         scope = CelestronTelescope.Celestron_C5_SCT()
-        self.assertEqual(scope.aperture.to('mm').magnitude, 127.0)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 125.0)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)
+        self.assertEqual(scope.focal_ratio().magnitude, 10.0)
 
     def test_nexstar_5se_specs(self):
-        # Even as part of a SE system, the OTA is a C5
+        """
+        NexStar 5SE is officially 125mm.
+        Source: https://www.celestron.com/products/nexstar-5se-computerized-telescope
+        """
         scope = CelestronTelescope.Celestron_NexStar_5SE()
-        self.assertEqual(scope.aperture.to('mm').magnitude, 127.0)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 125.0)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)
+        self.assertEqual(scope.focal_ratio().magnitude, 10.0)
 
     def test_astro_fi_5_sct_specs(self):
+        """
+        Astro-Fi 5 SCT is officially 125mm.
+        Source: https://www.celestron.com/products/astro-fi-5-schmidt-cassegrain-telescope
+        """
         scope = CelestronTelescope.Celestron_Astro_Fi_5_SCT()
-        self.assertEqual(scope.aperture.to('mm').magnitude, 127.0)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 125.0)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)
+        self.assertEqual(scope.focal_ratio().magnitude, 10.0)
 
 if __name__ == '__main__':
     unittest.main()
-
-def test_celestron_c5_ota_xlt_audit():
-    """
-    Audit test for Celestron C5 OTA (XLT) to verify precision specs.
-    Source: https://www.celestron.com/products/c5-spotting-scope
-    """
-    telescope = CelestronTelescope.Celestron_C5_OTA_XLT()
-
-    # Official Aperture: 127mm (5")
-    assert telescope.aperture.magnitude == 127
-
-    # Official Focal Length: 1250mm
-    assert telescope.focal_length.magnitude == 1250
-
-    # Official weight: 96 oz = 2721.55g -> rounded to 2722g in official specs
-    assert telescope.mass.magnitude == 2722
-
-    # Official Secondary Mirror Obstruction: 51mm (2.0")
-    assert telescope.central_obstruction.magnitude == 51
-
-    # Verify vendor string construction
-    assert telescope.get_vendor() == "Celestron C5 OTA (XLT)"
-
-    # Verify focal ratio calculation (stated f/10)
-    # 1250 / 127 = 9.84... but Celestron markets it as f/10.
-    # Physical specs are more important than marketing numbers.
-    assert round(telescope.focal_ratio().magnitude, 1) == 9.8

--- a/tests/unit/test_celestron_ota_specs.py
+++ b/tests/unit/test_celestron_ota_specs.py
@@ -29,7 +29,7 @@ class TestCelestronOTASpecs(unittest.TestCase):
     def test_nexstar_5se_specs(self):
         scope = CelestronTelescope.Celestron_NexStar_5SE()
         self.assertEqual(scope.get_vendor(), "Celestron NexStar 5SE")
-        self.assertEqual(scope.aperture.to('mm').magnitude, 127)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 125)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 1250)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 51)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)


### PR DESCRIPTION
I have completed a data integrity audit for the Celestron 5-inch Schmidt-Cassegrain series. 

### Key Changes:
- **Aperture Correction**: Updated `NexStar 5SE`, `Astro-Fi 5 SCT`, and `C5 SCT` aperture from 127mm to **125mm**. Official manufacturer documentation for these computerized/SCT models specifies a 125mm (4.92") aperture to maintain their signature f/10 focal ratio.
- **Selective Retention**: The `C5 OTA (XLT)` (spotting scope variant) correctly remains at **127mm** as per its specific technical rating.
- **Reference Updates**: Added and corrected source URLs in the database comments for better traceability.
- **Test Consolidation**: Updated and consolidated unit tests in `tests/unit/test_celestron_c5_audit.py` and `tests/unit/test_celestron_ota_specs.py` to verify the corrected physical specifications and calculated focal ratios.

Verified all 13 Celestron-specific tests pass.

---
*PR created automatically by Jules for task [8564274749440548731](https://jules.google.com/task/8564274749440548731) started by @pozar87*