### PR TITLE
🔍 Optic: Data audit for TPO 6\" f/4 Newtonian telescope

### DIFF
--- a/apts/opticalequipment/telescope/vendors/tpo.py
+++ b/apts/opticalequipment/telescope/vendors/tpo.py
@@ -70,15 +70,18 @@ class TpoTelescope(Telescope):
         "TPO_TPO_6_f_4_Newton": {
             "brand": "TPO",
             "name": "TPO 6\" f/4 Newton",
-            "type": "type_telescope",
+            "type": "newtonian_reflector",
             "optical_length": 0,
-            "mass": 4800,
+            "mass": 4354, # Verified via OPT (9.6 lbs tube weight) - https://optcorp.com/products/tpo-6-f-4-newtonian-reflecting-ota-telescope
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"", # Verified via OPT (2\" focuser drawtube)
+            "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
+            "aperture_mm": 154, # Verified via OPT (154mm / 6\" aperture)
+            "focal_length_mm": 610, # Verified via OPT (610mm focal length)
+            "central_obstruction_mm": 63, # Verified via OPT (63mm secondary mirror obstruction)
         },
         "TPO_TPO_8_f_4_Newton": {
             "brand": "TPO",

--- a/tests/unit/test_tpo_6_f4_audit.py
+++ b/tests/unit/test_tpo_6_f4_audit.py
@@ -1,0 +1,23 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.tpo import TpoTelescope
+from apts.utils import ConnectionType
+
+class TestTpo6F4Audit(unittest.TestCase):
+    def test_tpo_6_f4_specs(self):
+        """
+        Audit for TPO 6" f/4 Newtonian reflecting OTA telescope.
+        Source: https://optcorp.com/products/tpo-6-f-4-newtonian-reflecting-ota-telescope
+        """
+        scope = TpoTelescope.TPO_TPO_6_f_4_Newton()
+        self.assertEqual(scope.get_vendor(), "TPO TPO 6\" f/4 Newton")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 154)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 610)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 63)
+        self.assertEqual(scope.mass.to('gram').magnitude, 4354)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+
+        # Stated focal ratio: f/4, calculated: 610 / 154 = 3.96103896
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 3.9610, places=4)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Corrected TPO 6\" f/4 Newtonian specs using official OPT documentation. Set aperture_mm to 154, focal_length_mm to 610, central_obstruction_mm to 63, mass to 4354g (9.6 lbs), type to 'newtonian_reflector', cside_thread to '2\"', and cside_gender to 'Female'. Added a new unit test suite tests/unit/test_tpo_6_f4_audit.py to assert data-integrity of the entry.

---
*PR created automatically by Jules for task [100318620194101347](https://jules.google.com/task/100318620194101347) started by @pozar87*