### PR TITLE
🔍 Optic: Data audit for Celestron NexImage 10

### DIFF
--- a/apts/opticalequipment/camera/vendors/celestron.py
+++ b/apts/opticalequipment/camera/vendors/celestron.py
@@ -6,8 +6,8 @@ class CelestronCamera(Camera):
             "brand": "Celestron",
             "name": "NexImage 10",
             "type": "type_camera",
-            "optical_length": 12.5,
-            "mass": 120,
+            "optical_length": 10.6, # Verified via official Celestron documentation (10.6mm native back focus without nosepiece) - https://www.celestron.com/products/neximage-10-solar-system-color-imager
+            "mass": 57, # Verified via official Celestron documentation (2.0 oz / 57g) - https://www.celestron.com/products/neximage-10-solar-system-color-imager
             "tside_thread": "CS",
             "tside_gender": "Female",
             "cside_thread": "",

--- a/tests/unit/test_celestron_neximage_10_audit.py
+++ b/tests/unit/test_celestron_neximage_10_audit.py
@@ -1,0 +1,19 @@
+import unittest
+from apts.opticalequipment.camera.vendors.celestron import CelestronCamera
+from apts.utils import ConnectionType
+
+class TestCelestronNexImage10Audit(unittest.TestCase):
+    def test_neximage_10_specs(self):
+        cam = CelestronCamera.Celestron_NexImage_10()
+        self.assertEqual(cam.get_vendor(), "Celestron NexImage 10")
+        self.assertEqual(cam.width, 3856)
+        self.assertEqual(cam.height, 2764)
+        self.assertAlmostEqual(cam.sensor_width.to('mm').magnitude, 6.4)
+        self.assertAlmostEqual(cam.sensor_height.to('mm').magnitude, 4.6)
+        self.assertAlmostEqual(cam.pixel_size().to('micrometer').magnitude, 1.67)
+        self.assertAlmostEqual(cam.mass.to('gram').magnitude, 57)
+        self.assertAlmostEqual(cam.optical_length.to('mm').magnitude, 10.6)
+        self.assertEqual(cam.connection_type, ConnectionType.CS)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Optic: Data audit for Celestron NexImage 10 color camera. Corrected mass from 120g to 57g (2.0 oz) and optical_length (back focus distance) from 12.5mm to 10.6mm (native back focus without nosepiece) based on official Celestron documentation. Added a dedicated unit test suite.

Source: https://www.celestron.com/products/neximage-10-solar-system-color-imager

---
*PR created automatically by Jules for task [4002454350559454651](https://jules.google.com/task/4002454350559454651) started by @pozar87*