### PR TITLE
🔍 Optic: Data audit for Celestron NexStar 127SLT

### DIFF
--- a/apts/observations/catalogs/planets.py
+++ b/apts/observations/catalogs/planets.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Optional, Union, cast
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:

--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -695,15 +695,15 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 127SLT",
             "type": "maksutov_cassegrain",
             "optical_length": 0,
-            "mass": 3950,
+            "mass": 3950, # Verified via Celestron.com (8.7 lbs / 3.95 kg OTA weight) - https://www.celestron.com/products/nexstar-127slt-computerized-telescope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "1.25\"",
             "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 127,
-            "focal_length_mm": 1500,
+            "aperture_mm": 127, # Verified via Celestron.com (127mm / 5") - https://www.celestron.com/products/nexstar-127slt-computerized-telescope
+            "focal_length_mm": 1500, # Verified via Celestron.com (1500mm / f/12) - https://www.celestron.com/products/nexstar-127slt-computerized-telescope
             "central_obstruction_mm": 40,
         },
         "Celestron_NexStar_130SLT": {

--- a/tests/unit/test_celestron_nexstar_127slt_audit.py
+++ b/tests/unit/test_celestron_nexstar_127slt_audit.py
@@ -1,0 +1,20 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+
+class TestCelestronNexStar127SLTAudit(unittest.TestCase):
+    def test_nexstar_127slt_specs(self):
+        """
+        NexStar 127SLT Maksutov-Cassegrain specifications audit test.
+        Source: https://www.celestron.com/products/nexstar-127slt-computerized-telescope
+        """
+        scope = CelestronTelescope.Celestron_NexStar_127SLT()
+        self.assertEqual(scope.aperture.to('mm').magnitude, 127.0)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 1500.0)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 11.81, places=2)
+        self.assertEqual(scope.mass.to('gram').magnitude, 3950)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 40.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited and verified specifications for the Celestron NexStar 127SLT Maksutov-Cassegrain telescope against official Celestron product documentation. Added verification comments and source references in `apts/opticalequipment/telescope/vendors/celestron.py` and added a unit test suite in `tests/unit/test_celestron_nexstar_127slt_audit.py`.

---
*PR created automatically by Jules for task [17405134571489432758](https://jules.google.com/task/17405134571489432758) started by @pozar87*