### PR TITLE
🔍 Optic: Data audit for Explore Scientific FirstLight 203mm Newtonian

### DIFF
--- a/apts/opticalequipment/telescope/vendors/explore_scientific.py
+++ b/apts/opticalequipment/telescope/vendors/explore_scientific.py
@@ -216,15 +216,15 @@ class Explore_scientificTelescope(Telescope):
             "name": "FirstLight 203mm Newtonian",
             "type": "newtonian_reflector",
             "optical_length": 0,
-            "mass": 9500,
+            "mass": 9979, # Verified via official Explore Scientific specs (22 lbs OTA weight)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "2\"",
             "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 203,
-            "focal_length_mm": 800,
+            "aperture_mm": 203.2, # Verified via official specs (8 inches unrounded)
+            "focal_length_mm": 1000, # Verified via official Explore Scientific specs (FL-N2031000 has 1000mm FL) - https://explorescientific.com/products/explore-scientific-firstlight-203mm-newtonian
             "central_obstruction_mm": 63,
         },
         "Explore_Scientific_FirstLight_100mm_Mak": {

--- a/tests/unit/test_explore_scientific_specs.py
+++ b/tests/unit/test_explore_scientific_specs.py
@@ -26,6 +26,14 @@ def test_es_firstlight_newtonian_specs():
     assert scope.mass.magnitude == 3175
     assert scope.telescope_type == TelescopeType.NEWTONIAN_REFLECTOR
 
+    # FirstLight 203mm
+    scope_203 = Explore_scientificTelescope.Explore_Scientific_FirstLight_203mm_Newtonian()
+    assert scope_203.aperture.magnitude == 203.2
+    assert scope_203.focal_length.magnitude == 1000
+    assert scope_203.central_obstruction.magnitude == 63
+    assert scope_203.mass.magnitude == 9979
+    assert scope_203.telescope_type == TelescopeType.NEWTONIAN_REFLECTOR
+
 def test_es_firstlight_mak_specs():
     # FirstLight 152mm Mak
     scope = Explore_scientificTelescope.Explore_Scientific_FirstLight_152mm_Mak()


### PR DESCRIPTION
💡 Fix: Corrected aperture from rounded 203 to unrounded 203.2mm, focal length from incorrect 800 to 1000mm, and mass from generic 9500 to exact 9979g (22 lbs OTA weight).
🎯 Source: Reference to official manufacturer specs: https://explorescientific.com/products/explore-scientific-firstlight-203mm-newtonian

---
*PR created automatically by Jules for task [2693857528553064478](https://jules.google.com/task/2693857528553064478) started by @pozar87*