### PR TITLE
Fix light pollution API 404 warning logging

### DIFF
--- a/apts/light_pollution/core.py
+++ b/apts/light_pollution/core.py
@@ -63,6 +63,10 @@ class LightPollution:
                     data = resp.json()
                     self._api_data = data.get("payload", {}).get("metrics", {})
                     return self._api_data
+                elif resp.status_code == 404:
+                    logger.info(
+                        f"Light pollution data for coordinates ({self.lat}, {self.lon}) not found in API (404). Falling back to local dataset."
+                    )
                 else:
                     logger.warning(
                         f"Failed to fetch light pollution data from API: {resp.status_code}"

--- a/tests/unit/test_light_pollution.py
+++ b/tests/unit/test_light_pollution.py
@@ -96,6 +96,53 @@ class TestLightPollution(unittest.TestCase):
         result = self.lp.get_base_sqm()
         self.assertEqual(result, 21.88)
 
+    @patch("apts.utils.network.get_session")
+    def test_get_from_api_success(self, mock_get_session):
+        self.mock_get_settings.return_value = {"use_online_api": True}
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"payload": {"metrics": {"bortleClass": 4, "sqm": 20.1}}}
+        mock_session = MagicMock()
+        mock_session.get.return_value.__enter__.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        lp = LightPollution(lat=52.2297, lon=21.0122)
+        data = lp._get_from_api()
+        self.assertEqual(data, {"bortleClass": 4, "sqm": 20.1})
+
+    @patch("apts.light_pollution.core.logger")
+    @patch("apts.utils.network.get_session")
+    def test_get_from_api_404_not_found(self, mock_get_session, mock_logger):
+        self.mock_get_settings.return_value = {"use_online_api": True}
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+        mock_session = MagicMock()
+        mock_session.get.return_value.__enter__.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        lp = LightPollution(lat=80.0, lon=0.0)
+        data = lp._get_from_api()
+        self.assertIsNone(data)
+        mock_logger.info.assert_called_once()
+        mock_logger.warning.assert_not_called()
+
+    @patch("apts.light_pollution.core.logger")
+    @patch("apts.utils.network.get_session")
+    def test_get_from_api_500_server_error(self, mock_get_session, mock_logger):
+        self.mock_get_settings.return_value = {"use_online_api": True}
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 500
+        mock_session = MagicMock()
+        mock_session.get.return_value.__enter__.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        lp = LightPollution(lat=52.2297, lon=21.0122)
+        data = lp._get_from_api()
+        self.assertIsNone(data)
+        mock_logger.warning.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
Updates `apts.light_pollution.core` to handle HTTP 404 responses from the darkskysites API gracefully by logging at `INFO` level rather than emitting a `WARNING`. Added unit tests in `tests/unit/test_light_pollution.py` covering 200 OK, 404 Not Found, and 500 error status codes.

---
*PR created automatically by Jules for task [1726997835320887653](https://jules.google.com/task/1726997835320887653) started by @pozar87*