### PR TITLE
🔍 Optic: Data audit for Celestron AstroMaster 90AZ and NexStar 4SE

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -135,7 +135,7 @@ class CelestronTelescope(Telescope):
             "name": "AstroMaster 90AZ",
             "type": "refractor",
             "optical_length": 0,
-            "mass": 2268,
+            "mass": 1996, # Verified via Celestron.com (4.4 lbs OTA weight) - https://www.celestron.com/products/astromaster-90az-telescope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "1.25\"",
@@ -730,7 +730,7 @@ class CelestronTelescope(Telescope):
             "mass": 2722,
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "SC (Schmidt-Cassegrain)",
+            "cside_thread": "1.375\"-24", # Verified via standard Meade ETX / NexStar 4SE smaller rear thread specification
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",

--- a/apts/utils/equipment.py
+++ b/apts/utils/equipment.py
@@ -34,6 +34,7 @@ class ConnectionType(Enum):
     PENTAX_K = "Pentax K"
     CS = "CS"
     SC = "SC (Schmidt-Cassegrain)"
+    NX4 = "1.375\"-24"
     ZWO_6_BOLT = "ZWO 6-bolt"
     ZWO_4_BOLT = "ZWO 4-bolt"
     QHY_4_BOLT = "QHY 4-bolt"

--- a/tests/unit/test_astromaster_90az_specs.py
+++ b/tests/unit/test_astromaster_90az_specs.py
@@ -8,7 +8,7 @@ class TestAstroMaster90AZ(unittest.TestCase):
         self.assertEqual(scope.aperture.to('mm').magnitude, 90)
         self.assertEqual(scope.focal_length.to('mm').magnitude, 1000)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
-        self.assertEqual(scope.mass.to('gram').magnitude, 2268)
+        self.assertEqual(scope.mass.to('gram').magnitude, 1996)
         self.assertEqual(scope.focal_ratio().magnitude, 1000/90)
 
 if __name__ == '__main__':

--- a/tests/unit/test_celestron_ota_specs.py
+++ b/tests/unit/test_celestron_ota_specs.py
@@ -1,5 +1,6 @@
 import unittest
 from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+from apts.utils import ConnectionType
 
 class TestCelestronOTASpecs(unittest.TestCase):
     def test_c11_ota_specs(self):
@@ -25,6 +26,7 @@ class TestCelestronOTASpecs(unittest.TestCase):
         self.assertEqual(scope.focal_length.to('mm').magnitude, 1325)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 35)
         self.assertEqual(scope.mass.to('gram').magnitude, 2722)
+        self.assertEqual(scope.connection_type, ConnectionType.NX4)
 
     def test_nexstar_5se_specs(self):
         scope = CelestronTelescope.Celestron_NexStar_5SE()


### PR DESCRIPTION
This PR audits and corrects the Celestron hardware database:
1. Celestron AstroMaster 90AZ: corrected weight from 2268g to 1996g per official manufacturer specs.
2. Celestron NexStar 4SE: corrected visual back/rear cell thread from standard SC to 1.375"-24 (ETX/NX4 thread size) as standard for this Maksutov-Cassegrain. Added ConnectionType.NX4 to support this change.
3. Updated unit tests in `tests/unit/test_astromaster_90az_specs.py` and `tests/unit/test_celestron_ota_specs.py` accordingly. All tests pass successfully.

---
*PR created automatically by Jules for task [820586559751430997](https://jules.google.com/task/820586559751430997) started by @pozar87*