### PR TITLE
⚡ Bolt: Cache elevation queries using lru_cache

### DIFF
--- a/apts/place/elevation.py
+++ b/apts/place/elevation.py
@@ -1,9 +1,11 @@
 import logging
+from functools import lru_cache
 from ..utils.network import get_session
 
 logger = logging.getLogger(__name__)
 
 
+@lru_cache(maxsize=1024)
 def get_elevation(lat: float, lon: float) -> float | None:
     """
     Fetches elevation for a given latitude and longitude using the Open-Meteo Elevation API.

--- a/tests/unit/test_elevation.py
+++ b/tests/unit/test_elevation.py
@@ -5,6 +5,10 @@ from apts.place import Place
 
 class TestElevation(unittest.TestCase):
 
+    def setUp(self):
+        # Clear the cache for get_elevation to ensure a clean state for each test
+        get_elevation.cache_clear()
+
     @patch("apts.place.elevation.get_session")
     def test_get_elevation_success(self, mock_get_session):
         # Mock the response from the API


### PR DESCRIPTION
This pull request implements an in-memory cache for elevation queries. In Place initialization and various other points in the codebase, a call to get_elevation is made for a given coordinate pair to retrieve elevation from the Open-Meteo Elevation API. These calls have substantial network latency (~0.5s) and rate-limiting potential. By wrapping get_elevation with Python's native functools.lru_cache(maxsize=1024), subsequent requests for the same geographical coordinates bypass the slow API call entirely. Additionally, unit tests in tests/unit/test_elevation.py are updated with a setUp method that clears this cache prior to each test run to ensure strict test isolation and no cross-test leakage.

---
*PR created automatically by Jules for task [11121208986287288589](https://jules.google.com/task/11121208986287288589) started by @pozar87*