### PR TITLE
🏗️ Architect: Modularized saturation magnitude calculation in PhotometryMixIn

### DIFF
--- a/apts/optics/calculations/__init__.py
+++ b/apts/optics/calculations/__init__.py
@@ -12,6 +12,7 @@ from .photometry import (
     calculate_optimum_sub_exposure,
     calculate_limiting_magnitude_simple,
     calculate_saturation_magnitude_analytical,
+    calculate_saturation_magnitude,
     calculate_camera_limiting_magnitude,
     calculate_saturation_time,
 )
@@ -69,6 +70,7 @@ __all__ = [
     "calculate_optimum_sub_exposure",
     "calculate_limiting_magnitude_simple",
     "calculate_saturation_magnitude_analytical",
+    "calculate_saturation_magnitude",
     "calculate_camera_limiting_magnitude",
     "calculate_saturation_time",
     "calculate_npf_rule",

--- a/apts/optics/calculations/photometry.py
+++ b/apts/optics/calculations/photometry.py
@@ -228,6 +228,38 @@ def calculate_saturation_magnitude_analytical(
     return float(m_eff)
 
 
+def calculate_saturation_magnitude(
+    full_well: float,
+    flux_at_zero_mag: float,
+    exposure_time: float,
+    psf_peak_fraction: float,
+    airmass_val: Optional[float] = None,
+    extinction_k: float = 0.2,
+) -> Optional[float]:
+    """
+    Calculates the magnitude of a point source that would just saturate the sensor
+    at the given exposure time, considering PSF peak fraction and optional atmospheric extinction.
+
+    :param full_well: Sensor full-well capacity in electrons.
+    :param flux_at_zero_mag: Object flux for a 0th magnitude star in e-/s.
+    :param exposure_time: Exposure time in seconds.
+    :param psf_peak_fraction: Fraction of light in the central pixel (PSF model).
+    :param airmass_val: Optional airmass value at a given altitude.
+    :param extinction_k: Atmospheric extinction coefficient (default 0.2).
+    :return: Magnitude at saturation, or None if invalid inputs.
+    """
+    m_eff = calculate_saturation_magnitude_analytical(
+        full_well, flux_at_zero_mag, exposure_time, psf_peak_fraction
+    )
+    if np.isnan(m_eff):
+        return None
+
+    if airmass_val is not None:
+        return float(m_eff - extinction_k * airmass_val)
+
+    return float(m_eff)
+
+
 def calculate_camera_limiting_magnitude(
     snr_calculator_callable: Callable[[float], Optional[float]],
     target_snr: float = 5.0,

--- a/apts/optics/models/photometry.py
+++ b/apts/optics/models/photometry.py
@@ -1,4 +1,3 @@
-import math
 from typing import Optional, TYPE_CHECKING
 import numpy
 from ...units import get_unit_registry
@@ -351,14 +350,13 @@ class PhotometryMixIn:
         if flux_at_zero is None:
             return None
 
-        m_eff = optics_utils.calculate_saturation_magnitude_analytical(
-            self.output.full_well, flux_at_zero, exposure_time, f
+        airmass_val = self.airmass(altitude) if altitude is not None else None
+
+        return optics_utils.calculate_saturation_magnitude(
+            full_well=self.output.full_well,
+            flux_at_zero_mag=flux_at_zero,
+            exposure_time=exposure_time,
+            psf_peak_fraction=f,
+            airmass_val=airmass_val,
+            extinction_k=extinction_k,
         )
-
-        if altitude is not None:
-            # m_eff = m + k * X
-            # m = m_eff - k * X
-            airmass_val = self.airmass(altitude)
-            return float(m_eff - extinction_k * airmass_val)
-
-        return float(m_eff)

--- a/tests/unit/test_optics_calculations_photometry.py
+++ b/tests/unit/test_optics_calculations_photometry.py
@@ -5,6 +5,7 @@ from apts.optics.calculations.photometry import (
     calculate_optimum_sub_exposure,
     calculate_limiting_magnitude_simple,
     calculate_saturation_magnitude_analytical,
+    calculate_saturation_magnitude,
     calculate_camera_limiting_magnitude,
     calculate_saturation_time
 )
@@ -69,6 +70,33 @@ def test_calculate_saturation_magnitude_analytical():
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 1000000, 0, 1))
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 1000000, 1, 0))
     assert np.isnan(calculate_saturation_magnitude_analytical(10000, 0, 1, 1))
+
+
+def test_calculate_saturation_magnitude():
+    # Base analytical saturation magnitude = 5.0
+    m_no_airmass = calculate_saturation_magnitude(
+        full_well=10000.0,
+        flux_at_zero_mag=1000000.0,
+        exposure_time=1.0,
+        psf_peak_fraction=1.0,
+        airmass_val=None,
+    )
+    assert pytest.approx(m_no_airmass) == 5.0
+
+    # With airmass = 2.0 and extinction_k = 0.2
+    # m = 5.0 - 0.2 * 2.0 = 4.6
+    m_with_airmass = calculate_saturation_magnitude(
+        full_well=10000.0,
+        flux_at_zero_mag=1000000.0,
+        exposure_time=1.0,
+        psf_peak_fraction=1.0,
+        airmass_val=2.0,
+        extinction_k=0.2,
+    )
+    assert pytest.approx(m_with_airmass) == 4.6
+
+    # Invalid inputs -> None
+    assert calculate_saturation_magnitude(10000, 1000000, 0, 1) is None
 
 
 def test_calculate_camera_limiting_magnitude():


### PR DESCRIPTION
Refactored PhotometryMixIn by extracting saturation magnitude calculations (including airmass and extinction adjustments) into a pure calculation function in apts/optics/calculations/photometry.py. Fully backward compatible with unit tests added.

---
*PR created automatically by Jules for task [2306870504162609421](https://jules.google.com/task/2306870504162609421) started by @pozar87*