### PR TITLE
🏗️ Architect: Modularized planetary calculations

### DIFF
--- a/apts/events/calculations/planetary/__init__.py
+++ b/apts/events/calculations/planetary/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
     "calculate_mars_closest_approach",
     "calculate_planet_alignments",
     "calculate_planet_planet_occultations",
+    "calculate_celestial_configurations",
     "calculate_jovian_moon_events",
     "calculate_saturn_ring_crossings",
     "calculate_jupiter_grs_transits",

--- a/apts/events/calculations/planetary/utils.py
+++ b/apts/events/calculations/planetary/utils.py
@@ -1,5 +1,4 @@
 
-from skyfield.api import Star
 from ....catalogs import Catalogs
 from ....utils import planetary
 

--- a/apts/objects/solar/core.py
+++ b/apts/objects/solar/core.py
@@ -1,7 +1,6 @@
 import functools
 from typing import cast
 
-import numpy as np
 import pandas as pd
 
 from ...cache import get_mpcorb_data

--- a/apts/objects/visibility.py
+++ b/apts/objects/visibility.py
@@ -1,6 +1,6 @@
 import types
 import unittest.mock
-from typing import Any, cast, Optional
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd

--- a/apts/observations/catalogs/planets.py
+++ b/apts/observations/catalogs/planets.py
@@ -2,7 +2,6 @@ import logging
 from typing import TYPE_CHECKING, Optional, Union, cast
 from datetime import datetime
 
-import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:

--- a/apts/optics/calculations/geometric.py
+++ b/apts/optics/calculations/geometric.py
@@ -1,6 +1,6 @@
 import functools
 import operator
-from typing import Sequence, Any, Union
+from typing import Sequence, Any
 import numpy as np
 
 

--- a/apts/optics/models/exposure.py
+++ b/apts/optics/models/exposure.py
@@ -1,8 +1,5 @@
-import math
 from typing import Optional, TYPE_CHECKING, Any
-import numpy
 from ...units import get_unit_registry
-from ...constants import astronomy
 from ..calculations import exposure as optics_utils
 
 if TYPE_CHECKING:

--- a/apts/optics/models/resolution.py
+++ b/apts/optics/models/resolution.py
@@ -1,4 +1,3 @@
-import math
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:

--- a/apts/skyfield_searches/meteor_showers.py
+++ b/apts/skyfield_searches/meteor_showers.py
@@ -1,5 +1,4 @@
 from typing import Any, cast
-from skyfield.api import Star
 from ..cache import get_ephemeris, get_timescale
 from ..utils import planetary
 from .utils import find_solar_longitude_time

--- a/apts/skyfield_searches/planets/extrema.py
+++ b/apts/skyfield_searches/planets/extrema.py
@@ -175,10 +175,8 @@ def find_highest_altitude(observer, planet, start_date, end_date):
 
     # Extract observer coordinates
     lon_hours = 0.0
-    lat_deg = 0.0
     for vf in observer.vector_functions:
         if hasattr(vf, "latitude"):
-            lat_deg = vf.latitude.degrees
             lon_hours = vf.longitude.hours
             break
 

--- a/apts/skyfield_searches/utils.py
+++ b/apts/skyfield_searches/utils.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from typing import Any, cast
 import numpy as np
 

--- a/apts/utils/astronomy/calculations.py
+++ b/apts/utils/astronomy/calculations.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, cast, Tuple, Union, Optional
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd

--- a/apts/utils/planetary/__init__.py
+++ b/apts/utils/planetary/__init__.py
@@ -18,6 +18,17 @@ from .base import (
     get_reverse_translated_planet_names,
 )
 
+from .calculations import (
+    calculate_sub_observer_latitude,
+    calculate_apparent_polar_radius,
+    calculate_angular_diameter,
+    calculate_illuminated_fraction,
+    calculate_illuminated_disk_area,
+    calculate_surface_brightness,
+    calculate_sun_magnitude,
+    calculate_moon_magnitude_krisciunas,
+)
+
 from .physical import (
     get_planet_radius_km,
     get_planet_rotation_period,
@@ -77,6 +88,14 @@ __all__ = [
     "get_technical_name",
     "get_skyfield_obj",
     "get_reverse_translated_planet_names",
+    "calculate_sub_observer_latitude",
+    "calculate_apparent_polar_radius",
+    "calculate_angular_diameter",
+    "calculate_illuminated_fraction",
+    "calculate_illuminated_disk_area",
+    "calculate_surface_brightness",
+    "calculate_sun_magnitude",
+    "calculate_moon_magnitude_krisciunas",
     "get_planet_radius_km",
     "get_planet_rotation_period",
     "get_planet_distance_km",

--- a/apts/utils/planetary/calculations.py
+++ b/apts/utils/planetary/calculations.py
@@ -1,0 +1,112 @@
+import numpy as np
+from typing import Union, Any, cast
+
+
+def calculate_sub_observer_latitude(
+    alpha_rad: Union[float, np.ndarray],
+    delta_rad: Union[float, np.ndarray],
+    alpha0_rad: Union[float, np.ndarray],
+    delta0_rad: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates the sub-observer latitude (planetocentric latitude of the Earth) in degrees.
+    Formula: sin(De) = -sin(delta0)*sin(delta) - cos(delta0)*cos(delta)*cos(alpha0 - alpha)
+    Reference: Explanatory Supplement to the Astronomical Almanac.
+    """
+    sin_De = -np.sin(delta0_rad) * np.sin(delta_rad) - np.cos(delta0_rad) * np.cos(
+        delta_rad
+    ) * np.cos(alpha0_rad - alpha_rad)
+    De_rad = np.arcsin(np.clip(sin_De, -1.0, 1.0))
+    res = np.degrees(De_rad)
+    return float(cast(Any, res)) if np.isscalar(res) else res
+
+
+def calculate_apparent_polar_radius(
+    radius_eq: float,
+    radius_pol: float,
+    De_deg: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates the apparent polar radius in km accounting for planetary tilt De.
+    Formula: r_app = r_eq * sqrt(1 - e^2 * cos^2(De)) where e^2 = (r_eq^2 - r_pol^2) / r_eq^2
+    """
+    De_rad = np.radians(De_deg)
+    e_sq = (radius_eq**2 - radius_pol**2) / (radius_eq**2)
+    return radius_eq * np.sqrt(1 - e_sq * np.cos(De_rad) ** 2)
+
+
+def calculate_angular_diameter(
+    radius_km: Union[float, np.ndarray],
+    distance_km: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates the apparent angular diameter in arcseconds given radius in km and distance in km.
+    Formula: alpha_rad = 2 * arcsin(radius / distance)
+    """
+    alpha_rad = 2 * np.arcsin(radius_km / distance_km)
+    res = np.degrees(alpha_rad) * 3600.0
+    return float(cast(Any, res)) if np.isscalar(res) else res
+
+
+def calculate_illuminated_fraction(
+    phase_angle_rad: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates the illuminated fraction (0.0 to 1.0) given the phase angle in radians.
+    Formula: k = (1 + cos(i)) / 2
+    """
+    return (1 + np.cos(phase_angle_rad)) / 2
+
+
+def calculate_illuminated_disk_area(
+    angular_diameter_arcsec: Union[float, np.ndarray],
+    illuminated_fraction: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates the illuminated area of a disk in square arcseconds.
+    Formula: Area = pi * (diameter / 2)^2 * k
+    """
+    return np.pi * (angular_diameter_arcsec / 2.0) ** 2 * illuminated_fraction
+
+
+def calculate_surface_brightness(
+    magnitude: Union[float, np.ndarray],
+    area_arcsec2: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates average surface brightness in mag/arcsec² given visual magnitude and illuminated area.
+    Formula: S = V + 2.5 * log10(Area)
+    """
+    if np.isscalar(area_arcsec2):
+        if cast(Any, area_arcsec2) <= 0:
+            return float("inf")
+        res_scalar = magnitude + 2.5 * np.log10(area_arcsec2)
+        return float(cast(Any, res_scalar))
+    else:
+        res = np.full_like(area_arcsec2, np.inf, dtype=float)
+        valid = area_arcsec2 > 0
+        np.log10(area_arcsec2, where=valid, out=res)
+        res = np.where(valid, magnitude + 2.5 * res, np.inf)
+        return cast(np.ndarray, res)
+
+
+def calculate_sun_magnitude(
+    distance_au: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates apparent magnitude of the Sun given distance in AU.
+    Formula: M = -26.74 + 5 * log10(dist_au)
+    """
+    return -26.74 + 5 * np.log10(distance_au)
+
+
+def calculate_moon_magnitude_krisciunas(
+    phase_angle_deg: Union[float, np.ndarray],
+    distance_km: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """
+    Calculates Moon apparent visual magnitude using Krisciunas & Schaefer (1991) model.
+    """
+    v_base = -12.73 + 0.026 * np.abs(phase_angle_deg) + 4.0e-9 * (phase_angle_deg**4)
+    v_dist = 5 * np.log10(distance_km / 384400.0)
+    return v_base + v_dist

--- a/apts/utils/planetary/physical.py
+++ b/apts/utils/planetary/physical.py
@@ -5,6 +5,16 @@ from skyfield import magnitudelib
 from apts.cache import get_ephemeris, get_timescale
 from .constants import PLANET_RADII_KM, PLANET_POLAR_RADII_KM, PLANET_ROTATION_PERIODS_S
 from .base import get_simple_name, get_skyfield_obj
+from .calculations import (
+    calculate_sub_observer_latitude,
+    calculate_apparent_polar_radius,
+    calculate_angular_diameter,
+    calculate_illuminated_fraction,
+    calculate_illuminated_disk_area,
+    calculate_surface_brightness,
+    calculate_sun_magnitude,
+    calculate_moon_magnitude_krisciunas,
+)
 
 
 def get_planet_radius_km(planet_name: str) -> float:
@@ -119,17 +129,9 @@ def get_sub_observer_latitude(planet_name: str, time: Any) -> Union[float, np.nd
     alpha0_rad = np.radians(alpha0_deg)
     delta0_rad = np.radians(delta0_deg)
 
-    # Formula for sub-observer latitude De:
-    # sin(De) = -sin(delta0)*sin(delta) - cos(delta0)*cos(delta)*cos(alpha0 - alpha)
-    # This represents the latitude of the sub-observer point.
-    # Reference: Explanatory Supplement to the Astronomical Almanac.
-    sin_De = -np.sin(delta0_rad) * np.sin(delta_rad) - np.cos(delta0_rad) * np.cos(
-        delta_rad
-    ) * np.cos(alpha0_rad - alpha_rad)
-    De_rad = np.arcsin(np.clip(sin_De, -1.0, 1.0))
-
-    res = np.degrees(De_rad)
-    return float(cast(Any, res)) if np.isscalar(res) else res
+    return calculate_sub_observer_latitude(
+        alpha_rad, delta_rad, alpha0_rad, delta0_rad
+    )
 
 
 def get_planet_angular_diameter(
@@ -156,22 +158,12 @@ def get_planet_angular_diameter(
         if which == "polar":
             radius = radius_pol
         elif which == "apparent_polar":
-            # Apparent polar diameter depends on tilt
-            # Formula: r_app = r_eq * sqrt(1 - e^2 * cos^2(De))
-            # where e^2 = (r_eq^2 - r_pol^2) / r_eq^2
             De = get_sub_observer_latitude(planet_name, time)
-            De_rad = np.radians(De)
-            e_sq = (radius_eq**2 - radius_pol**2) / (radius_eq**2)
-            radius = radius_eq * np.sqrt(1 - e_sq * np.cos(De_rad) ** 2)
+            radius = calculate_apparent_polar_radius(radius_eq, radius_pol, De)
         else:
             raise ValueError(f"Invalid 'which' parameter: {which}")
 
-    # Angular diameter in radians
-    alpha_rad = 2 * np.arcsin(radius / distance)
-
-    # Convert to arcseconds
-    res = np.degrees(alpha_rad) * 3600.0
-    return float(cast(Any, res)) if np.isscalar(res) else res
+    return calculate_angular_diameter(radius, distance)
 
 
 def get_planet_fraction_illuminated(
@@ -193,7 +185,7 @@ def get_planet_fraction_illuminated(
     # Phase angle: angle Sun-Planet-Earth
     i_rad = astrometric.phase_angle(sun).radians
 
-    return (1 + np.cos(i_rad)) / 2
+    return calculate_illuminated_fraction(i_rad)
 
 
 def get_planet_phase(planet_name: str, time: Any) -> float | np.ndarray:
@@ -245,22 +237,13 @@ def get_planet_magnitude(
         astrometric = cast(Any, earth).at(time).observe(planet_obj)
 
     if name_norm == "sun":
-        # Sun magnitude: M = -26.74 at 1 AU
         dist_au = astrometric.distance().au
-        return -26.74 + 5 * np.log10(dist_au)
+        return calculate_sun_magnitude(dist_au)
 
     if name_norm == "moon":
-        # Moon magnitude using Krisciunas & Schaefer (1991)
-        # alpha is the phase angle Sun-Moon-Earth in degrees
         alpha = astrometric.phase_angle(sun).degrees
-        # V(R, alpha) = -12.73 + 0.026 * |alpha| + 4e-9 * alpha^4
-        v_base = -12.73 + 0.026 * np.abs(alpha) + 4.0e-9 * (alpha**4)
-
-        # Distance correction: delta is distance in km
         dist_km = astrometric.distance().km
-        # correction = 5 * log10(dist / 384400)
-        v_dist = 5 * np.log10(dist_km / 384400.0)
-        return v_base + v_dist
+        return calculate_moon_magnitude_krisciunas(alpha, dist_km)
 
     # Major planets and others supported by skyfield
     # Skyfield's magnitudelib.planetary_magnitude(astrometric) handles
@@ -294,9 +277,6 @@ def get_planet_surface_brightness(planet_name: str, time: Any) -> float | np.nda
     else:
         planet_obj = get_skyfield_obj(planet_name)
 
-    # Optimization: Consolidate redundant Skyfield observations into a single call.
-    # Apparent positions are expensive; reusing the result for magnitude, diameter,
-    # and illuminated fraction provides a significant speedup.
     astrometric = cast(Any, earth).at(time).observe(planet_obj)
 
     v = get_planet_magnitude(planet_name, time, astrometric=astrometric)
@@ -304,31 +284,12 @@ def get_planet_surface_brightness(planet_name: str, time: Any) -> float | np.nda
     # Angular diameter calculation using precomputed astrometric object
     radius_eq = get_planet_radius_km(planet_name)
     distance_km = astrometric.distance().km
-    alpha_rad = 2 * np.arcsin(radius_eq / distance_km)
-    d = np.degrees(alpha_rad) * 3600.0
+    d = calculate_angular_diameter(radius_eq, distance_km)
 
     if name_norm == "sun":
         k = 1.0
     else:
         k = get_planet_fraction_illuminated(planet_name, time, astrometric=astrometric)
 
-    # Area of illuminated portion of the disk in arcsec^2
-    # Area = pi * (radius)^2 * k
-    area = np.pi * (d / 2.0) ** 2 * k
-
-    # Handle cases where area might be zero or negative to avoid log10 errors
-    if np.isscalar(area):
-        if cast(Any, area) <= 0:
-            return float("inf")
-        # Ensure we return a Python float for consistency
-        res_scalar = v + 2.5 * np.log10(area)
-        return float(cast(Any, res_scalar))
-    else:
-        # For arrays, use np.where to handle zeros and return inf.
-        # We use np.log10's 'where' and 'out' parameters to avoid RuntimeWarnings
-        # when area contains zeros or negative values.
-        res = np.full_like(area, np.inf, dtype=float)
-        valid = area > 0
-        np.log10(area, where=valid, out=res)
-        res = np.where(valid, v + 2.5 * res, np.inf)
-        return cast(np.ndarray, res)
+    area = calculate_illuminated_disk_area(d, k)
+    return calculate_surface_brightness(v, area)

--- a/tests/unit/test_astronomy_package.py
+++ b/tests/unit/test_astronomy_package.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 import pytz

--- a/tests/unit/test_objects_calculations_visibility.py
+++ b/tests/unit/test_objects_calculations_visibility.py
@@ -1,7 +1,5 @@
-import pytest
 import numpy as np
 import pandas as pd
-from unittest.mock import MagicMock
 from apts.objects.calculations.visibility import (
     filter_objects_by_magnitude,
     calculate_visible_stars_mask,
@@ -82,7 +80,7 @@ def test_calculate_visible_stars_mask_fast_path():
         check_times_gmst,
         conditions,
     )
-    assert mask[0] == True
+    assert mask[0]
 
 
 def test_calculate_visible_stars_mask_complex_path():

--- a/tests/unit/test_optics_calculations_geometric.py
+++ b/tests/unit/test_optics_calculations_geometric.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from unittest.mock import MagicMock
 
 from apts.optics.calculations.geometric import (
@@ -37,8 +36,6 @@ def test_calculate_zoom_binoculars_etc():
 
     # Using isinstance check with a dynamically subclassed mock or registering classes
     from apts.opticalequipment.binoculars import Binoculars
-    from apts.opticalequipment.naked_eye import NakedEye
-    from apts.opticalequipment.smart_telescope import SmartTelescope
 
     # Create mock of Binoculars class
     class MyBinoculars(Binoculars):

--- a/tests/unit/test_planetary_calculations.py
+++ b/tests/unit/test_planetary_calculations.py
@@ -1,0 +1,106 @@
+import unittest
+import numpy as np
+
+from apts.utils.planetary.calculations import (
+    calculate_sub_observer_latitude,
+    calculate_apparent_polar_radius,
+    calculate_angular_diameter,
+    calculate_illuminated_fraction,
+    calculate_illuminated_disk_area,
+    calculate_surface_brightness,
+    calculate_sun_magnitude,
+    calculate_moon_magnitude_krisciunas,
+)
+
+
+class TestPlanetaryCalculations(unittest.TestCase):
+    def test_calculate_sub_observer_latitude_scalar(self):
+        # Test zero declination and same RA/Dec
+        res = calculate_sub_observer_latitude(
+            alpha_rad=0.0,
+            delta_rad=0.0,
+            alpha0_rad=0.0,
+            delta0_rad=np.radians(90.0),  # North pole at Dec=90
+        )
+        self.assertIsInstance(res, float)
+        self.assertAlmostEqual(res, 0.0, places=5)
+
+    def test_calculate_sub_observer_latitude_array(self):
+        alpha_rad = np.array([0.0, np.pi / 2])
+        delta_rad = np.array([0.0, 0.0])
+        alpha0_rad = np.array([0.0, 0.0])
+        delta0_rad = np.array([np.pi / 2, np.pi / 2])
+        res = calculate_sub_observer_latitude(
+            alpha_rad, delta_rad, alpha0_rad, delta0_rad
+        )
+        self.assertIsInstance(res, np.ndarray)
+        self.assertEqual(len(res), 2)
+
+    def test_calculate_apparent_polar_radius(self):
+        # Jupiter: r_eq ~ 71492 km, r_pol ~ 66854 km
+        r_eq = 71492.0
+        r_pol = 66854.0
+
+        # At tilt = 0 deg (equator-on view), apparent polar radius = r_pol
+        res_0 = calculate_apparent_polar_radius(r_eq, r_pol, De_deg=0.0)
+        self.assertAlmostEqual(res_0, r_pol, places=2)
+
+        # At tilt = 90 deg (pole-on view), apparent polar radius = r_eq
+        res_90 = calculate_apparent_polar_radius(r_eq, r_pol, De_deg=90.0)
+        self.assertAlmostEqual(res_90, r_eq, places=2)
+
+    def test_calculate_angular_diameter(self):
+        # Jupiter ~ 71492 km radius at ~ 778.5e6 km distance
+        r_km = 71492.0
+        dist_km = 778.5e6
+        ang_diam = calculate_angular_diameter(r_km, dist_km)
+        self.assertIsInstance(ang_diam, float)
+        self.assertGreater(ang_diam, 30.0)
+        self.assertLess(ang_diam, 50.0)
+
+    def test_calculate_illuminated_fraction(self):
+        # Phase angle = 0 rad (full disk) -> fraction = 1.0
+        self.assertAlmostEqual(calculate_illuminated_fraction(0.0), 1.0)
+        # Phase angle = pi/2 rad (half disk) -> fraction = 0.5
+        self.assertAlmostEqual(calculate_illuminated_fraction(np.pi / 2), 0.5)
+        # Phase angle = pi rad (new/dark disk) -> fraction = 0.0
+        self.assertAlmostEqual(calculate_illuminated_fraction(np.pi), 0.0)
+
+    def test_calculate_illuminated_disk_area(self):
+        # Diameter = 10 arcsec, fraction = 1.0 -> pi * 5^2 = ~78.5398 arcsec2
+        area = calculate_illuminated_disk_area(10.0, 1.0)
+        self.assertAlmostEqual(area, np.pi * 25.0, places=5)
+
+    def test_calculate_surface_brightness(self):
+        # V = 5.0, Area = 100 arcsec2 -> 5.0 + 2.5 * log10(100) = 5.0 + 5.0 = 10.0
+        sb = calculate_surface_brightness(5.0, 100.0)
+        self.assertAlmostEqual(sb, 10.0, places=5)
+
+        # Zero or negative area -> float('inf')
+        self.assertEqual(calculate_surface_brightness(5.0, 0.0), float("inf"))
+        self.assertEqual(calculate_surface_brightness(5.0, -10.0), float("inf"))
+
+        # Array input
+        areas = np.array([100.0, 0.0, 10.0])
+        sb_arr = calculate_surface_brightness(5.0, areas)
+        self.assertIsInstance(sb_arr, np.ndarray)
+        self.assertAlmostEqual(sb_arr[0], 10.0, places=5)
+        self.assertTrue(np.isinf(sb_arr[1]))
+
+    def test_calculate_sun_magnitude(self):
+        # At 1.0 AU, Sun magnitude = -26.74
+        m1 = calculate_sun_magnitude(1.0)
+        self.assertAlmostEqual(m1, -26.74, places=5)
+
+        # At 2.0 AU, magnitude increases by 5 * log10(2) ~ 1.505
+        m2 = calculate_sun_magnitude(2.0)
+        self.assertAlmostEqual(m2, -26.74 + 5 * np.log10(2.0), places=5)
+
+    def test_calculate_moon_magnitude_krisciunas(self):
+        # At phase = 0 deg and mean distance 384400 km
+        m0 = calculate_moon_magnitude_krisciunas(0.0, 384400.0)
+        self.assertAlmostEqual(m0, -12.73, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_scoring_calculations.py
+++ b/tests/unit/test_scoring_calculations.py
@@ -1,6 +1,5 @@
 import unittest
 import pandas as pd
-import numpy as np
 
 from apts.scoring.calculations import (
     calculate_altitude_score,

--- a/tests/unit/test_sky_watcher_esprit_120_audit.py
+++ b/tests/unit/test_sky_watcher_esprit_120_audit.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
 from apts.utils import ConnectionType, Gender
 

--- a/tests/unit/test_takahashi_audit.py
+++ b/tests/unit/test_takahashi_audit.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.telescope.vendors.takahashi import TakahashiTelescope
 
 def test_takahashi_fsq_85edp_audit():

--- a/tests/unit/test_virtuoso_gti_130p_audit.py
+++ b/tests/unit/test_virtuoso_gti_130p_audit.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
 
 def test_virtuoso_gti_130p_audit():

--- a/tests/unit/test_zwo_2400mc_audit.py
+++ b/tests/unit/test_zwo_2400mc_audit.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
 from apts.utils import ConnectionType, Gender
 

--- a/tests/unit/test_zwo_290_audit.py
+++ b/tests/unit/test_zwo_290_audit.py
@@ -1,4 +1,3 @@
-import pytest
 from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
 
 def test_zwo_asi290mm_audit():


### PR DESCRIPTION
Separated pure mathematical planetary calculations from Skyfield ephemeris lookups by extracting `calculate_sub_observer_latitude`, `calculate_apparent_polar_radius`, `calculate_angular_diameter`, `calculate_illuminated_fraction`, `calculate_illuminated_disk_area`, `calculate_surface_brightness`, `calculate_sun_magnitude`, and `calculate_moon_magnitude_krisciunas` into `apts/utils/planetary/calculations.py`. Refactored `apts/utils/planetary/physical.py` to delegate to these functions, re-exported them in `apts/utils/planetary/__init__.py`, added full unit tests in `tests/unit/test_planetary_calculations.py`, and resolved all lint warnings.

---
*PR created automatically by Jules for task [6225232390532135223](https://jules.google.com/task/6225232390532135223) started by @pozar87*