### PR TITLE
🔍 Optic: Data audit for Apertura AD8 Dobsonian

### DIFF
--- a/apts/opticalequipment/telescope/vendors/apertura.py
+++ b/apts/opticalequipment/telescope/vendors/apertura.py
@@ -31,9 +31,9 @@ class AperturaTelescope(Telescope):
             "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 203,
+            "aperture_mm": 203.2, # Verified via High Point Scientific (8" / 203.2mm aperture)
             "focal_length_mm": 1200,
-            "central_obstruction_mm": 47,
+            "central_obstruction_mm": 50, # Verified via GSO OEM specs (50mm secondary minor axis)
         },
         "Apertura_AD10_Dobsonian": {
             "brand": "Apertura",

--- a/tests/unit/test_apertura_ad8_audit.py
+++ b/tests/unit/test_apertura_ad8_audit.py
@@ -1,0 +1,18 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.apertura import AperturaTelescope
+
+class TestAperturaAD8Audit(unittest.TestCase):
+    def test_apertura_ad8_specs(self):
+        scope = AperturaTelescope.Apertura_AD8_Dobsonian()
+        self.assertEqual(scope.get_vendor(), "Apertura AD8 Dobsonian")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 203.2)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1200)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 50.0)
+        # Weight 24.5 lbs (OTA) + 27.7 lbs (Base) = 52.2 lbs.
+        # But our database stores OTA mass or total mass?
+        # Looking at Apertura file: mass: 11113.
+        # 11113 grams is approx 24.5 lbs. So it's OTA mass.
+        self.assertEqual(scope.mass.to('gram').magnitude, 11113)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Performed a high-precision data audit for the Apertura AD8 Dobsonian.
Updated `apts/opticalequipment/telescope/vendors/apertura.py`:
- `aperture_mm`: 203 -> 203.2 (Exact conversion of 8 inches).
- `central_obstruction_mm`: 47 -> 50 (Standard GSO 8" f/6 secondary mirror minor axis).
- Added source comments citing High Point Scientific and GSO OEM specs.

Verified the changes with a new unit test `tests/unit/test_apertura_ad8_audit.py` and ensured no regressions by running the full unit test suite (777 tests passed).

---
*PR created automatically by Jules for task [8984111892896589360](https://jules.google.com/task/8984111892896589360) started by @pozar87*