### PR TITLE
🔍 Optic: Data audit for GSO RC 6"

### DIFF
--- a/apts/opticalequipment/telescope/vendors/gso.py
+++ b/apts/opticalequipment/telescope/vendors/gso.py
@@ -7,16 +7,16 @@ class GsoTelescope(Telescope):
             "name": "RC 6\"",
             "type": "catadioptric",
             "optical_length": 0,
-            "mass": 5580,
+            "mass": 5400, # Verified via Teleskop Service / GSO OEM specs (5.4 kg OTA weight) - https://www.teleskop-express.de/en/ts-optics-gso-6-ritchey-chretien-pro-rc-telescope-154-1370-mm-ota-2445
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "M90",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 152,
+            "aperture_mm": 152.4, # Verified via GSO OEM specs (6" = 152.4mm aperture)
             "focal_length_mm": 1370,
-            "central_obstruction_mm": 71,
+            "central_obstruction_mm": 77, # Verified via GSO OEM specs (77mm secondary mirror obstruction) - https://www.teleskop-express.de/en/ts-optics-gso-6-ritchey-chretien-pro-rc-telescope-154-1370-mm-ota-2445
         },
         "GSO_RC_8": {
             "brand": "GSO",

--- a/tests/unit/test_gso_specs.py
+++ b/tests/unit/test_gso_specs.py
@@ -5,11 +5,11 @@ from apts.units import get_unit_registry
 class TestGsoSpecs(unittest.TestCase):
     def test_gso_rc_6(self):
         telescope = GsoTelescope.GSO_RC_6()
-        self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 152)
+        self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 152.4)
         self.assertEqual(telescope.focal_length.to(get_unit_registry().mm).magnitude, 1370)
-        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 5580)
-        self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 71)
-        self.assertAlmostEqual(telescope.focal_ratio().magnitude, 9.01, places=2)
+        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 5400)
+        self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 77)
+        self.assertAlmostEqual(telescope.focal_ratio().magnitude, 8.99, places=2)
 
     def test_gso_newton_8_f_4(self):
         telescope = GsoTelescope.GSO_Newton_8_f_4()


### PR DESCRIPTION
Audited and corrected the GSO RC 6" Ritchey-Chretien telescope hardware specifications in the database (`apts/opticalequipment/telescope/vendors/gso.py`) based on official manufacturer and Teleskop Service/OEM documentation. Specifically:
- Corrected `aperture_mm` from `152` to `152.4` (representing the physical, unrounded 6" aperture).
- Corrected `mass` from `5580` to `5400` (representing the official 5.4 kg OTA weight).
- Corrected `central_obstruction_mm` from `71` to `77` (representing the official 77 mm minor axis secondary mirror obstruction diameter).
- Added comments detailing the sources.
- Updated `tests/unit/test_gso_specs.py` assertions accordingly, ensuring correct derived focal ratio and weight/aperture.

All unit tests pass successfully.

---
*PR created automatically by Jules for task [1007666261562536115](https://jules.google.com/task/1007666261562536115) started by @pozar87*