### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Starquest-90MC

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -1155,16 +1155,16 @@ class Sky_watcherTelescope(Telescope):
             "tside_thread": "",
             "type": "newtonian_reflector",
         },
-        "Sky_Watcher_Starquest_80MC": {
-            "aperture_mm": 80,
+        "Sky_Watcher_Starquest_90MC": {
+            "aperture_mm": 90,
             "bf_role": "",
             "brand": "Sky-Watcher",
-            "central_obstruction_mm": 26,
+            "central_obstruction_mm": 29,  # Verified via Sky-Watcher Global (Secondary Mirror Diameter 29mm)
             "cside_gender": "Female",
-            "cside_thread": "2\"",
-            "focal_length_mm": 1000,
-            "mass": 1200,
-            "name": "Starquest 80MC",
+            "cside_thread": "1.25\"",  # Verified via First Light Optics (1.25" visual back) - https://www.firstlightoptics.com/telescopes-in-stock/sky-watcher-starquest-90mc-90mm-maksutov-cassegrain.html
+            "focal_length_mm": 1250,  # Verified via Sky-Watcher Global
+            "mass": 1370,  # Verified via Sky-Watcher Global (1.37 kg OTA Weight)
+            "name": "Starquest-90MC",
             "optical_length": 0,
             "reversible": False,
             "tside_gender": "",
@@ -1466,8 +1466,8 @@ class Sky_watcherTelescope(Telescope):
         return cls.from_database(cls._DATABASE["Sky_Watcher_Star_Adventurer_GTi_80ED"])
 
     @classmethod
-    def Sky_Watcher_Starquest_80MC(cls):
-        return cls.from_database(cls._DATABASE["Sky_Watcher_Starquest_80MC"])
+    def Sky_Watcher_Starquest_90MC(cls):
+        return cls.from_database(cls._DATABASE["Sky_Watcher_Starquest_90MC"])
 
     @classmethod
     def Sky_Watcher_Heritage_P130_FlexTube(cls):

--- a/tests/unit/test_sky_watcher_specs.py
+++ b/tests/unit/test_sky_watcher_specs.py
@@ -178,13 +178,13 @@ class TestSkyWatcherSpecs(unittest.TestCase):
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 136)
         self.assertEqual(scope.mass.to('gram').magnitude, 65000)
 
-    def test_starquest_80mc_specs(self):
-        scope = Sky_watcherTelescope.Sky_Watcher_Starquest_80MC()
-        self.assertEqual(scope.get_vendor(), "Sky-Watcher Starquest 80MC")
-        self.assertEqual(scope.aperture.to('mm').magnitude, 80)
-        self.assertEqual(scope.focal_length.to('mm').magnitude, 1000)
-        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 26)
-        self.assertEqual(scope.mass.to('gram').magnitude, 1200)
+    def test_starquest_90mc_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Starquest_90MC()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Starquest-90MC")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 90)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1250)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 29)
+        self.assertEqual(scope.mass.to('gram').magnitude, 1370)
 
     def test_250pds_newtonian_specs(self):
         scope = Sky_watcherTelescope.Sky_Watcher_250PDS_Newtonian()

--- a/tests/unit/test_sky_watcher_starquest_90mc_audit.py
+++ b/tests/unit/test_sky_watcher_starquest_90mc_audit.py
@@ -1,0 +1,32 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+
+def test_sky_watcher_starquest_90mc_specs():
+    """
+    Test that the Sky-Watcher Starquest-90MC specifications are correct.
+    Verified via First Light Optics: https://www.firstlightoptics.com/telescopes-in-stock/sky-watcher-starquest-90mc-90mm-maksutov-cassegrain.html
+    """
+    telescope = Sky_watcherTelescope.Sky_Watcher_Starquest_90MC()
+
+    assert telescope.get_vendor() == "Sky-Watcher Starquest-90MC"
+    assert telescope.telescope_type.name == "MAKSUTOV_CASSEGRAIN"
+
+    # Check physical specs
+    assert telescope.aperture.to("mm").magnitude == pytest.approx(90.0)
+    assert telescope.focal_length.to("mm").magnitude == pytest.approx(1250.0)
+    assert telescope.central_obstruction.to("mm").magnitude == pytest.approx(29.0)
+    assert telescope.mass.to("gram").magnitude == pytest.approx(1370.0)
+
+    # Check connections
+    from apts.utils import ConnectionType, Gender
+    assert telescope.connection_type == ConnectionType.F_1_25
+    assert telescope.connection_gender == Gender.FEMALE
+
+def test_old_starquest_80mc_is_removed():
+    """
+    Ensure the hallucinated Sky_Watcher_Starquest_80MC is no longer in the database.
+    """
+    with pytest.raises(AttributeError):
+        getattr(Sky_watcherTelescope, "Sky_Watcher_Starquest_80MC")
+
+    assert "Sky_Watcher_Starquest_80MC" not in Sky_watcherTelescope._DATABASE


### PR DESCRIPTION
Audit, verify, and correct the Sky-Watcher Starquest series database. Replaced the erroneous 'Starquest 80MC' entry with the verified 'Starquest-90MC' Maksutov-Cassegrain model. Updated aperture, focal length, central obstruction, mass, and connection type based on official Sky-Watcher and First Light Optics documentation. Verified with new and existing unit tests.

---
*PR created automatically by Jules for task [8235997815263087385](https://jules.google.com/task/8235997815263087385) started by @pozar87*