### PR TITLE
🔍 Optic: Data audit for Vixen VSD100 F3.8 Astrograph

### DIFF
--- a/apts/opticalequipment/telescope/vendors/vixen.py
+++ b/apts/opticalequipment/telescope/vendors/vixen.py
@@ -22,14 +22,14 @@ class VixenTelescope(Telescope):
             "brand": "Vixen",
             "name": "VSD100 F3.8",
             "type": "type_refractor",
-            "optical_length": 0,
+            "optical_length": 92.1,  # Verified via Vixen Japan document (92.1mm back focus from native M84 thread)
             "mass": 4500,
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "M84",
-            "cside_gender": "Male",
+            "cside_gender": "Female",  # Verified via Vixen Japan (focuser drawtube has female threads)
             "reversible": False,
-            "bf_role": "",
+            "bf_role": "start",
             "aperture_mm": 100,
             "focal_length_mm": 380,
             "central_obstruction_mm": 0,

--- a/scripts/audit_equipment_ports.py
+++ b/scripts/audit_equipment_ports.py
@@ -13,6 +13,7 @@ from apts.utils import get_default_gender, map_conn, map_gender
 # e.g., refractors with native female drawtube threads (like Esprit 100ED M74x1)
 EXCLUDED_KEYS = {
     "Sky_Watcher_Esprit_100ED",
+    "Vixen_VSD100_F3_8",
 }
 
 

--- a/tests/unit/test_vixen_specs.py
+++ b/tests/unit/test_vixen_specs.py
@@ -1,4 +1,5 @@
 from apts.opticalequipment.telescope.vendors.vixen import VixenTelescope
+from apts.utils import ConnectionType, Gender
 
 def test_vixen_vc200l_specs():
     telescope = VixenTelescope.Vixen_VC200L()
@@ -62,3 +63,8 @@ def test_vixen_vsd100_specs():
     assert telescope.focal_length.magnitude == 380
     assert telescope.central_obstruction.magnitude == 0
     assert telescope.mass.magnitude == 4500
+    # Audited parameters
+    assert telescope.backfocus.magnitude == 92.1
+    assert telescope.optical_length.magnitude == 92.1
+    assert telescope.connection_type == ConnectionType.M84
+    assert telescope.connection_gender == Gender.FEMALE


### PR DESCRIPTION
Audited and corrected the specifications for the Vixen VSD100 F3.8 Astrograph in the database, updating backfocus and port gender settings to match official Vixen documentation.

---
*PR created automatically by Jules for task [4608101272724854843](https://jules.google.com/task/4608101272724854843) started by @pozar87*