### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Evostar 80ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -408,10 +408,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA (2" dual-speed Crayford focuser visual back) - https://www.skywatcherusa.com/products/evostar-80ed
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Includes 2" Crayford focuser with 2" visual back) - https://www.skywatcherusa.com/products/evostar-80ed
             "focal_length_mm": 600,
-            "mass": 2470,
+            "mass": 2470,  # Verified via Sky-Watcher USA / Astronomics (5.4 lbs / 2.47 kg OTA weight) - https://www.skywatcherusa.com/products/evostar-80ed
             "name": "Evostar 80ED",
             "optical_length": 0,
             "reversible": False,
@@ -424,10 +424,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA / OVL UK (2" dual-speed Crayford focuser visual back) - https://www.skywatcherusa.com/products/evostar-80ed
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA / OVL UK (Includes 2" Crayford focuser with 2" visual back) - https://www.skywatcherusa.com/products/evostar-80ed
             "focal_length_mm": 600,
-            "mass": 2470,
+            "mass": 2470,  # Verified via Sky-Watcher USA / Astronomics (5.4 lbs / 2.47 kg OTA weight) - https://www.skywatcherusa.com/products/evostar-80ed
             "name": "Evostar 80ED DS-Pro",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_evostar_80ed_audit.py
+++ b/tests/unit/test_sky_watcher_evostar_80ed_audit.py
@@ -1,0 +1,34 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.opticalequipment.telescope.enums import TelescopeType
+from apts.utils import ConnectionType, Gender
+
+
+class TestSkyWatcherEvostar80EDAudit(unittest.TestCase):
+    def test_evostar_80ed_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_80ED()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 80ED")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 80)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 600)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 7.5)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2470)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+    def test_evostar_80ed_ds_pro_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_80ED_DS_Pro()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 80ED DS-Pro")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 80)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 600)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 7.5)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2470)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited and verified Sky-Watcher Evostar 80ED and Evostar 80ED DS-Pro telescopes against official Sky-Watcher USA technical documentation. Corrected drawtube visual back connection properties (`cside_thread`: "2\"", `cside_gender`: "Female") and added reference comments and comprehensive unit tests.

---
*PR created automatically by Jules for task [6903640643287582567](https://jules.google.com/task/6903640643287582567) started by @pozar87*