### PR TITLE
🔍 Optic: Data audit for Canon EF 135mm f/2L lenses

### DIFF
--- a/apts/opticalequipment/telescope/vendors/canon.py
+++ b/apts/opticalequipment/telescope/vendors/canon.py
@@ -16,11 +16,13 @@ class CanonTelescope(Telescope):
             "bf_role": "",
         },
         "Canon_EF_135mm_f_2L": {
+            "aperture_mm": 67.5, # Verified via Canon Europe spec sheet (135mm f/2 => 135/2 = 67.5mm) - https://www.canon-europe.com/lenses/ef-135mm-f-2l-usm-lens/specification.html
             "brand": "Canon",
+            "focal_length_mm": 135, # Verified via Canon Europe spec sheet
             "name": "EF 135mm f/2L",
             "type": "type_camera_lens",
             "optical_length": 0,
-            "mass": 750,
+            "mass": 750, # Verified via Canon Europe spec sheet
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "EOS",
@@ -302,11 +304,13 @@ class CanonTelescope(Telescope):
             "bf_role": "",
         },
         "Canon_EF_135mm_f_2L_USM": {
+            "aperture_mm": 67.5, # Verified via Canon Europe spec sheet (135mm f/2 => 135/2 = 67.5mm) - https://www.canon-europe.com/lenses/ef-135mm-f-2l-usm-lens/specification.html
             "brand": "Canon",
+            "focal_length_mm": 135, # Verified via Canon Europe spec sheet
             "name": "EF 135mm f/2L USM",
             "type": "type_camera_lens",
             "optical_length": 0,
-            "mass": 750,
+            "mass": 750, # Verified via Canon Europe spec sheet
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "EOS",

--- a/tests/unit/test_canon_135_audit.py
+++ b/tests/unit/test_canon_135_audit.py
@@ -1,0 +1,36 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.canon import CanonTelescope
+
+def test_canon_ef_135_specs():
+    """
+    Audit test for Canon EF 135mm f/2L and Canon EF 135mm f/2L USM based on official Canon Europe specs.
+    Source: https://www.canon-europe.com/lenses/ef-135mm-f-2l-usm-lens/specification.html
+    """
+    lenses = [
+        CanonTelescope.Canon_EF_135mm_f_2L(),
+        CanonTelescope.Canon_EF_135mm_f_2L_USM()
+    ]
+
+    for lens in lenses:
+        # Mass: stored as a Pint Quantity in grams (750g)
+        assert lens.mass.to('gram').magnitude == 750
+        assert str(lens.mass.units) == 'gram'
+
+        # Aperture: 67.5mm
+        assert lens.aperture.to('mm').magnitude == 67.5
+
+        # Focal length: 135mm
+        assert lens.focal_length.to('mm').magnitude == 135
+
+        # Focal ratio (f/2)
+        assert float(lens.focal_ratio().magnitude) == 2.0
+
+        # Central obstruction is 0 (refractor/lens)
+        assert lens.central_obstruction.magnitude == 0
+
+        # Connection type is EOS
+        from apts.utils.equipment import ConnectionType
+        assert lens.connection_type == ConnectionType.EOS
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Audited and corrected the missing aperture and focal length specifications for the Canon EF 135mm f/2L and f/2L USM lenses in the database to align with official manufacturer technical data. Written a validation test suite to confirm the updated properties.

---
*PR created automatically by Jules for task [13442813006833913902](https://jules.google.com/task/13442813006833913902) started by @pozar87*