### PR TITLE
🔍 Optic: Data audit for Canon EF 200mm f/2.8L II (USM)

### DIFF
--- a/apts/opticalequipment/telescope/vendors/canon.py
+++ b/apts/opticalequipment/telescope/vendors/canon.py
@@ -3,17 +3,20 @@ from ..base import Telescope
 class CanonTelescope(Telescope):
     _DATABASE = {
         "Canon_EF_200mm_f_2_8L_II": {
+            "aperture_mm": 71.42857, # Verified via Canon Europe spec sheet (200mm f/2.8 => 200 / 2.8 = 71.42857mm) - https://www.canon-europe.com/lenses/ef-200mm-f-2-8l-ii-usm-lens/specification.html
             "brand": "Canon",
+            "focal_length_mm": 200, # Verified via Canon Europe spec sheet
             "name": "EF 200mm f/2.8L II",
             "type": "type_camera_lens",
             "optical_length": 0,
-            "mass": 795,
+            "mass": 765, # Verified via Canon Europe spec sheet
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "EOS",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
+            "central_obstruction_mm": 0,
         },
         "Canon_EF_135mm_f_2L": {
             "aperture_mm": 67.5, # Verified via Canon Europe spec sheet (135mm f/2 => 135/2 = 67.5mm) - https://www.canon-europe.com/lenses/ef-135mm-f-2l-usm-lens/specification.html
@@ -226,17 +229,20 @@ class CanonTelescope(Telescope):
             "bf_role": "",
         },
         "Canon_EF_200mm_f_2_8L_II_USM": {
+            "aperture_mm": 71.42857, # Verified via Canon Europe spec sheet (200mm f/2.8 => 200 / 2.8 = 71.42857mm) - https://www.canon-europe.com/lenses/ef-200mm-f-2-8l-ii-usm-lens/specification.html
             "brand": "Canon",
+            "focal_length_mm": 200, # Verified via Canon Europe spec sheet
             "name": "EF 200mm f/2.8L II USM",
             "type": "type_camera_lens",
             "optical_length": 0,
-            "mass": 795,
+            "mass": 765, # Verified via Canon Europe spec sheet
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "EOS",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
+            "central_obstruction_mm": 0,
         },
         "Canon_EF_50mm_f_1_4_USM": {
             "brand": "Canon",

--- a/tests/unit/test_canon_200_audit.py
+++ b/tests/unit/test_canon_200_audit.py
@@ -1,0 +1,36 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.canon import CanonTelescope
+
+def test_canon_ef_200_specs():
+    """
+    Audit test for Canon EF 200mm f/2.8L II and Canon EF 200mm f/2.8L II USM based on official Canon Europe specs.
+    Source: https://www.canon-europe.com/lenses/ef-200mm-f-2-8l-ii-usm-lens/specification.html
+    """
+    lenses = [
+        CanonTelescope.Canon_EF_200mm_f_2_8L_II(),
+        CanonTelescope.Canon_EF_200mm_f_2_8L_II_USM()
+    ]
+
+    for lens in lenses:
+        # Mass: stored as a Pint Quantity in grams (765g)
+        assert lens.mass.to('gram').magnitude == 765
+        assert str(lens.mass.units) == 'gram'
+
+        # Aperture: 71.42857mm
+        assert lens.aperture.to('mm').magnitude == pytest.approx(71.42857, abs=1e-5)
+
+        # Focal length: 200mm
+        assert lens.focal_length.to('mm').magnitude == 200
+
+        # Focal ratio (f/2.8)
+        assert float(lens.focal_ratio().magnitude) == pytest.approx(2.8, abs=1e-5)
+
+        # Central obstruction is 0 (refractor/lens)
+        assert lens.central_obstruction.magnitude == 0
+
+        # Connection type is EOS
+        from apts.utils.equipment import ConnectionType
+        assert lens.connection_type == ConnectionType.EOS
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
In this data integrity audit, we cross-referenced official manufacturer documentation from Canon Europe and Canon USA for the Canon EF 200mm f/2.8L II and Canon EF 200mm f/2.8L II USM camera lenses.

Key Updates:
- Set 'focal_length_mm' to 200 (was missing).
- Set 'aperture_mm' to 71.42857 (was missing).
- Set 'central_obstruction_mm' to 0 (refractor lens).
- Corrected 'mass' from 795g to the official 765g.

Added a complete unit test module 'tests/unit/test_canon_200_audit.py' to verify the updated objects and their calculated focal ratio. All 822 tests pass successfully.

---
*PR created automatically by Jules for task [16220562259809971973](https://jules.google.com/task/16220562259809971973) started by @pozar87*