### PR TITLE
🏗️ Architect: Decomposed OpticsUtils into Pure Geometric Calculations Package

### DIFF
--- a/apts/optics/calculations/__init__.py
+++ b/apts/optics/calculations/__init__.py
@@ -7,6 +7,12 @@ from .photometry import calculate_sky_flux, calculate_object_flux, calculate_snr
 from .exposure import calculate_npf_rule, calculate_field_rotation_rate
 from .resolution import calculate_airy_disk_diameter
 from .eyepiece import calculate_exit_pupil, calculate_brightness
+from .geometric import (
+    barlows_multiplications,
+    calculate_zoom,
+    calculate_field_of_view,
+    calculate_fov_ratio,
+)
 
 __all__ = [
     "calculate_airmass",
@@ -20,4 +26,8 @@ __all__ = [
     "calculate_airy_disk_diameter",
     "calculate_exit_pupil",
     "calculate_brightness",
+    "barlows_multiplications",
+    "calculate_zoom",
+    "calculate_field_of_view",
+    "calculate_fov_ratio",
 ]

--- a/apts/optics/calculations/geometric.py
+++ b/apts/optics/calculations/geometric.py
@@ -1,0 +1,123 @@
+import functools
+import operator
+from typing import Sequence, Any, Union
+import numpy as np
+
+
+def barlows_multiplications(barlows_list: Sequence[Any]) -> float:
+    """
+    Calculates total Barlow lens multiplication factor.
+    """
+    barlows = [barlow.magnification for barlow in barlows_list]
+    # Multiply all barlows
+    return float(functools.reduce(operator.mul, barlows, 1))
+
+
+def calculate_zoom(
+    telescope: Any,
+    barlows: Sequence[Any],
+    output: Any,
+) -> Any:
+    """
+    Calculates zoom (magnification) of an optical configuration.
+    """
+    from ...units import get_unit_registry
+    from ...opticalequipment.binoculars import Binoculars
+    from ...opticalequipment.naked_eye import NakedEye
+    from ...opticalequipment.smart_telescope import SmartTelescope
+
+    if isinstance(telescope, (Binoculars, NakedEye, SmartTelescope)):
+        return telescope.magnification * get_unit_registry().dimensionless
+
+    # Original logic
+    magnification = barlows_multiplications(barlows)
+    return telescope.focal_length * magnification / output._zoom_divider()
+
+
+def calculate_field_of_view(
+    telescope: Any,
+    barlows: Sequence[Any],
+    output: Any,
+) -> Any:
+    """
+    Calculates field of view of an optical configuration.
+    """
+    from ...opticalequipment.binoculars import Binoculars
+    from ...opticalequipment.naked_eye import NakedEye
+    from ...opticalequipment.smart_telescope import SmartTelescope
+
+    if isinstance(telescope, (Binoculars, NakedEye, SmartTelescope)):
+        return telescope.fov()
+
+    # Original logic
+    magnification = barlows_multiplications(barlows)
+    zoom = calculate_zoom(telescope, barlows, output)
+    return output.field_of_view(telescope, zoom, magnification)
+
+
+def calculate_fov_ratio(object_size: Any, sensor_size: Any, focal_length: Any) -> Any:
+    """
+    Determine the percentage of the frame the object occupies.
+    object_size: tuple (major, minor) in arcminutes
+    sensor_size: tuple (width, height) in mm
+    focal_length: focal length in mm
+    """
+
+    def _get_magnitude(data):
+        if hasattr(data, "to"):
+            # It's a Quantity (scalar or array-wrapped)
+            return data.to("arcminute").magnitude
+        if isinstance(data, (np.ndarray, list, tuple)):
+            # If we have a list of Quantities, np.array() might try to be too smart
+            # and fail if they are heterogeneous or have different units.
+            # Let's handle it by checking if it's a list/tuple and converting elements
+            if isinstance(data, (list, tuple)):
+                # Check if any element is a Quantity
+                if any(hasattr(v, "to") for v in data):
+                    return np.array(
+                        [
+                            (
+                                v.to("arcminute").magnitude
+                                if hasattr(v, "to")
+                                else float(v or 0)
+                            )
+                            for v in data
+                        ],
+                        dtype=float,
+                    )
+
+            data_array = np.array(data)
+            # Check if it contains Quantities (object dtype)
+            if data_array.dtype == object and len(data_array) > 0:
+                # Check first element to see if it's a Quantity
+                if hasattr(data_array[0], "to"):
+                    return np.array(
+                        [
+                            (
+                                v.to("arcminute").magnitude
+                                if hasattr(v, "to")
+                                else float(v or 0)
+                            )
+                            for v in data_array
+                        ],
+                        dtype=float,
+                    )
+            return data_array.astype(float)
+        return float(data or 0)
+
+    # Handle potential pint.Quantity objects in object_size
+    obj_major_arcmin = _get_magnitude(object_size[0])
+    obj_minor_arcmin = _get_magnitude(object_size[1])
+
+    obj_major_deg = obj_major_arcmin / 60.0
+    obj_minor_deg = obj_minor_arcmin / 60.0
+
+    # FOV in degrees = 2 * arctan(sensor_size / (2 * focal_length))
+    fov_w_deg = np.degrees(2 * np.arctan(sensor_size[0] / (2 * focal_length)))
+    fov_h_deg = np.degrees(2 * np.arctan(sensor_size[1] / (2 * focal_length)))
+
+    ratio_w = obj_major_deg / fov_w_deg
+    ratio_h = obj_minor_deg / fov_h_deg
+
+    # Use the maximum ratio to ensure it's not "clipped"
+    return np.maximum(ratio_w, ratio_h) * 100.0

--- a/apts/optics/models/geometric.py
+++ b/apts/optics/models/geometric.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
 
 from ...units import get_unit_registry
 from ..utils import OpticsUtils
+from .. import calculations as optics_utils
 
 
 class GeometricMixIn:
@@ -25,7 +26,7 @@ class GeometricMixIn:
     def effective_barlow(self) -> float:
         if "effective_barlow" not in self._cache:
             self._cache["effective_barlow"] = float(
-                OpticsUtils.barlows_multiplications(self.barlows)
+                optics_utils.barlows_multiplications(self.barlows)
             )
         return self._cache["effective_barlow"]
 

--- a/apts/optics/utils.py
+++ b/apts/optics/utils.py
@@ -1,15 +1,10 @@
-import functools
-import operator
 from typing import TYPE_CHECKING, Any, Sequence, Union, cast
-
-import numpy as np
 
 if TYPE_CHECKING:
     from pint import Quantity
     from ..opticalequipment.base import OpticalEquipment, OutputOpticalEquipment
     from ..opticalequipment.smart_telescope import SmartTelescope
 
-from ..units import get_unit_registry
 from . import calculations as optics_utils
 from ..opticalequipment.binoculars import Binoculars
 from ..opticalequipment.naked_eye import NakedEye
@@ -63,9 +58,10 @@ class OpticsUtils:
 
     @staticmethod
     def barlows_multiplications(barlows_list: Sequence[Any]) -> float:
-        barlows = [barlow.magnification for barlow in barlows_list]
-        # Multiply all barlows
-        return float(functools.reduce(operator.mul, barlows, 1))
+        """
+        Calculates total Barlow lens multiplication factor.
+        """
+        return optics_utils.barlows_multiplications(barlows_list)
 
     @staticmethod
     def compute_zoom(
@@ -73,14 +69,10 @@ class OpticsUtils:
         barlows: Sequence[Any],
         output: Union["OutputOpticalEquipment", Binoculars, NakedEye, "SmartTelescope"],
     ) -> "Quantity":
-        from ..opticalequipment.smart_telescope import SmartTelescope
-
-        if isinstance(telescope, (Binoculars, NakedEye, SmartTelescope)):
-            return telescope.magnification * get_unit_registry().dimensionless
-
-        # Original logic
-        magnification = OpticsUtils.barlows_multiplications(barlows)
-        return telescope.focal_length * magnification / output._zoom_divider()
+        """
+        Calculates zoom (magnification) of an optical configuration.
+        """
+        return optics_utils.calculate_zoom(telescope, barlows, output)
 
     @staticmethod
     def calculate_airmass(altitude_degrees: float) -> float:
@@ -98,16 +90,10 @@ class OpticsUtils:
         barlows: Sequence[Any],
         output: Union["OutputOpticalEquipment", Binoculars, NakedEye, "SmartTelescope"],
     ) -> "Quantity":
-        from ..opticalequipment.smart_telescope import SmartTelescope
-
-        if isinstance(telescope, (Binoculars, NakedEye, SmartTelescope)):
-            return telescope.fov()
-
-        # Original logic
-        magnification = OpticsUtils.barlows_multiplications(barlows)
-        zoom = OpticsUtils.compute_zoom(telescope, barlows, output)
-        # TODO: this is not best way to do it
-        return output.field_of_view(telescope, zoom, magnification)
+        """
+        Calculates field of view of an optical configuration.
+        """
+        return optics_utils.calculate_field_of_view(telescope, barlows, output)
 
     @staticmethod
     def calculate_fov_ratio(object_size, sensor_size, focal_length):
@@ -117,62 +103,4 @@ class OpticsUtils:
         sensor_size: tuple (width, height) in mm
         focal_length: focal length in mm
         """
-
-        def _get_magnitude(data):
-            if hasattr(data, "to"):
-                # It's a Quantity (scalar or array-wrapped)
-                return data.to("arcminute").magnitude
-            if isinstance(data, (np.ndarray, list, tuple)):
-                # If we have a list of Quantities, np.array() might try to be too smart
-                # and fail if they are heterogeneous or have different units.
-                # Let's handle it by checking if it's a list/tuple and converting elements
-                if isinstance(data, (list, tuple)):
-                    # Check if any element is a Quantity
-                    if any(hasattr(v, "to") for v in data):
-                        return np.array(
-                            [
-                                (
-                                    v.to("arcminute").magnitude
-                                    if hasattr(v, "to")
-                                    else float(v or 0)
-                                )
-                                for v in data
-                            ],
-                            dtype=float,
-                        )
-
-                data_array = np.array(data)
-                # Check if it contains Quantities (object dtype)
-                if data_array.dtype == object and len(data_array) > 0:
-                    # Check first element to see if it's a Quantity
-                    if hasattr(data_array[0], "to"):
-                        return np.array(
-                            [
-                                (
-                                    v.to("arcminute").magnitude
-                                    if hasattr(v, "to")
-                                    else float(v or 0)
-                                )
-                                for v in data_array
-                            ],
-                            dtype=float,
-                        )
-                return data_array.astype(float)
-            return float(data or 0)
-
-        # Handle potential pint.Quantity objects in object_size
-        obj_major_arcmin = _get_magnitude(object_size[0])
-        obj_minor_arcmin = _get_magnitude(object_size[1])
-
-        obj_major_deg = obj_major_arcmin / 60.0
-        obj_minor_deg = obj_minor_arcmin / 60.0
-
-        # FOV in degrees = 2 * arctan(sensor_size / (2 * focal_length))
-        fov_w_deg = np.degrees(2 * np.arctan(sensor_size[0] / (2 * focal_length)))
-        fov_h_deg = np.degrees(2 * np.arctan(sensor_size[1] / (2 * focal_length)))
-
-        ratio_w = obj_major_deg / fov_w_deg
-        ratio_h = obj_minor_deg / fov_h_deg
-
-        # Use the maximum ratio to ensure it's not "clipped"
-        return np.maximum(ratio_w, ratio_h) * 100.0
+        return optics_utils.calculate_fov_ratio(object_size, sensor_size, focal_length)

--- a/tests/unit/test_optics_calculations_geometric.py
+++ b/tests/unit/test_optics_calculations_geometric.py
@@ -1,0 +1,101 @@
+import pytest
+import numpy as np
+from unittest.mock import MagicMock
+
+from apts.optics.calculations.geometric import (
+    barlows_multiplications,
+    calculate_zoom,
+    calculate_field_of_view,
+    calculate_fov_ratio,
+)
+from apts.units import get_unit_registry
+
+ureg = get_unit_registry()
+
+
+def test_barlows_multiplications():
+    # Empty list should return 1.0
+    assert barlows_multiplications([]) == 1.0
+
+    # Mock barlow lenses
+    barlow1 = MagicMock()
+    barlow1.magnification = 2.0
+    barlow2 = MagicMock()
+    barlow2.magnification = 1.5
+
+    assert barlows_multiplications([barlow1]) == 2.0
+    assert barlows_multiplications([barlow1, barlow2]) == 3.0
+
+
+def test_calculate_zoom_binoculars_etc():
+    # Binoculars, NakedEye, or SmartTelescope have a magnification property
+    mock_binoculars = MagicMock()
+    mock_binoculars.magnification = 8.0
+
+    # Using isinstance check with a dynamically subclassed mock or registering classes
+    from apts.opticalequipment.binoculars import Binoculars
+    from apts.opticalequipment.naked_eye import NakedEye
+    from apts.opticalequipment.smart_telescope import SmartTelescope
+
+    # Create mock of Binoculars class
+    class MyBinoculars(Binoculars):
+        def __init__(self):
+            pass
+
+    binocs = MyBinoculars()
+    binocs.magnification = 10.0
+
+    zoom = calculate_zoom(binocs, [], None)
+    assert zoom.magnitude == 10.0
+    assert zoom.units == ureg.dimensionless
+
+
+def test_calculate_zoom_telescope():
+    mock_telescope = MagicMock()
+    mock_telescope.focal_length = 1000 * ureg.mm
+
+    mock_barlow = MagicMock()
+    mock_barlow.magnification = 2.0
+
+    mock_output = MagicMock()
+    mock_output._zoom_divider.return_value = 10 * ureg.mm
+
+    zoom = calculate_zoom(mock_telescope, [mock_barlow], mock_output)
+    # 1000 * 2 / 10 = 200
+    assert zoom.magnitude == 200.0
+
+
+def test_calculate_field_of_view_binoculars_etc():
+    from apts.opticalequipment.naked_eye import NakedEye
+
+    class MyNakedEye(NakedEye):
+        def __init__(self):
+            pass
+
+    eye = MyNakedEye()
+    eye.fov = MagicMock(return_value=120 * ureg.deg)
+
+    fov = calculate_field_of_view(eye, [], None)
+    assert fov.magnitude == 120.0
+    assert fov.units == ureg.deg
+
+
+def test_calculate_field_of_view_telescope():
+    mock_telescope = MagicMock()
+    mock_telescope.focal_length = 1000 * ureg.mm
+
+    mock_barlow = MagicMock()
+    mock_barlow.magnification = 2.0
+
+    mock_output = MagicMock()
+    mock_output._zoom_divider.return_value = 10 * ureg.mm
+    mock_output.field_of_view.return_value = 0.5 * ureg.deg
+
+    fov = calculate_field_of_view(mock_telescope, [mock_barlow], mock_output)
+    assert fov.magnitude == 0.5
+    assert fov.units == ureg.deg
+
+
+def test_calculate_fov_ratio_scalar():
+    ratio = calculate_fov_ratio((60, 30), (22.2, 14.8), 750)
+    assert ratio == pytest.approx(58.96, rel=1e-3)


### PR DESCRIPTION
Refactored OpticsUtils in apts/optics/utils.py by extracting pure geometric calculations into apts/optics/calculations/geometric.py. Centralized logic for barlows_multiplications, calculate_zoom, calculate_field_of_view, and calculate_fov_ratio as pure functions. Refactored OpticsUtils and GeometricMixIn to delegate to these utilities while preserving backward compatibility. Verified with new unit tests in tests/unit/test_optics_calculations_geometric.py.

---
*PR created automatically by Jules for task [3933238343663096531](https://jules.google.com/task/3933238343663096531) started by @pozar87*