### PR TITLE
🏗️ Architect: Modularized scoring calculations in apts/scoring

### DIFF
--- a/apts/scoring/__init__.py
+++ b/apts/scoring/__init__.py
@@ -1,3 +1,19 @@
 from .engine import SuitabilityScorer
+from .calculations import (
+    calculate_altitude_score,
+    calculate_window_score,
+    calculate_fov_score,
+    calculate_moon_penalty_score,
+    calculate_brightness_score,
+    calculate_scores_bulk,
+)
 
-__all__ = ["SuitabilityScorer"]
+__all__ = [
+    "SuitabilityScorer",
+    "calculate_altitude_score",
+    "calculate_window_score",
+    "calculate_fov_score",
+    "calculate_moon_penalty_score",
+    "calculate_brightness_score",
+    "calculate_scores_bulk",
+]

--- a/apts/scoring/calculations.py
+++ b/apts/scoring/calculations.py
@@ -1,0 +1,70 @@
+import pandas as pd
+
+from ..constants import ObjectTableLabels
+from .rules import ALTITUDE_RULE, WINDOW_RULE, FOV_RULE, BRIGHTNESS_RULE, MOON_RULE
+
+
+def calculate_altitude_score(altitude: float) -> int:
+    """S_alt: Altitude score (Max 30 pts)"""
+    return ALTITUDE_RULE.score(altitude)
+
+
+def calculate_window_score(window_minutes: float) -> int:
+    """S_win: Imaging Window score (Max 20 pts)"""
+    return WINDOW_RULE.score(window_minutes / 60.0)
+
+
+def calculate_fov_score(fov_ratio: float) -> int:
+    """S_fov: FOV Fit score (Max 30 pts)"""
+    return FOV_RULE.score(fov_ratio)
+
+
+def calculate_moon_penalty_score(
+    moon_separation: float, is_narrowband: bool = False
+) -> float:
+    """S_moon: Moon Penalty score (Max 20 pts)"""
+    return MOON_RULE.score(moon_separation, is_narrowband)
+
+
+def calculate_brightness_score(magnitude: float) -> int:
+    """S_bright: Brightness score (Max 10 pts)"""
+    return BRIGHTNESS_RULE.score(magnitude)
+
+
+def calculate_scores_bulk(
+    df: pd.DataFrame, is_narrowband: bool = False
+) -> pd.DataFrame:
+    """
+    Vectorized calculation of scores for a DataFrame of targets.
+    """
+    alt = df[ObjectTableLabels.ALTITUDE].to_numpy()
+    s_alt = ALTITUDE_RULE.score_bulk(alt)
+
+    hours = df["window_minutes"].to_numpy() / 60.0
+    s_win = WINDOW_RULE.score_bulk(hours)
+
+    fov = df["fov_ratio"].to_numpy()
+    s_fov = FOV_RULE.score_bulk(fov)
+
+    moon_sep = df["moon_separation"].to_numpy()
+    s_moon = MOON_RULE.score_bulk(moon_sep, is_narrowband)
+
+    mag = df["Magnitude_float"].to_numpy()
+    s_bright = BRIGHTNESS_RULE.score_bulk(mag)
+
+    total_score = s_alt + s_win + s_fov + s_moon + s_bright
+
+    return pd.DataFrame(
+        {
+            "total_score": total_score,
+            "s_alt": s_alt,
+            "s_win": s_win,
+            "s_fov": s_fov,
+            "s_moon": s_moon,
+            "s_bright": s_bright,
+            "altitude": alt,
+            "window_minutes": df["window_minutes"].to_numpy(),
+            "moon_separation": moon_sep,
+        },
+        index=df.index,
+    )

--- a/apts/scoring/engine.py
+++ b/apts/scoring/engine.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from ..cache import get_cached_score, set_cached_score
 from ..constants import FilterStrategy, ObjectTableLabels
-from .rules import ALTITUDE_RULE, WINDOW_RULE, FOV_RULE, BRIGHTNESS_RULE, MOON_RULE
+from . import calculations as scoring_calc
 
 logger = logging.getLogger(__name__)
 
@@ -24,63 +24,32 @@ class SuitabilityScorer:
 
     def score_altitude(self, altitude: float) -> int:
         """S_alt: Altitude score (Max 30 pts)"""
-        return ALTITUDE_RULE.score(altitude)
+        return scoring_calc.calculate_altitude_score(altitude)
 
     def score_imaging_window(self, window_minutes: float) -> int:
         """S_win: Imaging Window score (Max 20 pts)"""
-        return WINDOW_RULE.score(window_minutes / 60.0)
+        return scoring_calc.calculate_window_score(window_minutes)
 
     def score_fov_fit(self, fov_ratio: float) -> int:
         """S_fov: FOV Fit score (Max 30 pts)"""
-        return FOV_RULE.score(fov_ratio)
+        return scoring_calc.calculate_fov_score(fov_ratio)
 
     def score_moon_penalty(self, moon_separation: float) -> float:
         """S_moon: Moon Penalty score (Max 20 pts)"""
-        return MOON_RULE.score(
+        return scoring_calc.calculate_moon_penalty_score(
             moon_separation, self.filter_strategy == FilterStrategy.NARROWBAND
         )
 
     def score_brightness(self, magnitude: float) -> int:
         """S_bright: Brightness score (Max 10 pts)"""
-        return BRIGHTNESS_RULE.score(magnitude)
+        return scoring_calc.calculate_brightness_score(magnitude)
 
     def calculate_scores_bulk(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Vectorized calculation of scores for a DataFrame of targets.
         """
-        alt = df[ObjectTableLabels.ALTITUDE].to_numpy()
-        s_alt = ALTITUDE_RULE.score_bulk(alt)
-
-        hours = df["window_minutes"].to_numpy() / 60.0
-        s_win = WINDOW_RULE.score_bulk(hours)
-
-        fov = df["fov_ratio"].to_numpy()
-        s_fov = FOV_RULE.score_bulk(fov)
-
-        moon_sep = df["moon_separation"].to_numpy()
-        s_moon = MOON_RULE.score_bulk(
-            moon_sep, self.filter_strategy == FilterStrategy.NARROWBAND
-        )
-
-        mag = df["Magnitude_float"].to_numpy()
-        s_bright = BRIGHTNESS_RULE.score_bulk(mag)
-
-        total_score = s_alt + s_win + s_fov + s_moon + s_bright
-
-        return pd.DataFrame(
-            {
-                "total_score": total_score,
-                "s_alt": s_alt,
-                "s_win": s_win,
-                "s_fov": s_fov,
-                "s_moon": s_moon,
-                "s_bright": s_bright,
-                "altitude": alt,
-                "window_minutes": df["window_minutes"].to_numpy(),
-                "moon_separation": moon_sep,
-            },
-            index=df.index,
-        )
+        is_narrowband = self.filter_strategy == FilterStrategy.NARROWBAND
+        return scoring_calc.calculate_scores_bulk(df, is_narrowband=is_narrowband)
 
     def _get_skyfield_obj(self, target_row: Any):
         """Helper to get or reconstruct Skyfield object from target row."""

--- a/tests/unit/test_scoring_calculations.py
+++ b/tests/unit/test_scoring_calculations.py
@@ -1,0 +1,85 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from apts.scoring.calculations import (
+    calculate_altitude_score,
+    calculate_window_score,
+    calculate_fov_score,
+    calculate_moon_penalty_score,
+    calculate_brightness_score,
+    calculate_scores_bulk,
+)
+from apts.constants import ObjectTableLabels
+
+
+class TestScoringCalculations(unittest.TestCase):
+    def test_calculate_altitude_score(self):
+        self.assertEqual(calculate_altitude_score(70.0), 30)
+        self.assertEqual(calculate_altitude_score(65.0), 30)
+        self.assertEqual(calculate_altitude_score(55.0), 25)
+        self.assertEqual(calculate_altitude_score(40.0), 18)
+        self.assertEqual(calculate_altitude_score(25.0), 10)
+        self.assertEqual(calculate_altitude_score(15.0), 0)
+
+    def test_calculate_window_score(self):
+        self.assertEqual(calculate_window_score(360.0), 20)  # 6 hrs -> >= 5
+        self.assertEqual(calculate_window_score(300.0), 20)  # 5 hrs -> >= 5
+        self.assertEqual(calculate_window_score(240.0), 16)  # 4 hrs -> >= 3
+        self.assertEqual(calculate_window_score(150.0), 12)  # 2.5 hrs -> >= 2
+        self.assertEqual(calculate_window_score(90.0), 8)   # 1.5 hrs -> >= 1
+        self.assertEqual(calculate_window_score(30.0), 0)   # 0.5 hrs -> 0
+
+    def test_calculate_fov_score(self):
+        self.assertEqual(calculate_fov_score(50.0), 30)   # in range (30, 110)
+        self.assertEqual(calculate_fov_score(15.0), 18)   # in range (10, 200)
+        self.assertEqual(calculate_fov_score(5.0), 0)     # outside range
+
+    def test_calculate_moon_penalty_score(self):
+        # Broadband
+        self.assertAlmostEqual(calculate_moon_penalty_score(0.0, is_narrowband=False), 20.0)
+        self.assertAlmostEqual(calculate_moon_penalty_score(50.0, is_narrowband=False), 9.0)
+        self.assertAlmostEqual(calculate_moon_penalty_score(100.0, is_narrowband=False), 0.0)
+
+        # Narrowband (always max 20 pts)
+        self.assertEqual(calculate_moon_penalty_score(0.0, is_narrowband=True), 20.0)
+        self.assertEqual(calculate_moon_penalty_score(50.0, is_narrowband=True), 20.0)
+
+    def test_calculate_brightness_score(self):
+        self.assertEqual(calculate_brightness_score(4.0), 10)  # < 5
+        self.assertEqual(calculate_brightness_score(7.0), 7)   # < 8
+        self.assertEqual(calculate_brightness_score(10.0), 4)  # < 11
+        self.assertEqual(calculate_brightness_score(12.0), 1)  # default
+
+    def test_calculate_scores_bulk(self):
+        df = pd.DataFrame(
+            {
+                ObjectTableLabels.ALTITUDE: [70.0, 25.0],
+                "window_minutes": [360.0, 90.0],
+                "fov_ratio": [50.0, 15.0],
+                "moon_separation": [50.0, 100.0],
+                "Magnitude_float": [4.0, 12.0],
+            }
+        )
+
+        res_broadband = calculate_scores_bulk(df, is_narrowband=False)
+        self.assertEqual(len(res_broadband), 2)
+        self.assertIn("total_score", res_broadband.columns)
+        self.assertIn("s_alt", res_broadband.columns)
+        self.assertIn("s_win", res_broadband.columns)
+        self.assertIn("s_fov", res_broadband.columns)
+        self.assertIn("s_moon", res_broadband.columns)
+        self.assertIn("s_bright", res_broadband.columns)
+
+        # Row 0 broadband: s_alt=30, s_win=20, s_fov=30, s_moon=9.0, s_bright=10 -> total=99.0
+        self.assertEqual(res_broadband.iloc[0]["s_alt"], 30)
+        self.assertEqual(res_broadband.iloc[0]["s_win"], 20)
+        self.assertEqual(res_broadband.iloc[0]["s_fov"], 30)
+        self.assertAlmostEqual(res_broadband.iloc[0]["s_moon"], 9.0)
+        self.assertEqual(res_broadband.iloc[0]["s_bright"], 10)
+        self.assertAlmostEqual(res_broadband.iloc[0]["total_score"], 99.0)
+
+        # Test narrowband bulk
+        res_narrowband = calculate_scores_bulk(df, is_narrowband=True)
+        self.assertEqual(res_narrowband.iloc[0]["s_moon"], 20.0)
+        self.assertAlmostEqual(res_narrowband.iloc[0]["total_score"], 110.0)


### PR DESCRIPTION
This change modularizes the scoring logic by extracting pure calculation functions (`calculate_altitude_score`, `calculate_window_score`, `calculate_fov_score`, `calculate_moon_penalty_score`, `calculate_brightness_score`, and `calculate_scores_bulk`) into `apts/scoring/calculations.py`. `SuitabilityScorer` in `apts/scoring/engine.py` was refactored to delegate to these functions while preserving full backward compatibility. Re-exported the new functions in `apts/scoring/__init__.py` and added unit tests in `tests/unit/test_scoring_calculations.py`.

---
*PR created automatically by Jules for task [8306171753751114116](https://jules.google.com/task/8306171753751114116) started by @pozar87*