### PR TITLE
🔍 Optic: Data audit for SVBony SV503 70ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/svbony.py
+++ b/apts/opticalequipment/telescope/vendors/svbony.py
@@ -6,17 +6,18 @@ class SvbonyTelescope(Telescope):
             "brand": "SVBony",
             "name": "SV503 70ED",
             "type": "type_refractor",
-            "optical_length": 0,
-            "mass": 2220,
+            "optical_length": 90, # Verified via Svbony (Back Focus Length)
+            "mass": 2220, # Verified via Svbony (Tube weight with rings)
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"", # Verified via Svbony (2" dual-speed rack and pinion focuser)
+            "cside_gender": "Female",
             "reversible": False,
-            "bf_role": "",
+            "bf_role": "start",
             "aperture_mm": 70,
             "focal_length_mm": 420,
             "central_obstruction_mm": 0,
+            # Source: https://telescopescanada.ca/products/svbony-sv503-telescope-ed-70mm-f6-doublet-refractor-for-astronomy-sv503
         },
         "SVBony_SV503_70ED_Quad": {
             "brand": "SVBony",

--- a/tests/unit/test_svbony_specs.py
+++ b/tests/unit/test_svbony_specs.py
@@ -6,6 +6,10 @@ def test_sv503_70ed_specs():
     assert telescope.focal_length.magnitude == 420
     assert telescope.mass.magnitude == 2220
     assert telescope.central_obstruction.magnitude == 0
+    assert telescope.optical_length.magnitude == 90
+    assert telescope.backfocus.magnitude == 90
+    assert telescope.connection_type.value == "2"
+    assert telescope.connection_gender.value == "F"
 
 def test_sv503_70ed_quad_specs():
     telescope = SvbonyTelescope.SVBony_SV503_70ED_Quad()


### PR DESCRIPTION
Corrected and updated the SVBony SV503 70ED telescope specifications in the apts database to match official manufacturer and distributor documentation:
- Updated native camera-side connection thread to 2" Female (focuser drawtube receptacle) instead of incorrect M48 Male.
- Set optical_length/backfocus to 90mm instead of 0.
- Set bf_role to 'start' for correct optical train calculations.
- Added verified source reference URL comments.
- Updated and verified with test assertions in `tests/unit/test_svbony_specs.py`.

---
*PR created automatically by Jules for task [6051744697958432538](https://jules.google.com/task/6051744697958432538) started by @pozar87*