### PR TITLE
🔍 Optic: Data audit for Celestron Astro-Fi 6 SCT

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -167,7 +167,7 @@ class CelestronTelescope(Telescope):
             "name": "Astro-Fi 6 SCT",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 4536, # Verified via Celestron.com (10 lbs OTA weight)
+            "mass": 2177, # Verified via Celestron.com (4.8 lbs / 2.17 kg OTA weight) - https://www.celestron.com/products/astro-fi-6-schmidt-cassegrain-telescope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
@@ -176,7 +176,7 @@ class CelestronTelescope(Telescope):
             "bf_role": "",
             "aperture_mm": 150,
             "focal_length_mm": 1500,
-            "central_obstruction_mm": 56,
+            "central_obstruction_mm": 55.88, # Verified via Celestron.com (2.2" secondary obstruction) - https://www.celestron.com/products/astro-fi-6-schmidt-cassegrain-telescope
         },
         "Celestron_C11_A_XLT_OTA": {
             "brand": "Celestron",

--- a/tests/unit/test_celestron_c6_audit.py
+++ b/tests/unit/test_celestron_c6_audit.py
@@ -12,7 +12,7 @@ class TestCelestronC6Audit(unittest.TestCase):
 
     def test_astro_fi_6_sct_mass(self):
         scope = CelestronTelescope.Celestron_Astro_Fi_6_SCT()
-        self.assertEqual(scope.mass.to('gram').magnitude, 4536)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2177)
 
     def test_nexstar_evolution_6_mass(self):
         scope = CelestronTelescope.Celestron_NexStar_Evolution_6()


### PR DESCRIPTION
### 🔍 Optic: Data audit for Celestron Astro-Fi 6 SCT

#### 🔧 Calibrate & Fix
- Corrected the `mass` field for `Celestron_Astro_Fi_6_SCT` from `4536` to `2177` grams (representing the official 4.8 lbs / 2.17 kg OTA weight).
- Corrected the `central_obstruction_mm` field for `Celestron_Astro_Fi_6_SCT` from `56` to `55.88` mm (representing the official 2.2" secondary mirror obstruction).
- Added a reference URL comment pointing to the official Celestron product specification page.
- Updated `test_astro_fi_6_sct_mass` in `tests/unit/test_celestron_c6_audit.py` to assert the correct, audited mass of `2177` grams.

#### 🎯 Source
- Reference: [Celestron Astro Fi 6 Schmidt-Cassegrain Telescope Product Page](https://www.celestron.com/products/astro-fi-6-schmidt-cassegrain-telescope)

---
*PR created automatically by Jules for task [13417016580877705104](https://jules.google.com/task/13417016580877705104) started by @pozar87*