### PR TITLE
🔍 Optic: Data audit for ZWO ASI715MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -1845,11 +1845,11 @@ class ZwoCamera(Camera):
             "brand": "ZWO",
             "cside_gender": "",
             "cside_thread": "",
-            "full_well_e": 6030,
+            "full_well_e": 6030,  # Verified via ZWO official product specs (6.03ke) - https://www.zwoastro.com/product/asi715mc/
             "height": 2192,
-            "mass": 126,
+            "mass": 126,  # Verified via ZWO (126g) - https://www.zwoastro.com/product/asi715mc/
             "name": "ASI715MC",
-            "optical_length": 6.5,
+            "optical_length": 12.5,  # Verified via ZWO (12.5mm backfocus distance / CS thread) - https://www.zwoastro.com/product/asi715mc/
             "pixel_size_um": 1.45,
             "quantum_efficiency_pct": 80,
             "read_noise_e": 0.72,
@@ -1857,7 +1857,7 @@ class ZwoCamera(Camera):
             "sensor_height_mm": 3.18,
             "sensor_width_mm": 5.6,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",  # Verified via ZWO (CS-mount native thread with 12.5mm backfocus) - https://www.zwoastro.com/product/asi715mc/
             "type": "type_camera",
             "width": 3864,
         },

--- a/tests/unit/test_zwo_715mc_audit.py
+++ b/tests/unit/test_zwo_715mc_audit.py
@@ -1,0 +1,43 @@
+import unittest
+from pint import Quantity
+
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils.equipment import ConnectionType
+
+
+class TestZwoASI715MCAudit(unittest.TestCase):
+
+    def test_asi715mc_specs(self):
+        cam = ZwoCamera.ZWO_ASI_715MC()
+
+        # Mass: 126g
+        self.assertEqual(cam.mass.to("gram").magnitude, 126)
+
+        # Optical length / backfocus: 12.5mm
+        self.assertEqual(cam.optical_length.to("mm").magnitude, 12.5)
+        self.assertEqual(cam.backfocus, Quantity(12.5, "millimeter"))
+
+        # Connection thread: CS
+        self.assertEqual(cam.connection_type, ConnectionType.CS)
+
+        # Resolution: 3864 x 2192 (8.5MP)
+        self.assertEqual(cam.width, 3864)
+        self.assertEqual(cam.height, 2192)
+
+        # Sensor dimensions & pixel size: 1.45µm, 5.6mm x 3.18mm
+        self.assertEqual(cam.pixel_size().to("micrometer").magnitude, 1.45)
+        self.assertEqual(cam.sensor_width.to("mm").magnitude, 5.6)
+        self.assertEqual(cam.sensor_height.to("mm").magnitude, 3.18)
+
+        # Full well capacity: 6030 e-
+        self.assertEqual(cam.full_well, 6030)
+
+        # Read noise: 0.72 e-
+        self.assertEqual(cam.read_noise, 0.72)
+
+        # Peak Quantum Efficiency: 80%
+        self.assertEqual(cam.quantum_efficiency, 80)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🔍 Optic: Data audit for ZWO ASI715MC

💡 Fix: Corrected optical length / backfocus from 6.5mm to 12.5mm and thread from M42 to CS.
🎯 Source: Official ZWO ASI715MC product specifications (https://www.zwoastro.com/product/asi715mc/).

---
*PR created automatically by Jules for task [3633201601450015607](https://jules.google.com/task/3633201601450015607) started by @pozar87*