### PR TITLE
🔍 Optic: Data audit for ZWO ASI2400MC Pro

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -774,7 +774,7 @@ class ZwoCamera(Camera):
             "cside_thread": "",
             "full_well_e": 100000,
             "height": 4042,
-            "mass": 1000,
+            "mass": 730,  # Verified via ZWO (0.73kg) - https://www.zwoastro.com/product/asi2400mc-pro/
             "name": "ASI2400MC Pro",
             "optical_length": 17.5,
             "pixel_size_um": 5.94,
@@ -784,7 +784,7 @@ class ZwoCamera(Camera):
             "sensor_height_mm": 24.0,
             "sensor_width_mm": 36.0,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "M54",  # Verified via ZWO (M54x0.75 female) - https://www.zwoastro.com/product/asi2400mc-pro/
             "type": "type_camera",
             "width": 6072,
         },

--- a/tests/unit/test_zwo_2400mc_audit.py
+++ b/tests/unit/test_zwo_2400mc_audit.py
@@ -1,0 +1,28 @@
+import pytest
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils import ConnectionType, Gender
+
+def test_zwo_2400mc_audit():
+    # Instantiate the camera
+    camera = ZwoCamera.ZWO_ASI_2400MC_Pro()
+
+    # Assert physical specifications
+    assert camera.vendor == "ZWO ASI2400MC Pro"
+    # Current value is 1000, corrected should be 730
+    assert camera.mass.to("gram").magnitude == 730
+    assert camera.optical_length.to("mm").magnitude == 17.5
+
+    # Assert sensor specifications
+    assert camera.full_well == 100000
+    assert camera.pixel_size().to("micrometer").magnitude == 5.94
+    assert camera.quantum_efficiency == 80
+    assert camera.read_noise == 1.1
+    assert camera.width == 6072
+    assert camera.height == 4042
+    assert camera.sensor_width.to("mm").magnitude == 36.0
+    assert camera.sensor_height.to("mm").magnitude == 24.0
+
+    # Assert connections
+    # Current value is M42, corrected should be M54
+    assert camera.connection_type == ConnectionType.M54
+    assert camera.connection_gender == Gender.FEMALE


### PR DESCRIPTION
Audited and corrected the ZWO ASI2400MC Pro specifications based on official manufacturer documentation. Updated the mass parameter from a placeholder 1000g to 730g and the telescope-side thread from M42 to M54. Added a validation unit test verifying these specs.

---
*PR created automatically by Jules for task [7428321305185803879](https://jules.google.com/task/7428321305185803879) started by @pozar87*