### PR TITLE
Filter technical calculation columns from user data objects

### DIFF
--- a/apts/constants/objecttablelabels.py
+++ b/apts/constants/objecttablelabels.py
@@ -40,3 +40,20 @@ class ObjectTableLabels:
 
     CURRENT_ALT = "current_alt"
     CURRENT_AZ = "current_az"
+
+
+TECHNICAL_COLUMNS = [
+    "skyfield_object",
+    "ra_hours",
+    "dec_degrees",
+    "Magnitude_float",
+    "sin_dec",
+    "cos_dec_cos_ra",
+    "cos_dec_sin_ra",
+    "NGC_norm",
+    "IC_norm",
+    "Name_norm",
+    "TechnicalName",
+    "current_alt",
+    "current_az",
+]

--- a/apts/objects/base.py
+++ b/apts/objects/base.py
@@ -26,6 +26,23 @@ class Objects(VisibilityMixIn, AlmanacMixIn, ABC):
     def get_skyfield_object(self, obj) -> object:
         pass
 
+    def drop_technical_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Removes internal technical calculation and caching columns from a DataFrame
+        before returning or presenting it to the user.
+        """
+        from .utils import filter_technical_columns
+        return filter_technical_columns(df)
+
+    def data(self, clean: bool = True) -> pd.DataFrame:
+        """
+        Returns the catalog DataFrame. If clean is True (default),
+        internal technical calculation columns are omitted.
+        """
+        if clean:
+            return self.drop_technical_columns(self.objects)
+        return self.objects
+
     def compute(self, calculation_date=None, df_to_compute=None) -> pd.DataFrame:
         """
         Default compute implementation using vectorized geometric formulas.

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -5,6 +5,7 @@ from ..catalogs import Catalogs
 from ..catalogs.ngc import normalize_name as internal_normalize_name
 from ..constants import ObjectTableLabels
 from .base import Objects
+from .utils import filter_technical_columns
 
 
 class NGC(Objects):
@@ -31,6 +32,7 @@ class NGC(Objects):
         star_magnitude_limit=None,
         limiting_magnitude=None,
         exclude_messier=True,
+        clean=True,
         **kwargs,
     ) -> pd.DataFrame:
         # Override get_visible to lazily restore skyfield objects and Pint units
@@ -42,7 +44,7 @@ class NGC(Objects):
         if "skyfield_object" not in self.objects.columns:
             self.objects["skyfield_object"] = None
 
-        # 2. Call super().get_visible to perform vectorized visibility calculations
+        # 2. Call super().get_visible with clean=False to perform vectorized visibility calculations
         # NGC uses is_star_catalog=True and ra_hours/dec_degrees columns,
         # so super().get_visible() does NOT need skyfield_objects yet.
         visible = super().get_visible(
@@ -53,18 +55,19 @@ class NGC(Objects):
             sort_by=sort_by,
             star_magnitude_limit=star_magnitude_limit,
             limiting_magnitude=limiting_magnitude,
+            clean=False,
             **kwargs,
         )
 
         if visible.empty:
-            return visible
+            return filter_technical_columns(visible) if clean else visible
 
         # 3. Apply exclude_messier filter to visible objects
         if exclude_messier and "M" in visible.columns:
             visible = visible[visible["M"].isna()]
 
         if visible.empty:
-            return visible  # type: ignore[return-value]
+            return filter_technical_columns(visible) if clean else visible  # type: ignore[return-value]
 
         # 4. Defer restoration of skyfield_objects and Pint units to visible subset
         from skyfield.api import Star
@@ -136,6 +139,9 @@ class NGC(Objects):
             # Refresh the 'visible' slice with restored objects for returning to the caller.
             # We must re-copy from the master catalog to ensure consistency.
             visible.update(self.objects.loc[indices_needing_restoration])
+
+        if clean:
+            visible = filter_technical_columns(visible)
 
         return visible  # type: ignore[return-value]
 

--- a/apts/objects/solar/core.py
+++ b/apts/objects/solar/core.py
@@ -8,6 +8,7 @@ from ...cache import get_mpcorb_data
 from ...constants import DSOType, ObjectTableLabels
 from ...utils import MINOR_PLANET_NAMES, planetary
 from ..base import Objects
+from ..utils import filter_technical_columns
 from .calculations import compute_ephem_and_skyfield_data
 
 
@@ -113,6 +114,7 @@ class SolarObjects(Objects):
         sort_by=ObjectTableLabels.TRANSIT,
         star_magnitude_limit=None,
         limiting_magnitude=None,
+        clean=True,
     ):
         # Always ensure some basic computation is done if needed for magnitude filtering
         # Actually self.objects starts with only names. Magnitude is needed for filtering.
@@ -122,7 +124,7 @@ class SolarObjects(Objects):
         ):
             self.compute(self.calculation_date, skip_transits=False)
 
-        # First, call the parent's get_visible method
+        # First, call the parent's get_visible method with clean=False
         visible = super().get_visible(
             conditions,
             start,
@@ -131,6 +133,7 @@ class SolarObjects(Objects):
             sort_by,
             star_magnitude_limit,
             limiting_magnitude,
+            clean=False,
         )
 
         if not visible.empty:
@@ -143,6 +146,9 @@ class SolarObjects(Objects):
                 pd.Series,
                 visible["TechnicalName"].map(name_map),  # pyright: ignore[reportArgumentType]
             ).astype("string")
+
+        if clean:
+            visible = filter_technical_columns(visible)
 
         return visible
 

--- a/apts/objects/utils.py
+++ b/apts/objects/utils.py
@@ -1,12 +1,28 @@
+import pandas as pd
+
+from ..constants.objecttablelabels import TECHNICAL_COLUMNS
 from ..utils.astronomy.refraction import calculate_refraction
 from ..utils.astronomy.calculations import (
     vectorized_geometric_compute,
     vectorized_geometric_imaging_duration,
 )
 
+
+def filter_technical_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Removes internal technical calculation and caching columns from a DataFrame
+    before returning or presenting it to the user.
+    """
+    cols_to_drop = [col for col in TECHNICAL_COLUMNS if col in df.columns]
+    if cols_to_drop:
+        return df.drop(columns=cols_to_drop, errors="ignore")
+    return df
+
+
 # Keep the original exports for backward compatibility
 __all__ = [
     "calculate_refraction",
     "vectorized_geometric_compute",
     "vectorized_geometric_imaging_duration",
+    "filter_technical_columns",
 ]

--- a/apts/objects/visibility.py
+++ b/apts/objects/visibility.py
@@ -12,6 +12,7 @@ from .calculations import (
     filter_objects_by_magnitude,
     calculate_visible_stars_mask,
 )
+from .utils import filter_technical_columns
 
 
 class VisibilityMixIn:
@@ -237,16 +238,19 @@ class VisibilityMixIn:
         sort_by=ObjectTableLabels.TRANSIT,
         star_magnitude_limit=None,
         limiting_magnitude=None,
+        clean=True,
     ) -> pd.DataFrame:
         if not start or not stop:
-            return pd.DataFrame(columns=self.objects.columns)
+            df = pd.DataFrame(columns=self.objects.columns)
+            return filter_technical_columns(df) if clean else df
 
         candidate_objects = self._filter_by_magnitude(
             conditions, star_magnitude_limit, limiting_magnitude
         )
 
         if candidate_objects.empty:
-            return pd.DataFrame(columns=self.objects.columns)
+            df = pd.DataFrame(columns=self.objects.columns)
+            return filter_technical_columns(df) if clean else df
 
         # Vectorized visibility check
         check_times = self._prepare_visibility_check_times(start, stop)
@@ -273,7 +277,8 @@ class VisibilityMixIn:
             )
 
         if visible_candidate_objects.empty:
-            return pd.DataFrame(columns=self.objects.columns)
+            df = pd.DataFrame(columns=self.objects.columns)
+            return filter_technical_columns(df) if clean else df
 
         # Compute transit/rise/set ONLY for visible objects if needed for sorting or plotting
         self._ensure_computed_fields(visible_candidate_objects, sort_by)
@@ -283,5 +288,8 @@ class VisibilityMixIn:
         # Sort objects by given order, handling potential NaNs
         if sort_by in visible.columns and not bool(visible[sort_by].isnull().all()):
             visible = visible.sort_values(by=sort_by, ascending=True)
+
+        if clean:
+            visible = filter_technical_columns(visible)
 
         return visible

--- a/apts/observations/catalogs/messier.py
+++ b/apts/observations/catalogs/messier.py
@@ -41,7 +41,9 @@ class MessierCatalogMixIn:
         self, language: Optional[str] = None, **args
     ) -> pd.DataFrame:
         if self.sun_observation:
-            return pd.DataFrame(columns=self.local_messier.objects.columns)
+            return self.local_messier.drop_technical_columns(
+                pd.DataFrame(columns=self.local_messier.objects.columns)
+            )
 
         with language_context(language):
             from ...i18n import bulk_gettext

--- a/apts/observations/catalogs/ngc.py
+++ b/apts/observations/catalogs/ngc.py
@@ -41,7 +41,9 @@ class NgcCatalogMixIn:
         self, language: Optional[str] = None, **args
     ) -> pd.DataFrame:
         if self.sun_observation:
-            return pd.DataFrame(columns=self.local_ngc.objects.columns)
+            return self.local_ngc.drop_technical_columns(
+                pd.DataFrame(columns=self.local_ngc.objects.columns)
+            )
 
         with language_context(language):
             from ...i18n import bulk_gettext

--- a/apts/observations/catalogs/planets.py
+++ b/apts/observations/catalogs/planets.py
@@ -40,6 +40,7 @@ class PlanetsCatalogMixIn:
     def get_visible_planets(
         self, language: Optional[str] = None, **args
     ) -> pd.DataFrame:
+        clean = args.pop("clean", True)
         with language_context(language):
             from ...i18n import bulk_gettext
 
@@ -48,6 +49,7 @@ class PlanetsCatalogMixIn:
                 self.start,
                 self.time_limit,
                 limiting_magnitude=self.limiting_magnitude,
+                clean=False,
                 **args,
             )
 
@@ -56,15 +58,20 @@ class PlanetsCatalogMixIn:
                 # Usually Sun, Moon, and potentially Venus/Jupiter if they are bright enough.
                 # We use a threshold of 0 magnitude for daytime planet visibility.
                 # Optimization: use pre-calculated Magnitude_float for faster filtering.
-                mags = visible["Magnitude_float"].values
-                tech_names = visible["TechnicalName"].values
-                # Keep Sun, Moon, or anything with magnitude < 0
-                mask = (tech_names == "sun") | (tech_names == "moon") | (mags < 0)
-                visible = visible[mask].copy()
+                mags = visible["Magnitude_float"].values if "Magnitude_float" in visible.columns else np.array([])
+                tech_names = visible["TechnicalName"].values if "TechnicalName" in visible.columns else np.array([])
+                if len(mags) > 0 and len(tech_names) > 0:
+                    # Keep Sun, Moon, or anything with magnitude < 0
+                    mask = (tech_names == "sun") | (tech_names == "moon") | (mags < 0)
+                    visible = visible[mask].copy()
 
             # Optimization: use bulk_gettext (unique value mapping) instead of .apply(gettext_)
             if "Name" in visible.columns:
                 visible["Name"] = cast(pd.Series, bulk_gettext(visible["Name"])).astype(
                     "string"
                 )
+
+            if clean:
+                visible = self.local_planets.drop_technical_columns(visible)
+
             return visible

--- a/apts/observations/report/data.py
+++ b/apts/observations/report/data.py
@@ -55,22 +55,9 @@ class ReportDataMixIn:
             "planets_count": len(visible_planets_df),
             "messier_count": len(messier_df),
             "ngc_count": len(ngc_df),
-            "planets_table": visible_planets_df.drop(columns=["TechnicalName"]).to_html()
-            if "TechnicalName" in visible_planets_df.columns
-            else visible_planets_df.to_html(),
+            "planets_table": visible_planets_df.to_html(),
             "messier_table": messier_df.to_html(),
-            "ngc_table": ngc_df.drop(
-                columns=[
-                    "ra_hours",
-                    "dec_degrees",
-                    "skyfield_object",
-                    "NGC_norm",
-                    "IC_norm",
-                    "Name_norm",
-                    "Magnitude_float",
-                ],
-                errors="ignore",
-            ).to_html(),
+            "ngc_table": ngc_df.to_html(),
             "equipment_table": self.equipment.data().to_html(),
             "place_name": html.escape(self.place.name),
             "lat": np.rad2deg(self.place.lat),

--- a/apts/plotting/altitude/planets.py
+++ b/apts/plotting/altitude/planets.py
@@ -166,7 +166,7 @@ def _plot_single_planet_curve(
     )
 
     specific_planet_color = get_planet_color(
-        planetary.get_simple_name(str(getattr(planet, "TechnicalName"))),
+        planetary.get_simple_name(str(getattr(planet, "TechnicalName", getattr(planet, ObjectTableLabels.NAME)))),
         effective_dark_mode,
         default_planet_color,  # type: ignore
     )

--- a/tests/unit/test_objects_technical_columns.py
+++ b/tests/unit/test_objects_technical_columns.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timezone
+import pandas as pd
+import pytest
+
+from apts.catalogs import Catalogs
+from apts.conditions import Conditions
+from apts.constants.objecttablelabels import TECHNICAL_COLUMNS
+from apts.equipment.base import Equipment
+from apts.objects import Messier, NGC, SolarObjects, Stars
+from apts.objects.utils import filter_technical_columns
+from apts.observations import Observation
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.place import Place
+
+
+def test_filter_technical_columns_helper():
+    dummy_df = pd.DataFrame(
+        {
+            "Name": ["M31", "Jupiter"],
+            "skyfield_object": [None, None],
+            "ra_hours": [0.7, 12.5],
+            "dec_degrees": [41.2, -2.5],
+            "Magnitude_float": [3.4, -2.1],
+            "sin_dec": [0.65, -0.04],
+            "cos_dec_cos_ra": [0.5, 0.8],
+            "cos_dec_sin_ra": [0.4, 0.1],
+            "NGC_norm": ["NGC0224", None],
+            "IC_norm": [None, None],
+            "Name_norm": ["M31", "JUPITER"],
+            "TechnicalName": [None, "jupiter barycenter"],
+            "current_alt": [45.0, 30.0],
+            "current_az": [180.0, 90.0],
+            "Magnitude": [3.4, -2.1],
+        }
+    )
+
+    cleaned = filter_technical_columns(dummy_df)
+    assert "Name" in cleaned.columns
+    assert "Magnitude" in cleaned.columns
+    for col in TECHNICAL_COLUMNS:
+        assert col not in cleaned.columns
+
+
+def test_objects_data_and_drop_technical():
+    place = Place(50.0647, 19.9450, "Krakow", 200)
+    catalogs = Catalogs()
+    messier = Messier(place, catalogs)
+
+    # Master catalog should retain technical columns
+    assert "ra_hours" in messier.objects.columns
+    assert "Magnitude_float" in messier.objects.columns
+
+    # Clean data view
+    clean_df = messier.data(clean=True)
+    for col in TECHNICAL_COLUMNS:
+        assert col not in clean_df.columns
+
+    # Unclean data view
+    unclean_df = messier.data(clean=False)
+    assert "ra_hours" in unclean_df.columns
+    assert "Magnitude_float" in unclean_df.columns
+
+
+def test_get_visible_filters_technical_columns():
+    place = Place(50.0647, 19.9450, "Krakow", 200)
+    catalogs = Catalogs()
+    conditions = Conditions()
+    start = datetime(2025, 5, 20, 22, 0, 0, tzinfo=timezone.utc)
+    stop = datetime(2025, 5, 20, 23, 0, 0, tzinfo=timezone.utc)
+
+    messier = Messier(place, catalogs)
+    visible_m = messier.get_visible(conditions, start, stop, clean=True)
+    if not visible_m.empty:
+        for col in TECHNICAL_COLUMNS:
+            assert col not in visible_m.columns
+
+    unclean_m = messier.get_visible(conditions, start, stop, clean=False)
+    if not unclean_m.empty:
+        assert "ra_hours" in unclean_m.columns
+
+    solar = SolarObjects(place)
+    visible_s = solar.get_visible(conditions, start, stop, clean=True)
+    if not visible_s.empty:
+        for col in TECHNICAL_COLUMNS:
+            assert col not in visible_s.columns
+
+
+def test_observation_catalog_mixins_cleaned():
+    place = Place(50.0647, 19.9450, "Krakow", 200)
+    telescope = Sky_watcherTelescope.Sky_Watcher_Explorer_150P()
+    camera = ZwoCamera.ZWO_ASI_178MM()
+    equipment = Equipment()
+    equipment.add_vertex("Telescope", telescope)
+    equipment.add_vertex("Camera", camera)
+    equipment.add_edge("Space", "Telescope")
+    equipment.add_edge("Telescope", "Camera")
+    conditions = Conditions()
+    target_date = datetime(2025, 5, 20, 22, 0, 0, tzinfo=timezone.utc)
+    obs = Observation(place, equipment, conditions, target_date=target_date)
+
+    messier_df = obs.get_visible_messier()
+    for col in TECHNICAL_COLUMNS:
+        assert col not in messier_df.columns
+
+    ngc_df = obs.get_visible_ngc()
+    for col in TECHNICAL_COLUMNS:
+        assert col not in ngc_df.columns
+
+    planets_df = obs.get_visible_planets()
+    for col in TECHNICAL_COLUMNS:
+        assert col not in planets_df.columns


### PR DESCRIPTION
Identified and filtered out internal technical calculation and optimization columns (such as skyfield_object, ra_hours, dec_degrees, Magnitude_float, sin_dec, cos_dec_cos_ra, cos_dec_sin_ra, NGC_norm, IC_norm, Name_norm, TechnicalName, current_alt, current_az) from user-facing DataFrames across Messier, NGC, Stars, SolarObjects, and Observation catalog mixins. Added clean=True parameter to get_visible methods while retaining internal technical columns in master objects DataFrames for computation performance. Added unit tests to verify technical column filtering.

---
*PR created automatically by Jules for task [18170638401747447016](https://jules.google.com/task/18170638401747447016) started by @pozar87*