### PR TITLE
Fix planet plotting to preserve TechnicalName column for non-English UIs

### DIFF
--- a/apts/__init__.py
+++ b/apts/__init__.py
@@ -166,4 +166,4 @@ if should_auto_preload_data():
         preload_data()
 
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/apts/plotting/altitude/planets.py
+++ b/apts/plotting/altitude/planets.py
@@ -16,6 +16,7 @@ from apts.i18n import gettext_
 from apts.plotting.utils import mark_good_conditions, mark_observation
 from apts.utils import planetary
 from apts.utils.plot import PlotUtils
+
 from ...constants import ObjectTableLabels
 
 if TYPE_CHECKING:
@@ -36,6 +37,11 @@ def generate_plot_planets(
     plot_colors = get_plot_colors(effective_dark_mode)
 
     ax = args.pop("ax", None)
+    # Consumed for API compatibility: magnitude filtering is already applied
+    # inside get_visible_planets() via the observation's limiting_magnitude.
+    # Without popping it, it would be forwarded to pyplot.subplots() below
+    # and crash when no ax is provided.
+    args.pop("star_magnitude_limit", None)
     fig = None
     if ax:
         fig = ax.figure
@@ -45,7 +51,10 @@ def generate_plot_planets(
     fig.patch.set_facecolor(style["FIGURE_FACE_COLOR"])
     ax.set_facecolor(style["AXES_FACE_COLOR"])
 
-    planets_df = observation.get_visible_planets().copy()
+    # TechnicalName (and other technical columns) is stripped from the
+    # user-facing DataFrame (clean=True), but it is required here to resolve
+    # Skyfield objects and planet colors regardless of the UI language.
+    planets_df = observation.get_visible_planets(clean=False).copy()
 
     # Extended range for plotting context (+/- 30 mins)
     plot_start = (
@@ -166,7 +175,13 @@ def _plot_single_planet_curve(
     )
 
     specific_planet_color = get_planet_color(
-        planetary.get_simple_name(str(getattr(planet, "TechnicalName", getattr(planet, ObjectTableLabels.NAME)))),
+        planetary.get_simple_name(
+            str(
+                getattr(
+                    planet, "TechnicalName", getattr(planet, ObjectTableLabels.NAME)
+                )
+            )
+        ),
         effective_dark_mode,
         default_planet_color,  # type: ignore
     )
@@ -177,8 +192,11 @@ def _plot_single_planet_curve(
     else:
         # Optimization: list comprehension over .values is faster than .apply() for fallback path.
         time_series = pd.Series(
-            [t.utc_datetime() if hasattr(t, "utc_datetime") else pd.NaT for t in curve_df["Time"].values],
-            index=curve_df.index
+            [
+                t.utc_datetime() if hasattr(t, "utc_datetime") else pd.NaT
+                for t in curve_df["Time"].values
+            ],
+            index=curve_df.index,
         )
     valid_times = pd.notna(time_series)
 

--- a/apts/plotting/planets.py
+++ b/apts/plotting/planets.py
@@ -25,7 +25,9 @@ def plot_visible_planets_svg(
     style = get_plot_style(effective_dark_mode)
     default_fill_color = style["AXES_FACE_COLOR"]
 
-    visible_planets = observation.get_visible_planets(**args)
+    # Keep technical columns (TechnicalName) - needed for canonical planet
+    # identification and colors, and unaffected by UI language translation.
+    visible_planets = observation.get_visible_planets(clean=False, **args)
     dwg = svg.Drawing(style={"background-color": style["BACKGROUND_COLOR"]})
     if not visible_planets.empty:
         max_size = visible_planets[["Size"]].max().iloc[0]

--- a/apts/plotting/skymap_objects/planets.py
+++ b/apts/plotting/skymap_objects/planets.py
@@ -1,14 +1,15 @@
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Optional, cast
 
 import numpy
 import pandas as pd
-from types import SimpleNamespace
 from matplotlib.patches import Ellipse
 
 from apts.constants.graphconstants import get_planet_color
 from apts.constants.plot import CoordinateSystem
 from apts.i18n import gettext_
 from apts.utils import planetary
+
 from ...constants import ObjectTableLabels
 
 if TYPE_CHECKING:
@@ -33,7 +34,10 @@ def _plot_planets_on_skymap(
         visible_planets = observation.local_planets.objects.copy()
         visible_planets["TechnicalName"] = visible_planets[ObjectTableLabels.NAME]
     else:
-        visible_planets = observation.get_visible_planets()
+        # Keep technical columns (TechnicalName, current_alt, current_az) -
+        # needed for canonical planet identification, colors and pre-computed
+        # coordinates regardless of the UI language.
+        visible_planets = observation.get_visible_planets(clean=False)
     if not visible_planets.empty:
         target_technical_name = (
             planetary.get_technical_name(target_name) if target_name else None
@@ -214,7 +218,9 @@ def _get_solar_system_object_visual_size(
             # Find the planet data to get its magnitude
             technical_name = planetary.get_technical_name(object_name)
             planets_df = observation.local_planets.objects
-            object_data = planets_df[planets_df[ObjectTableLabels.NAME] == technical_name]
+            object_data = planets_df[
+                planets_df[ObjectTableLabels.NAME] == technical_name
+            ]
             if not object_data.empty:
                 magnitude = object_data.iloc[0].get(ObjectTableLabels.MAGNITUDE)
                 if hasattr(magnitude, "magnitude"):

--- a/apts/plotting/utils/geometry.py
+++ b/apts/plotting/utils/geometry.py
@@ -113,7 +113,9 @@ def get_object_angular_size_deg(observation: "Observation", object_name: str) ->
             return float(size_arcsec) / 3600.0
 
     # Fallback to English-named visible planets
-    visible_planets = observation.get_visible_planets(language="en")
+    # Keep technical columns (TechnicalName) for canonical name matching
+    # (the translated Name column is not a reliable identifier here).
+    visible_planets = observation.get_visible_planets(language="en", clean=False)
     object_data = visible_planets[
         (visible_planets["TechnicalName"] == object_name)
         | (visible_planets["Name"] == object_name)

--- a/tests/plotting/test_plot.py
+++ b/tests/plotting/test_plot.py
@@ -128,6 +128,7 @@ def test_plot_skymap_renders_messier_objects(mock_observation):
         )
         mock_ts = MagicMock(spec=Timescale)
         from skyfield.api import load
+
         ts = load.timescale()
         mock_time = ts.utc(2025, 2, 18)
         mock_ts.tdb.return_value = mock_time
@@ -187,6 +188,7 @@ def test_plot_ngc_object_with_no_size(mock_observation):
 
         mock_ts = MagicMock(spec=Timescale)
         from skyfield.api import load
+
         ts = load.timescale()
         mock_time = ts.utc(2025, 2, 18)
         mock_ts.tdb.return_value = mock_time
@@ -513,10 +515,8 @@ def test_plot_stars_on_skymap_equatorial_with_zoom():
         print(f"Mock dec_degrees_array type: {type(dec_degrees_array)}")
 
         # Add debug output to track the mock objects
-        print(
-        )
-        print(
-        )
+        print()
+        print()
 
         # Test the actual property access and indexing
 
@@ -530,7 +530,6 @@ def test_plot_stars_on_skymap_equatorial_with_zoom():
             zoom_deg=2.0,
             coordinate_system=cast(Any, CoordinateSystem.EQUATORIAL),
         )
-
 
         # Check if scatter was called at all
         print(f"mock_ax.scatter called: {mock_ax.scatter.called}")
@@ -756,7 +755,9 @@ def test_plot_messier_ellipse_angle_on_equatorial_zoom():
                 pa, p_angle, cs, fh, fv
             ),
         ),
-        patch("apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"),
+        patch(
+            "apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"
+        ),
         patch(
             "apts.plotting.skymap_objects.calculate_parallactic_angle",
             return_value=parallactic_angle_val,
@@ -871,7 +872,9 @@ def test_plot_target_messier_ellipse_angle_on_horizontal_zoom():
                 pa, p_angle, cs, fh, fv
             ),
         ),
-        patch("apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"),
+        patch(
+            "apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"
+        ),
         patch(
             "apts.plotting.skymap_objects.calculate_parallactic_angle",
             return_value=parallactic_angle_val,
@@ -1006,7 +1009,9 @@ def test_plot_non_target_messier_ellipse_angle_on_horizontal_zoom():
                 pa, p_angle, cs, fh, fv
             ),
         ),
-        patch("apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"),
+        patch(
+            "apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"
+        ),
         patch(
             "apts.plotting.skymap_objects.calculate_parallactic_angle",
             return_value=parallactic_angle_val,
@@ -1137,7 +1142,9 @@ def test_plot_non_target_messier_ellipse_angle_on_equatorial_zoom():
                 pa, p_angle, cs, fh, fv
             ),
         ),
-        patch("apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"),
+        patch(
+            "apts.plotting.skymaps.skymap_zoom.get_brightness_color", return_value="0.5"
+        ),
         patch(
             "apts.plotting.skymap_objects.calculate_parallactic_angle",
             return_value=parallactic_angle_val,
@@ -1430,7 +1437,6 @@ def test_plot_stars_ra_wrapping_equatorial():
             coordinate_system=cast(Any, CoordinateSystem.EQUATORIAL),
         )
 
-
         # Verify that scatter was called with stars in the wrapped zoom window
         scatter_calls = mock_ax.scatter.call_args_list
 
@@ -1569,3 +1575,62 @@ def test_plot_stars_ra_wrapping_equatorial():
         assert len(ax.collections) == 3
 
         plt.close(fig)
+
+
+def test_plot_planets_requests_technical_columns():
+    """
+    Regression test: get_visible_planets() strips technical columns (clean=True)
+    and its Name column may be translated (e.g. "Księżyc" in Polish). The altitude
+    planets plot must request clean=False so the canonical TechnicalName remains
+    available for Skyfield object resolution - otherwise plotting crashes with
+    "'NoneType' object has no attribute '_observe_from_bcrs'" for non-English UIs.
+    """
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    import numpy as np
+    import pandas as pd
+    import pytz
+    from matplotlib import pyplot as plt
+
+    from apts.observations import Observation
+    from apts.plotting.altitude import (
+        generate_plot_planets as _generate_plot_planets,
+    )
+
+    mock_observation = MagicMock(spec=Observation)
+    mock_observation.place = MagicMock()
+    mock_observation.place.local_timezone = pytz.utc
+    mock_observation.start = datetime(2023, 1, 1, 22, 0, tzinfo=pytz.utc)
+    mock_observation.stop = datetime(2023, 1, 2, 6, 0, tzinfo=pytz.utc)
+    mock_observation.time_limit = mock_observation.stop
+    mock_observation.conditions = MagicMock()
+    mock_observation.conditions.min_object_altitude = 10
+    mock_observation.conditions.is_visible.return_value = np.array([])
+
+    # Simulate the user-facing (clean=True) DataFrame: no TechnicalName, and a
+    # translated Name column.
+    mock_visible_planets = pd.DataFrame(
+        {
+            "Name": ["Księżyc", "Uran"],
+            "Rising": [pd.NaT, pd.NaT],
+            "Setting": [pd.NaT, pd.NaT],
+        }
+    )
+    mock_observation.get_visible_planets.return_value = mock_visible_planets
+    mock_observation.place.get_altaz_curve.return_value = pd.DataFrame(
+        {"Time": [], "Altitude": [], "Azimuth": [], "Time_dt": []}
+    )
+    mock_observation.local_planets.get_skyfield_object.return_value = MagicMock()
+
+    fig, ax = plt.subplots()
+    try:
+        _generate_plot_planets(observation=mock_observation, ax=ax)
+    except Exception as e:
+        plt.close(fig)
+        pytest.fail(f"_generate_plot_planets raised an unexpected exception: {e}")
+    plt.close(fig)
+
+    # The plot must request the uncleaned DataFrame so the canonical
+    # TechnicalName is available for Skyfield object resolution.
+    mock_observation.get_visible_planets.assert_called_with(clean=False)


### PR DESCRIPTION
Without clean=False, get_visible_planets() strips TechnicalName and may return a translated Name (e.g., "Księżyc"), causing Skyfield object resolution to fail. Also pop stray star_magnitude_limit arg to prevent pyplot.subplots() crash.