### PR TITLE
🏗️ Architect: Modularized Photometry Calculations

### DIFF
--- a/apts/optics/calculations/__init__.py
+++ b/apts/optics/calculations/__init__.py
@@ -3,7 +3,17 @@ from .atmospheric import (
     calculate_atmospheric_extinction,
     calculate_atmospheric_dispersion,
 )
-from .photometry import calculate_sky_flux, calculate_object_flux, calculate_snr
+from .photometry import (
+    calculate_sky_flux,
+    calculate_object_flux,
+    calculate_snr,
+    calculate_required_subs,
+    calculate_optimum_sub_exposure,
+    calculate_limiting_magnitude_simple,
+    calculate_saturation_magnitude_analytical,
+    calculate_camera_limiting_magnitude,
+    calculate_saturation_time,
+)
 from .exposure import (
     calculate_npf_rule,
     calculate_field_rotation_rate,
@@ -42,6 +52,12 @@ __all__ = [
     "calculate_sky_flux",
     "calculate_object_flux",
     "calculate_snr",
+    "calculate_required_subs",
+    "calculate_optimum_sub_exposure",
+    "calculate_limiting_magnitude_simple",
+    "calculate_saturation_magnitude_analytical",
+    "calculate_camera_limiting_magnitude",
+    "calculate_saturation_time",
     "calculate_npf_rule",
     "calculate_field_rotation_rate",
     "calculate_estimated_star_trailing",

--- a/apts/optics/calculations/photometry.py
+++ b/apts/optics/calculations/photometry.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from typing import Union, cast
+from typing import Union, cast, Optional, Callable
 
 
 def calculate_sky_flux(
@@ -226,3 +226,53 @@ def calculate_saturation_magnitude_analytical(
     # m_eff = -2.5 * log10(target_flux / flux_at_zero)
     m_eff = -2.5 * np.log10(target_flux / flux_at_zero_mag)
     return float(m_eff)
+
+
+def calculate_camera_limiting_magnitude(
+    snr_calculator_callable: Callable[[float], Optional[float]],
+    target_snr: float = 5.0,
+) -> Optional[float]:
+    """
+    Calculates the limiting magnitude for a camera based on reaching a target SNR.
+    Uses binary search to find the magnitude where SNR equals target_snr.
+    Search range: 0.0 to 30.0 magnitude. Convergence: 0.01 magnitude.
+
+    :param snr_calculator_callable: A callable (typically a lambda or function)
+                                    that takes magnitude (float) and returns
+                                    the SNR (float or None).
+    :param target_snr: Target Signal-to-Noise Ratio (default 5.0).
+    :return: Limiting magnitude as float, or None if calculation fails.
+    """
+    low = 0.0
+    high = 30.0
+
+    for _ in range(12):  # 2^12 = 4096, plenty for 0.01 prec in 30 range
+        mid = (low + high) / 2
+        current_snr = snr_calculator_callable(mid)
+        if current_snr is None:
+            return None
+        if current_snr > target_snr:
+            low = mid
+        else:
+            high = mid
+
+    return round(float(low), 2)
+
+
+def calculate_saturation_time(
+    full_well: float,
+    obj_flux: float,
+    psf_peak_fraction: float,
+) -> Optional[float]:
+    """
+    Calculates the maximum exposure time before the central pixel of a point source saturates.
+    Based on the full-well capacity of the sensor and the Gaussian PSF model.
+
+    :param full_well: Sensor full-well capacity in electrons.
+    :param obj_flux: Total integrated object flux in e-/s.
+    :param psf_peak_fraction: Fraction of light in the central pixel (PSF model).
+    :return: Maximum exposure time in seconds, or None if calculation is invalid.
+    """
+    if obj_flux <= 0 or psf_peak_fraction <= 0:
+        return None
+    return full_well / (obj_flux * psf_peak_fraction)

--- a/apts/optics/models/photometry.py
+++ b/apts/optics/models/photometry.py
@@ -242,14 +242,11 @@ class PhotometryMixIn:
         Uses binary search to find the magnitude where SNR equals target_snr.
         Search range: 0.0 to 30.0 magnitude. Convergence: 0.01 magnitude.
         """
-        low = 0.0
-        high = 30.0
         n_subs = int(numpy.ceil(total_integration_time / sub_exposure_time))
 
-        for _ in range(12):  # 2^12 = 4096, plenty for 0.01 prec in 30 range
-            mid = (low + high) / 2
-            current_snr = self.snr(
-                mid,
+        def snr_calculator(mag: float) -> Optional[float]:
+            return self.snr(
+                mag,
                 sqm,
                 sub_exposure_time,
                 n_subs=n_subs,
@@ -257,14 +254,11 @@ class PhotometryMixIn:
                 altitude=altitude,
                 extinction_k=extinction_k,
             )
-            if current_snr is None:
-                return None
-            if current_snr > target_snr:
-                low = mid
-            else:
-                high = mid
 
-        return round(float(low), 2)
+        return optics_utils.calculate_camera_limiting_magnitude(
+            snr_calculator,
+            target_snr=target_snr,
+        )
 
     def limiting_magnitude(self, sqm: float, integration_time: float) -> float:
         from ...opticalequipment.camera import Camera
@@ -319,12 +313,14 @@ class PhotometryMixIn:
         )
         f = self.psf_peak_fraction(seeing)
 
-        if obj_flux is None or f is None or obj_flux <= 0 or f <= 0:
+        if obj_flux is None or f is None:
             return None
 
-        # S_peak = flux * t * f
-        # t = full_well / (flux * f)
-        t = self.output.full_well / (obj_flux * f)
+        t = optics_utils.calculate_saturation_time(
+            self.output.full_well, obj_flux, f
+        )
+        if t is None:
+            return None
         return t * get_unit_registry().second
 
     def saturation_magnitude(

--- a/tests/unit/test_optics_calculations_photometry.py
+++ b/tests/unit/test_optics_calculations_photometry.py
@@ -4,7 +4,9 @@ from apts.optics.calculations.photometry import (
     calculate_required_subs,
     calculate_optimum_sub_exposure,
     calculate_limiting_magnitude_simple,
-    calculate_saturation_magnitude_analytical
+    calculate_saturation_magnitude_analytical,
+    calculate_camera_limiting_magnitude,
+    calculate_saturation_time
 )
 
 def test_calculate_required_subs():
@@ -67,3 +69,37 @@ def test_calculate_saturation_magnitude_analytical():
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 1000000, 0, 1))
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 1000000, 1, 0))
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 0, 1, 1))
+
+
+def test_calculate_camera_limiting_magnitude():
+    # Setup a mock/dummy snr function:
+    # Let's say SNR is: 5.0 when magnitude is 15.0,
+    # SNR > 5.0 when mag < 15.0, and SNR < 5.0 when mag > 15.0.
+    # Specifically, snr = 5.0 * (2.0 ** (15.0 - mag))
+    def mock_snr(mag):
+        return 5.0 * (2.0 ** (15.0 - mag))
+
+    limit_mag = calculate_camera_limiting_magnitude(mock_snr, target_snr=5.0)
+    assert limit_mag is not None
+    # Since snr = 5.0 at mag = 15.0, binary search should converge to 15.0.
+    assert pytest.approx(limit_mag, abs=0.02) == 15.0
+
+    # Test when SNR function returns None (e.g. invalid inputs)
+    def none_snr(mag):
+        return None
+    assert calculate_camera_limiting_magnitude(none_snr) is None
+
+
+def test_calculate_saturation_time():
+    # full_well = 10000, obj_flux = 100, psf_peak_fraction = 0.5
+    # expected t = 10000 / (100 * 0.5) = 10000 / 50 = 200
+    t = calculate_saturation_time(
+        full_well=10000.0,
+        obj_flux=100.0,
+        psf_peak_fraction=0.5
+    )
+    assert t == 200.0
+
+    # Invalid obj_flux <= 0 or psf_peak_fraction <= 0
+    assert calculate_saturation_time(10000.0, 0.0, 0.5) is None
+    assert calculate_saturation_time(10000.0, 100.0, -0.1) is None


### PR DESCRIPTION
Refactored PhotometryMixIn in apts/optics/models/photometry.py by extracting pure mathematical and search calculations (calculate_camera_limiting_magnitude and calculate_saturation_time) into apts/optics/calculations/photometry.py as pure functions. Exposed the functions in the package-level __init__.py namespace, and added specific unit tests in tests/unit/test_optics_calculations_photometry.py. All 1112 unit tests pass successfully.

---
*PR created automatically by Jules for task [12305541328290957799](https://jules.google.com/task/12305541328290957799) started by @pozar87*