### PR TITLE
🔍 Optic: Data audit for GSO RC Telescopes

### DIFF
--- a/apts/opticalequipment/telescope/vendors/gso.py
+++ b/apts/opticalequipment/telescope/vendors/gso.py
@@ -39,7 +39,7 @@ class GsoTelescope(Telescope):
             "name": "RC 10\"",
             "type": "catadioptric",
             "optical_length": 0,
-            "mass": 15000,
+            "mass": 15700, # Verified via GSRC10M Metal Tube specs (15.7 kg) - https://www.astromanie.ch/en/ritchey-chretien/248-ts-10-f8-ritchey-chretien-astrograph-tube-metal.html
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "M117",
@@ -48,14 +48,14 @@ class GsoTelescope(Telescope):
             "bf_role": "",
             "aperture_mm": 254,
             "focal_length_mm": 2000,
-            "central_obstruction_mm": 110,
+            "central_obstruction_mm": 112, # Verified via Teleskop-Express GSRC10M specifications (112mm secondary obstruction)
         },
         "GSO_RC_12": {
             "brand": "GSO",
             "name": "RC 12\"",
             "type": "catadioptric",
             "optical_length": 0,
-            "mass": 21000,
+            "mass": 20500, # Verified via GSRC12M Metal Tube specs (20.5 kg) - https://www.teleskop-express.de/en/telescopes-4/rc-ritchey-chretien-telescopes-75/ts-optics-gso-12-f-8-ritchey-chretien-pro-rc-telescope-304-2432-mm-ota-4713
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "M117",
@@ -64,7 +64,7 @@ class GsoTelescope(Telescope):
             "bf_role": "",
             "aperture_mm": 304,
             "focal_length_mm": 2432,
-            "central_obstruction_mm": 130,
+            "central_obstruction_mm": 150, # Verified via Teleskop-Express GSRC12M specifications (150mm secondary obstruction)
         },
         "GSO_Newton_6_f_5": {
             "brand": "GSO",

--- a/tests/unit/test_gso_specs.py
+++ b/tests/unit/test_gso_specs.py
@@ -27,5 +27,29 @@ class TestGsoSpecs(unittest.TestCase):
         self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 64)
         self.assertAlmostEqual(telescope.focal_ratio().magnitude, 4.92, places=2)
 
+    def test_gso_rc_8(self):
+        telescope = GsoTelescope.GSO_RC_8()
+        self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 203)
+        self.assertEqual(telescope.focal_length.to(get_unit_registry().mm).magnitude, 1624)
+        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 7500)
+        self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 85)
+        self.assertAlmostEqual(telescope.focal_ratio().magnitude, 8.0, places=2)
+
+    def test_gso_rc_10(self):
+        telescope = GsoTelescope.GSO_RC_10()
+        self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 254)
+        self.assertEqual(telescope.focal_length.to(get_unit_registry().mm).magnitude, 2000)
+        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 15700)
+        self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 112)
+        self.assertAlmostEqual(telescope.focal_ratio().magnitude, 7.87, places=2)
+
+    def test_gso_rc_12(self):
+        telescope = GsoTelescope.GSO_RC_12()
+        self.assertEqual(telescope.aperture.to(get_unit_registry().mm).magnitude, 304)
+        self.assertEqual(telescope.focal_length.to(get_unit_registry().mm).magnitude, 2432)
+        self.assertEqual(telescope.mass.to(get_unit_registry().gram).magnitude, 20500)
+        self.assertEqual(telescope.central_obstruction.to(get_unit_registry().mm).magnitude, 150)
+        self.assertAlmostEqual(telescope.focal_ratio().magnitude, 8.0, places=2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Calibrated and corrected the technical specifications (mass and secondary obstruction) for the GSO RC 10" and GSO RC 12" telescopes in the apts database using official manufacturer and distributor (Teleskop-Express and Astromanie) documentation. Added corresponding unit tests in test_gso_specs.py.

---
*PR created automatically by Jules for task [14151509190259259195](https://jules.google.com/task/14151509190259259195) started by @pozar87*