### PR TITLE
🔍 Optic: Data audit for William Optics Pleiades 68

### DIFF
--- a/apts/opticalequipment/telescope/vendors/william_optics.py
+++ b/apts/opticalequipment/telescope/vendors/william_optics.py
@@ -239,7 +239,7 @@ class William_opticsTelescope(Telescope):
             "reversible": False,
             "bf_role": "",
             "aperture_mm": 68,
-            "focal_length_mm": 258.4,
+            "focal_length_mm": 260, # Verified via official William Optics documentation (260mm focal length) - https://williamoptics.com/products/pleiades-68
             "central_obstruction_mm": 0,
         },
         "William_Optics_Pleiades_111": {

--- a/tests/unit/test_william_optics_specs.py
+++ b/tests/unit/test_william_optics_specs.py
@@ -17,7 +17,7 @@ def test_william_optics_redcat51_specs():
 def test_william_optics_pleiades68_specs():
     telescope = William_opticsTelescope.William_Optics_Pleiades_68()
     assert telescope.aperture.magnitude == 68
-    assert telescope.focal_length.magnitude == 258.4
+    assert telescope.focal_length.magnitude == 260
     assert telescope.mass.magnitude == 2980
     assert telescope.central_obstruction.magnitude == 0
 


### PR DESCRIPTION
This change audits, verifies, and corrects the physical specifications of the William Optics Pleiades 68 Astrograph.

Key Changes:
- In `apts/opticalequipment/telescope/vendors/william_optics.py`, updated `focal_length_mm` from `258.4` to `260` and added a comment pointing to the official manufacturer's page: https://williamoptics.com/products/pleiades-68
- In `tests/unit/test_william_optics_specs.py`, updated the focal length assertion to expect `260`.
- All tests pass successfully.

---
*PR created automatically by Jules for task [4986142523565213390](https://jules.google.com/task/4986142523565213390) started by @pozar87*