### PR TITLE
🔍 Optic: Data audit for Meade LX85 ACF 6"

### DIFF
--- a/apts/opticalequipment/telescope/vendors/meade.py
+++ b/apts/opticalequipment/telescope/vendors/meade.py
@@ -8,16 +8,16 @@ class MeadeTelescope(Telescope):
             "name": "LX85 ACF 6\"",
             "type": "catadioptric",
             "optical_length": 0,
-            "mass": 4490,
+            "mass": 5030,  # Verified via official Meade / Levenhuk documentation (5.03 kg OTA weight) - https://eu.levenhuk.com/catalogue/telescopes/meade-lx85-6-acf-ota/
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 152.4,
-            "focal_length_mm": 1524,
-            "central_obstruction_mm": 56,
+            "aperture_mm": 152.4,  # Verified via official Meade spec sheet (6" = 152.4mm)
+            "focal_length_mm": 1524,  # Verified via official Meade spec sheet (1524mm f/10)
+            "central_obstruction_mm": 56,  # Verified via official Meade spec sheet (56mm secondary obstruction)
         },
         "Meade_LX85_ACF_8": {
             "brand": "Meade",

--- a/tests/unit/test_meade_lx85_6_acf_audit.py
+++ b/tests/unit/test_meade_lx85_6_acf_audit.py
@@ -1,0 +1,39 @@
+import pytest
+from apts.opticalequipment.telescope.vendors.meade import MeadeTelescope
+from apts.opticalequipment.telescope.base import TelescopeType
+from apts.utils import ConnectionType
+
+def test_meade_lx85_6_acf_specs():
+    """
+    Audit test for Meade LX85 ACF 6" telescope based on official Meade / manufacturer documentation.
+    Source: https://eu.levenhuk.com/catalogue/telescopes/meade-lx85-6-acf-ota/
+    """
+    scope = MeadeTelescope.Meade_LX85_ACF_6()
+
+    # Vendor / Model Name
+    assert scope.get_vendor() == "Meade LX85 ACF 6\""
+
+    # Telescope Type
+    assert scope.telescope_type == TelescopeType.CATADIOPTRIC
+
+    # Mass: stored as a Pint Quantity in grams (5030g / 5.03kg OTA weight)
+    assert scope.mass.to('gram').magnitude == 5030
+    assert scope.mass.to('kg').magnitude == pytest.approx(5.03, abs=1e-3)
+
+    # Aperture: 152.4mm
+    assert scope.aperture.to('mm').magnitude == pytest.approx(152.4, abs=1e-3)
+
+    # Focal length: 1524mm
+    assert scope.focal_length.to('mm').magnitude == 1524
+
+    # Focal ratio: f/10
+    assert float(scope.focal_ratio().magnitude) == pytest.approx(10.0, abs=1e-3)
+
+    # Central obstruction: 56mm
+    assert scope.central_obstruction.to('mm').magnitude == 56
+
+    # Connection type: SC (Schmidt-Cassegrain)
+    assert scope.connection_type == ConnectionType.SC
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/test_meade_specs.py
+++ b/tests/unit/test_meade_specs.py
@@ -2,7 +2,7 @@ import pytest
 from apts.opticalequipment.telescope.vendors.meade import MeadeTelescope
 
 @pytest.mark.parametrize("factory_method, expected_aperture, expected_focal, expected_mass, expected_co", [
-    (MeadeTelescope.Meade_LX85_ACF_6, 152.4, 1524, 4490, 56),
+    (MeadeTelescope.Meade_LX85_ACF_6, 152.4, 1524, 5030, 56),
     (MeadeTelescope.Meade_LX85_ACF_8, 203.2, 2032, 5760, 76),
     (MeadeTelescope.Meade_LX200_ACF_8, 203.2, 2032, 6350, 76),
     (MeadeTelescope.Meade_LX200_ACF_10, 254.0, 2540, 11790, 94),


### PR DESCRIPTION
Data audit and specification verification for the Meade LX85 ACF 6" telescope based on official manufacturer documentation. Updated tube mass to 5.03 kg (5030 g), verified optical specifications and mechanical interface threads, added reference comments, and added unit test coverage.

---
*PR created automatically by Jules for task [1151432771589740910](https://jules.google.com/task/1151432771589740910) started by @pozar87*