### PR TITLE
🔍 Optic: Data audit for Celestron NexStar 130SLT

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -711,16 +711,16 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 130SLT",
             "type": "newtonian_reflector",
             "optical_length": 0,
-            "mass": 3990,
+            "mass": 3990, # Verified via Celestron.com (8.8 lbs / 3.99 kg OTA weight) - https://www.celestron.com/products/nexstar-130slt-computerized-telescope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "2\"",
             "cside_gender": "Female",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 130,
-            "focal_length_mm": 650,
-            "central_obstruction_mm": 38,
+            "aperture_mm": 130, # Verified via Celestron.com (130mm / 5.12") - https://www.celestron.com/products/nexstar-130slt-computerized-telescope
+            "focal_length_mm": 650, # Verified via Celestron.com (650mm / f/5) - https://www.celestron.com/products/nexstar-130slt-computerized-telescope
+            "central_obstruction_mm": 38, # Verified via Celestron.com (38mm / 1.5" secondary mirror obstruction) - https://www.celestron.com/products/nexstar-130slt-computerized-telescope
         },
         "Celestron_NexStar_4SE": {
             "brand": "Celestron",

--- a/tests/unit/test_celestron_nexstar_130slt_audit.py
+++ b/tests/unit/test_celestron_nexstar_130slt_audit.py
@@ -1,0 +1,21 @@
+import unittest
+
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+
+class TestCelestronNexStar130SLTAudit(unittest.TestCase):
+    def test_nexstar_130slt_specs(self):
+        """
+        NexStar 130SLT Newtonian Reflector specifications audit test.
+        Source: https://www.celestron.com/products/nexstar-130slt-computerized-telescope
+        """
+        scope = CelestronTelescope.Celestron_NexStar_130SLT()
+        self.assertEqual(scope.aperture.to('mm').magnitude, 130.0)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 650.0)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 5.0, places=2)
+        self.assertEqual(scope.mass.to('gram').magnitude, 3990)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 38.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🔍 Optic: Data audit for Celestron NexStar 130SLT

- Audited and verified specifications for Celestron NexStar 130SLT in `apts/opticalequipment/telescope/vendors/celestron.py` (130mm aperture, 650mm focal length, 38mm secondary mirror obstruction, 3990g OTA weight, 2" female cside thread).
- Added official Celestron website reference URL comments.
- Added unit test suite in `tests/unit/test_celestron_nexstar_130slt_audit.py`.

---
*PR created automatically by Jules for task [11737050784077685368](https://jules.google.com/task/11737050784077685368) started by @pozar87*