### PR TITLE
🔍 Optic: Data audit for TPO f/4 Newtonian Telescopes

### DIFF
--- a/apts/opticalequipment/telescope/vendors/tpo.py
+++ b/apts/opticalequipment/telescope/vendors/tpo.py
@@ -86,28 +86,34 @@ class TpoTelescope(Telescope):
         "TPO_TPO_8_f_4_Newton": {
             "brand": "TPO",
             "name": "TPO 8\" f/4 Newton",
-            "type": "type_telescope",
+            "type": "newtonian_reflector",
             "optical_length": 0,
-            "mass": 7800,
+            "mass": 8709, # Verified via OPT (19.2 lbs tube weight) - https://optcorp.com/products/tpo-8-f-4-newtonian-reflecting-ota-telescope
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"", # Verified via OPT (2\" focuser connection)
+            "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
+            "aperture_mm": 200, # Verified via OPT (200mm aperture)
+            "focal_length_mm": 800, # Verified via OPT (800mm focal length)
+            "central_obstruction_mm": 70, # Verified via OPT (70mm secondary mirror obstruction)
         },
         "TPO_TPO_10_f_4_Newton": {
             "brand": "TPO",
             "name": "TPO 10\" f/4 Newton",
-            "type": "type_telescope",
+            "type": "newtonian_reflector",
             "optical_length": 0,
-            "mass": 12000,
+            "mass": 13290, # Verified via OPT (29.3 lbs tube weight) - https://optcorp.com/products/tpo-10-f-4-newtonian-reflecting-ota-telescope
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"", # Verified via OPT (3.3\" focuser steps down to 2\" compression ring)
+            "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
+            "aperture_mm": 254, # Verified via OPT (254mm / 10\" aperture)
+            "focal_length_mm": 1016, # Verified via OPT (1016mm focal length)
+            "central_obstruction_mm": 70, # Verified via OPT (70mm secondary mirror obstruction)
         },
         "TPO_TPO_80mm_ED_APO": {
             "brand": "TPO",

--- a/tests/unit/test_tpo_8_10_f4_audit.py
+++ b/tests/unit/test_tpo_8_10_f4_audit.py
@@ -1,0 +1,42 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.tpo import TpoTelescope
+from apts.utils import ConnectionType
+from apts.opticalequipment.telescope.base import TelescopeType
+
+class TestTpo810F4Audit(unittest.TestCase):
+    def test_tpo_8_f4_specs(self):
+        """
+        Audit for TPO 8" f/4 Newtonian reflecting OTA telescope.
+        Source: https://optcorp.com/products/tpo-8-f-4-newtonian-reflecting-ota-telescope
+        """
+        scope = TpoTelescope.TPO_TPO_8_f_4_Newton()
+        self.assertEqual(scope.get_vendor(), "TPO TPO 8\" f/4 Newton")
+        self.assertEqual(scope.telescope_type, TelescopeType.NEWTONIAN_REFLECTOR)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 200)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 800)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 70)
+        self.assertEqual(scope.mass.to('gram').magnitude, 8709)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+
+        # Derived focal ratio: 800 / 200 = 4.0
+        self.assertEqual(scope.focal_ratio().magnitude, 4.0)
+
+    def test_tpo_10_f4_specs(self):
+        """
+        Audit for TPO 10" f/4 Newtonian reflecting OTA telescope.
+        Source: https://optcorp.com/products/tpo-10-f-4-newtonian-reflecting-ota-telescope
+        """
+        scope = TpoTelescope.TPO_TPO_10_f_4_Newton()
+        self.assertEqual(scope.get_vendor(), "TPO TPO 10\" f/4 Newton")
+        self.assertEqual(scope.telescope_type, TelescopeType.NEWTONIAN_REFLECTOR)
+        self.assertEqual(scope.aperture.to('mm').magnitude, 254)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1016)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 70)
+        self.assertEqual(scope.mass.to('gram').magnitude, 13290)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+
+        # Derived focal ratio: 1016 / 254 = 4.0
+        self.assertEqual(scope.focal_ratio().magnitude, 4.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have audited, verified, and corrected the technical specifications for the TPO 8" and 10" f/4 Newtonian Reflecting OTA Telescopes in the `apts` database. The missing attributes (aperture, focal length, secondary mirror obstruction, precise mass, and focuser connection ports) have been added using official OPT manufacturer specifications.

Additionally, I created a dedicated unit test suite under `tests/unit/test_tpo_8_10_f4_audit.py` to ensure high data integrity, backward compatibility, and derived focal ratio verification.

---
*PR created automatically by Jules for task [4329494855295842167](https://jules.google.com/task/4329494855295842167) started by @pozar87*