### PR TITLE
🏗️ Architect: Modularized Light Pollution Package

### DIFF
--- a/apts/light_pollution/__init__.py
+++ b/apts/light_pollution/__init__.py
@@ -1,0 +1,4 @@
+from .core import LightPollution
+from .calculations import bortle_to_sqm
+
+__all__ = ["LightPollution", "bortle_to_sqm"]

--- a/apts/light_pollution/calculations.py
+++ b/apts/light_pollution/calculations.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+def bortle_to_sqm(bortle_class: float) -> float:
+    """
+    Converts a Bortle class (1-9) to an approximate Sky Quality Meter (SQM) value
+    in mag/arcsec^2. Uses linear interpolation between established midpoints.
+    Source: https://en.wikipedia.org/wiki/Bortle_scale
+    """
+    xp = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    fp = [21.88, 21.67, 21.45, 21.05, 19.77, 18.87, 18.25, 17.5, 16.0]
+    return float(np.interp(bortle_class, xp, fp))

--- a/apts/light_pollution/core.py
+++ b/apts/light_pollution/core.py
@@ -1,9 +1,9 @@
 import logging
-import numpy as np
 from PIL import Image
 from importlib import resources
 
-from .config import get_light_pollution_settings
+from apts.config import get_light_pollution_settings
+from .calculations import bortle_to_sqm
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +16,7 @@ class LightPollution:
         in mag/arcsec^2. Uses linear interpolation between established midpoints.
         Source: https://en.wikipedia.org/wiki/Bortle_scale
         """
-        xp = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-        fp = [21.88, 21.67, 21.45, 21.05, 19.77, 18.87, 18.25, 17.5, 16.0]
-        return float(np.interp(bortle_class, xp, fp))
+        return bortle_to_sqm(bortle_class)
 
     _IMAGE = None
     _PIX = None
@@ -54,7 +52,7 @@ class LightPollution:
 
         try:
             # We import here to avoid circular dependency and leverage existing central cache
-            from .utils.network import get_session
+            from apts.utils.network import get_session
 
             url = "https://www.darkskysites.com/api/site-intelligence"
             params = {"lat": self.lat, "lng": self.lon}

--- a/tests/unit/test_light_pollution.py
+++ b/tests/unit/test_light_pollution.py
@@ -6,7 +6,7 @@ from apts.light_pollution import LightPollution
 class TestLightPollution(unittest.TestCase):
     def setUp(self):
         # We patch Image.open in the setUp to avoid loading the actual image in every test
-        self.patcher = patch("apts.light_pollution.Image.open")
+        self.patcher = patch("apts.light_pollution.core.Image.open")
         self.mock_image_open = self.patcher.start()
         self.mock_image = MagicMock()
         self.mock_image.size = (14400, 5600)  # Set expected dimensions
@@ -15,7 +15,7 @@ class TestLightPollution(unittest.TestCase):
         self.mock_image_open.return_value = self.mock_image
 
         # Patch API calls and settings to avoid network access during tests
-        self.patch_settings = patch("apts.light_pollution.get_light_pollution_settings")
+        self.patch_settings = patch("apts.light_pollution.core.get_light_pollution_settings")
         self.mock_get_settings = self.patch_settings.start()
         self.mock_get_settings.return_value = {"use_online_api": False}
 
@@ -75,21 +75,21 @@ class TestLightPollution(unittest.TestCase):
         result = self.lp.get_light_pollution()
         self.assertEqual(result, -1)
 
-    @patch("apts.light_pollution.LightPollution._get_from_api")
+    @patch("apts.light_pollution.core.LightPollution._get_from_api")
     def test_get_light_pollution_api(self, mock_get_from_api):
         # Test getting light pollution from API
         mock_get_from_api.return_value = {"bortleClass": 4.5}
         result = self.lp.get_light_pollution()
         self.assertEqual(result, 4.5)
 
-    @patch("apts.light_pollution.LightPollution._get_from_api")
+    @patch("apts.light_pollution.core.LightPollution._get_from_api")
     def test_get_base_sqm_api(self, mock_get_from_api):
         # Test getting SQM from API
         mock_get_from_api.return_value = {"sqm": 20.5}
         result = self.lp.get_base_sqm()
         self.assertEqual(result, 20.5)
 
-    @patch("apts.light_pollution.LightPollution._get_from_api")
+    @patch("apts.light_pollution.core.LightPollution._get_from_api")
     def test_get_base_sqm_fallback(self, mock_get_from_api):
         # Test fallback to Bortle if SQM is missing from API
         mock_get_from_api.return_value = {"bortleClass": 1}


### PR DESCRIPTION
This PR decomposes the monolithic `apts/light_pollution.py` file into a modular package structure under `apts/light_pollution/`. The pure stateless conversion utility `bortle_to_sqm` is extracted to `calculations.py`, and the main coordinate-based query class is placed in `core.py`. Full backward compatibility is preserved via package-level exports in `__init__.py`.

---
*PR created automatically by Jules for task [16247524369186586264](https://jules.google.com/task/16247524369186586264) started by @pozar87*