### PR TITLE
🏗️ Architect: Modularized Objects base class and centralized computation

### DIFF
--- a/apts/objects/base.py
+++ b/apts/objects/base.py
@@ -3,6 +3,7 @@ import types
 import unittest.mock
 from abc import ABC, abstractmethod
 from typing import Any, cast
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -26,9 +27,34 @@ class Objects(ABC):
     def get_skyfield_object(self, obj) -> object:
         pass
 
-    @abstractmethod
-    def compute(self, calculation_date=None, df_to_compute=None) -> pd.DataFrame | None:
-        pass
+    def compute(self, calculation_date=None, df_to_compute=None) -> pd.DataFrame:
+        """
+        Default compute implementation using vectorized geometric formulas.
+        Works for all catalogs (Stars, Messier, NGC, SolarObjects).
+        """
+        observer_to_use, _ = self._prepare_observer(calculation_date)
+
+        # If no specific DataFrame is provided, use the class's default.
+        if df_to_compute is None:
+            df_to_compute = self.objects
+
+        # Work on a copy to avoid modifying the original DataFrame slice
+        computed_df = df_to_compute.copy()
+
+        # Fast transit and altitude calculation
+        transits, alts, rises, sets = self._vectorized_geometric_compute(
+            computed_df, observer_to_use
+        )
+        computed_df[ObjectTableLabels.TRANSIT] = transits
+        computed_df[ObjectTableLabels.ALTITUDE] = alts
+        computed_df[ObjectTableLabels.RISING] = rises
+        computed_df[ObjectTableLabels.SETTING] = sets
+
+        # Always update the master objects DataFrame to keep data in sync.
+        # This handles both full catalog computations and subset-specific updates.
+        self.objects.update(computed_df)
+
+        return computed_df
 
     def __init__(self, place, calculation_date=None):
         self.place = place
@@ -56,6 +82,33 @@ class Objects(ABC):
         cast(Any, self.__dict__).update(state)
         # Re-create the unpicklable entries.
         self.ts = get_timescale()
+
+    def _prepare_observer(self, calculation_date):
+        """Prepares the observer and time for computation."""
+        if calculation_date is not None:
+            # It's a Skyfield Time object. If it's an array, use the first element.
+            if hasattr(calculation_date, "shape") and calculation_date.shape:
+                t = calculation_date[0]
+            elif isinstance(calculation_date, type(self.ts.now())):
+                t = calculation_date
+            else:
+                t = self.ts.utc(calculation_date)
+
+            # Avoid creating a whole new Place object, which is slow.
+            # We only need basic properties for computation.
+            observer_to_use = SimpleNamespace(
+                date=t,
+                local_timezone=self.place.local_timezone,
+                lat_decimal=self.place.lat_decimal,
+                lon_decimal=self.place.lon_decimal,
+                elevation=self.place.elevation,
+                observer=self.place.observer,
+                sun=getattr(self.place, "sun", None),
+            )
+        else:
+            observer_to_use = self.place
+            t = self.place.date
+        return observer_to_use, t
 
     def _filter_by_magnitude(
         self, conditions, star_magnitude_limit, limiting_magnitude
@@ -172,6 +225,65 @@ class Objects(ABC):
                         self.objects.loc[visible_candidate_objects.index]
                     )
 
+    def _prepare_visibility_check_times(self, start, stop):
+        """Prepares the time grid for visibility checking."""
+        ts = self.ts
+        t_start = ts.utc(start)
+        t_stop = ts.utc(stop)
+        # Use 100 points to match previous behavior and ensure precision
+        return ts.linspace(t_start, t_stop, 100)
+
+    def _perform_visibility_check(self, candidate_objects, check_times, conditions):
+        """Core visibility check logic."""
+        visible_mask = np.zeros(len(candidate_objects), dtype=bool)
+
+        # Optimization: Identify stars vs moving bodies (others).
+        # For star-only catalogs (NGC, Messier), we can bypass expensive row-wise
+        # Skyfield object instantiation and property access by using a class flag.
+        if getattr(self, "is_star_catalog", False) and "ra_hours" in candidate_objects.columns:
+            is_star = np.ones(len(candidate_objects), dtype=bool)
+            skyfield_objs = None
+        else:
+            # Traditional path for mixed or moving-body catalogs.
+            # Fast property extraction instead of iterrows()
+            if "skyfield_object" in candidate_objects.columns:
+                skyfield_objs = cast(
+                    pd.Series, candidate_objects["skyfield_object"]
+                ).to_numpy()
+            else:
+                skyfield_objs = np.array(
+                    [self.get_skyfield_object(row) for row in candidate_objects.itertuples()]
+                )
+            is_star = np.array([isinstance(obj, Star) for obj in skyfield_objs])
+
+        stars_indices = np.where(is_star)[0]
+        if skyfield_objs is not None:
+            other_indices = np.where(~is_star & pd.notnull(skyfield_objs))[0]
+        else:
+            other_indices = np.array([], dtype=int)
+
+        if len(stars_indices) > 0:
+            self._get_visible_stars(
+                candidate_objects,
+                skyfield_objs,
+                stars_indices,
+                check_times,
+                conditions,
+                visible_mask,
+            )
+
+        observer = self.place.observer
+        # Optimization: move observer.at(check_times) out of the loop
+        # to reuse calculated observer positions for all objects.
+        obs_at_check_times = observer.at(check_times)
+
+        # Check Other objects (like planets)
+        self._get_visible_other(
+            skyfield_objs, other_indices, obs_at_check_times, conditions, visible_mask
+        )
+
+        return visible_mask
+
     def get_visible(
         self,
         conditions,
@@ -193,11 +305,7 @@ class Objects(ABC):
             return pd.DataFrame(columns=self.objects.columns)
 
         # Vectorized visibility check
-        ts = self.ts
-        t_start = ts.utc(start)
-        t_stop = ts.utc(stop)
-        # Use 100 points to match previous behavior and ensure precision
-        check_times = ts.linspace(t_start, t_stop, 100)
+        check_times = self._prepare_visibility_check_times(start, stop)
 
         # Check if get_altaz_curve is mocked or overridden (common in tests)
         # Original method is a bound method, mocked/overridden is often a function or a Mock object
@@ -213,53 +321,9 @@ class Objects(ABC):
                 pd.DataFrame, candidate_objects.loc[visible_objects_indices].copy()
             )
         else:
-            visible_mask = np.zeros(len(candidate_objects), dtype=bool)
-
-            # Optimization: Identify stars vs moving bodies (others).
-            # For star-only catalogs (NGC, Messier), we can bypass expensive row-wise
-            # Skyfield object instantiation and property access by using a class flag.
-            if getattr(self, "is_star_catalog", False) and "ra_hours" in candidate_objects.columns:
-                is_star = np.ones(len(candidate_objects), dtype=bool)
-                skyfield_objs = None
-            else:
-                # Traditional path for mixed or moving-body catalogs.
-                # Fast property extraction instead of iterrows()
-                if "skyfield_object" in candidate_objects.columns:
-                    skyfield_objs = cast(
-                        pd.Series, candidate_objects["skyfield_object"]
-                    ).to_numpy()
-                else:
-                    skyfield_objs = np.array(
-                        [self.get_skyfield_object(row) for row in candidate_objects.itertuples()]
-                    )
-                is_star = np.array([isinstance(obj, Star) for obj in skyfield_objs])
-
-            stars_indices = np.where(is_star)[0]
-            if skyfield_objs is not None:
-                other_indices = np.where(~is_star & pd.notnull(skyfield_objs))[0]
-            else:
-                other_indices = np.array([], dtype=int)
-
-            if len(stars_indices) > 0:
-                self._get_visible_stars(
-                    candidate_objects,
-                    skyfield_objs,
-                    stars_indices,
-                    check_times,
-                    conditions,
-                    visible_mask,
-                )
-
-            observer = self.place.observer
-            # Optimization: move observer.at(check_times) out of the loop
-            # to reuse calculated observer positions for all objects.
-            obs_at_check_times = observer.at(check_times)
-
-            # Check Other objects (like planets)
-            self._get_visible_other(
-                skyfield_objs, other_indices, obs_at_check_times, conditions, visible_mask
+            visible_mask = self._perform_visibility_check(
+                candidate_objects, check_times, conditions
             )
-
             visible_candidate_objects: pd.DataFrame = cast(
                 pd.DataFrame, candidate_objects.loc[visible_mask].copy()
             )
@@ -301,7 +365,7 @@ class Objects(ABC):
 
     def _vectorized_geometric_compute(self, df, observer):
         """
-        Fast transit, altitude, rising, and setting calculation for a DataFrame of Stars.
+        Fast transit, altitude, rising, and setting calculation for a DataFrame of objects.
         Uses vectorized numpy operations and geometric approximations for speed.
 
         Note: Rising/setting times use a geometric formula that accounts for atmospheric
@@ -320,11 +384,12 @@ class Objects(ABC):
                 valid_mask = pd.notna(ras) & pd.notna(decs)
             elif "skyfield_object" in df.columns:
                 sky_objs = df["skyfield_object"].to_numpy()
-                valid_mask = np.array([isinstance(obj, Star) for obj in sky_objs])
+                # Relaxed validity check: any valid Skyfield object in the column
+                valid_mask = pd.notnull(sky_objs)
             else:
                 valid_mask = np.ones(len(df), dtype=bool)
         else:
-            # Fallback: Extract Skyfield Star objects and their coordinates in a vectorized way
+            # Fallback: Extract Skyfield objects and their coordinates in a vectorized way
             if "skyfield_object" in df.columns:
                 sky_objs = df["skyfield_object"].to_numpy()
             else:
@@ -333,13 +398,23 @@ class Objects(ABC):
                     [self.get_skyfield_object(row) for row in df.itertuples()]
                 )
 
-            valid_mask = np.array([isinstance(obj, Star) for obj in sky_objs])
+            valid_mask = pd.notnull(sky_objs)
 
             ras = np.array(
-                [obj.ra.hours if isinstance(obj, Star) else 0 for obj in sky_objs]
+                [
+                    getattr(obj, "ra", getattr(obj, "target_ra", None)).hours
+                    if obj is not None and hasattr(obj, "ra")
+                    else 0
+                    for obj in sky_objs
+                ]
             )
             decs = np.array(
-                [obj.dec.degrees if isinstance(obj, Star) else 0 for obj in sky_objs]
+                [
+                    getattr(obj, "dec", getattr(obj, "target_dec", None)).degrees
+                    if obj is not None and hasattr(obj, "dec")
+                    else 0
+                    for obj in sky_objs
+                ]
             )
 
         return vectorized_geometric_compute(

--- a/apts/objects/messier.py
+++ b/apts/objects/messier.py
@@ -1,5 +1,4 @@
 import functools
-from types import SimpleNamespace
 from .base import Objects
 from ..catalogs import Catalogs
 from ..constants import ObjectTableLabels
@@ -18,44 +17,6 @@ class Messier(Objects):
         self.calculation_date = (
             calculation_date  # Store calculation_date for lazy computation
         )
-
-    def compute(self, calculation_date=None, df_to_compute=None):
-        if calculation_date is not None:
-            # It's a Skyfield Time object. If it's an array, use the first element.
-            if hasattr(calculation_date, "shape") and calculation_date.shape:
-                t = calculation_date[0]
-            elif isinstance(calculation_date, type(self.ts.now())):
-                t = calculation_date
-            else:
-                t = self.ts.utc(calculation_date)
-
-            # Avoid creating a whole new Place object, which is slow.
-            observer_to_use = SimpleNamespace(
-                date=t,
-                local_timezone=self.place.local_timezone,
-                lat_decimal=self.place.lat_decimal,
-                lon_decimal=self.place.lon_decimal,
-                elevation=self.place.elevation,
-                observer=self.place.observer,
-            )
-        else:
-            observer_to_use = self.place
-
-        # If no specific DataFrame is provided, use the class's default.
-        target_df = df_to_compute if df_to_compute is not None else self.objects
-        computed_df = target_df.copy()
-
-        # Fast transit and altitude calculation for stars
-        transits, alts, rises, sets = self._vectorized_geometric_compute(
-            computed_df, observer_to_use
-        )
-        computed_df[ObjectTableLabels.TRANSIT] = transits
-        computed_df[ObjectTableLabels.ALTITUDE] = alts
-        computed_df[ObjectTableLabels.RISING] = rises
-        computed_df[ObjectTableLabels.SETTING] = sets
-
-        self.objects.update(computed_df)
-        return computed_df
 
     @functools.lru_cache(maxsize=128)
     def get_skyfield_object_cached(self, obj_id):

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import numpy as np
 import pandas as pd
 
@@ -140,46 +138,6 @@ class NGC(Objects):
             visible.update(self.objects.loc[indices_needing_restoration])
 
         return visible  # type: ignore[return-value]
-
-    def compute(self, calculation_date=None, df_to_compute=None):
-        if calculation_date is not None:
-            # It's a Skyfield Time object. If it's an array, use the first element.
-            if hasattr(calculation_date, "shape") and calculation_date.shape:
-                t = calculation_date[0]
-            elif isinstance(calculation_date, type(self.ts.now())):
-                t = calculation_date
-            else:
-                t = self.ts.utc(calculation_date)
-
-            # Avoid creating a whole new Place object, which is slow.
-            observer_to_use = SimpleNamespace(
-                date=t,
-                local_timezone=self.place.local_timezone,
-                lat_decimal=self.place.lat_decimal,
-                lon_decimal=self.place.lon_decimal,
-                elevation=self.place.elevation,
-                observer=self.place.observer,
-            )
-        else:
-            observer_to_use = self.place
-
-        # If no specific DataFrame is provided, use the class's default.
-        if df_to_compute is None:
-            df_to_compute = self.objects
-
-        # Work on a copy to avoid modifying the original DataFrame slice
-        computed_df = df_to_compute.copy()
-
-        # Fast transit and altitude calculation for stars
-        transits, alts, rises, sets = self._vectorized_geometric_compute(
-            computed_df, observer_to_use
-        )
-        computed_df[ObjectTableLabels.TRANSIT] = transits
-        computed_df[ObjectTableLabels.ALTITUDE] = alts
-        computed_df[ObjectTableLabels.RISING] = rises
-        computed_df[ObjectTableLabels.SETTING] = sets
-        self.objects.update(computed_df)
-        return computed_df
 
     def get_skyfield_object(self, obj):
         # Handle lazy skyfield_object restoration

--- a/apts/objects/solar/core.py
+++ b/apts/objects/solar/core.py
@@ -1,5 +1,4 @@
 import functools
-from types import SimpleNamespace
 from typing import cast
 
 import numpy as np
@@ -9,7 +8,6 @@ from ...cache import get_mpcorb_data
 from ...constants import DSOType, ObjectTableLabels
 from ...utils import MINOR_PLANET_NAMES, planetary
 from ..base import Objects
-from ..utils import vectorized_geometric_compute
 from .calculations import compute_ephem_and_skyfield_data
 
 
@@ -79,30 +77,6 @@ class SolarObjects(Objects):
 
         return sky_obj if sky_obj is not None and pd.notna(sky_obj) else None
 
-    def _prepare_observer(self, calculation_date):
-        """Prepares the observer and time for computation."""
-        if calculation_date is not None:
-            t = (
-                calculation_date
-                if isinstance(calculation_date, type(self.ts.now()))
-                else self.ts.utc(calculation_date)
-            )
-            # Avoid creating a whole new Place object, which is slow.
-            # We only need basic properties for computation.
-            observer_to_use = SimpleNamespace(
-                date=t,
-                local_timezone=self.place.local_timezone,
-                lat_decimal=self.place.lat_decimal,
-                lon_decimal=self.place.lon_decimal,
-                elevation=self.place.elevation,
-                observer=self.place.observer,
-                sun=self.place.sun,
-            )
-        else:
-            observer_to_use = self.place
-            t = self.place.date
-        return observer_to_use, t
-
     def compute(self, calculation_date=None, df_to_compute=None, skip_transits=False):
         observer_to_use, t = self._prepare_observer(calculation_date)
         target_df = df_to_compute if df_to_compute is not None else self.objects
@@ -118,22 +92,9 @@ class SolarObjects(Objects):
         computed_df.loc[:, ObjectTableLabels.DSO_TYPE] = DSOType.OTHER.value
 
         if not skip_transits:
-            valid_mask = np.ones(len(computed_df), dtype=bool)
-            transits, alts, rises, sets = vectorized_geometric_compute(
-                self.ts,
-                observer_to_use.lat_decimal,
-                observer_to_use.lon_decimal,
-                observer_to_use.local_timezone,
-                observer_to_use.date,
-                computed_df["ra_hours"].to_numpy(),
-                computed_df["dec_degrees"].to_numpy(),
-                valid_mask,
-                len(computed_df),
-            )
-            computed_df[ObjectTableLabels.TRANSIT] = transits
-            computed_df[ObjectTableLabels.ALTITUDE] = alts
-            computed_df[ObjectTableLabels.RISING] = rises
-            computed_df[ObjectTableLabels.SETTING] = sets
+            # Call the base class compute for transit, altitude, rise/set.
+            # We pass computed_df which now has ra_hours/dec_degrees and skyfield_objects.
+            computed_df = super().compute(calculation_date, computed_df)
 
         # Ensure all columns exist in self.objects
         for col in computed_df.columns:

--- a/apts/objects/stars.py
+++ b/apts/objects/stars.py
@@ -1,6 +1,3 @@
-from types import SimpleNamespace
-
-
 from .base import Objects
 from ..catalogs import Catalogs
 from ..constants import ObjectTableLabels
@@ -17,46 +14,6 @@ class Stars(Objects):
         self.calculation_date = (
             calculation_date  # Store calculation_date for lazy computation
         )
-
-    def compute(self, calculation_date=None, df_to_compute=None):
-        if calculation_date is not None:
-            # It's a Skyfield Time object. If it's an array, use the first element.
-            if hasattr(calculation_date, "shape") and calculation_date.shape:
-                t = calculation_date[0]
-            elif isinstance(calculation_date, type(self.ts.now())):
-                t = calculation_date
-            else:
-                t = self.ts.utc(calculation_date)
-
-            # Avoid creating a whole new Place object, which is slow.
-            observer_to_use = SimpleNamespace(
-                date=t,
-                local_timezone=self.place.local_timezone,
-                lat_decimal=self.place.lat_decimal,
-                lon_decimal=self.place.lon_decimal,
-                elevation=self.place.elevation,
-                observer=self.place.observer,
-            )
-        else:
-            observer_to_use = self.place
-
-        # If no specific DataFrame is provided, use the class's default.
-        if df_to_compute is None:
-            df_to_compute = self.objects
-
-        # Work on a copy to avoid modifying the original DataFrame slice
-        computed_df = df_to_compute.copy()
-
-        # Fast transit and altitude calculation for stars
-        transits, alts, rises, sets = self._vectorized_geometric_compute(
-            computed_df, observer_to_use
-        )
-        computed_df[ObjectTableLabels.TRANSIT] = transits
-        computed_df[ObjectTableLabels.ALTITUDE] = alts
-        computed_df[ObjectTableLabels.RISING] = rises
-        computed_df[ObjectTableLabels.SETTING] = sets
-        self.objects.update(computed_df)
-        return computed_df
 
     def get_skyfield_object(self, obj):
         if hasattr(obj, "skyfield_object"):
@@ -81,5 +38,3 @@ class Stars(Objects):
         if not result.empty:
             return self.get_skyfield_object(result.iloc[0])
         return None
-
-


### PR DESCRIPTION
This refactor addresses the "God Object" tendency in the astronomical object catalogs by centralizing common computation logic. By hoisting the observer preparation and the default `compute` implementation into the `Objects` base class, we eliminate significant code duplication across `Stars`, `Messier`, `NGC`, and `SolarObjects` subclasses. 

Key improvements:
1. **DRY Principle**: Shared math and observer setup are now in one place.
2. **Reduced Complexity**: The complex `get_visible` method was decomposed into logical private helpers, improving readability and maintainability.
3. **Flexibility**: The vectorized geometric computation is now robust enough to handle any Skyfield object with RA/Dec coordinates, not just fixed stars.
4. **Consistency**: All catalogs now share a standard interface and implementation for calculating transits, altitudes, and rise/set times.

All relevant unit tests were run and passed successfully.

---
*PR created automatically by Jules for task [7634173279161904084](https://jules.google.com/task/7634173279161904084) started by @pozar87*