### PR TITLE
add support for Askar 50P telescope

### DIFF
--- a/apts/opticalequipment/telescope/vendors/askar.py
+++ b/apts/opticalequipment/telescope/vendors/askar.py
@@ -403,6 +403,23 @@ class AskarTelescope(Telescope):
             "focal_length_mm": 784,
             "central_obstruction_mm": 0,
         },
+        "Askar_50P": {
+            "brand": "Askar",
+            "name": "50P",
+            "type": "type_refractor",
+            "optical_length": 0,
+            "mass": 1400,
+            "tside_thread": "",
+            "tside_gender": "",
+            "cside_thread": "M48",
+            "cside_gender": "Male",
+            "reversible": False,
+            "bf_role": "",
+            "aperture_mm": 50,
+            "focal_length_mm": 190,
+            "central_obstruction_mm": 0,
+            # Source: https://www.sharpstar-optics.com/Products_1/50P.html
+        },
     }
 
     @classmethod
@@ -504,3 +521,7 @@ class AskarTelescope(Telescope):
     @classmethod
     def Askar_140APO_Reduced(cls):
         return cls.from_database(cls._DATABASE['Askar_140APO_Reduced'])
+
+    @classmethod
+    def Askar_50P(cls):
+        return cls.from_database(cls._DATABASE['Askar_50P'])

--- a/scripts/verify_askar_static.py
+++ b/scripts/verify_askar_static.py
@@ -60,6 +60,13 @@ class TestAskarSpecsStatic(unittest.TestCase):
         self.assertEqual(specs['focal_length_mm'], 1421)
         self.assertEqual(specs['mass'], 14900)
 
+    def test_50p(self):
+        specs = self.db['Askar_50P']
+        self.assertEqual(specs['aperture_mm'], 50)
+        self.assertEqual(specs['focal_length_mm'], 190)
+        self.assertEqual(specs['mass'], 1400)
+        self.assertEqual(specs['cside_thread'], 'M48')
+
     def test_all_have_co(self):
         for key, specs in self.db.items():
             self.assertIn('central_obstruction_mm', specs, f"{key} is missing central_obstruction_mm")

--- a/tests/unit/test_askar_audit.py
+++ b/tests/unit/test_askar_audit.py
@@ -12,5 +12,15 @@ class TestAskarAudit(unittest.TestCase):
         self.assertEqual(scope.connection_type, ConnectionType.M48)
         self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
 
+    def test_50p_specs(self):
+        # Official specs: 50mm aperture, 190mm focal length, 1400g mass, M48 camera thread
+        scope = AskarTelescope.Askar_50P()
+        self.assertEqual(scope.aperture.to('mm').magnitude, 50)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 190)
+        self.assertEqual(scope.mass.to('gram').magnitude, 1400)
+        self.assertEqual(scope.connection_type, ConnectionType.M48)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.get_vendor(), "Askar 50P")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added the Askar 50P quadruplet Petzval astrograph refractor telescope to `apts/opticalequipment/telescope/vendors/askar.py` using official manufacturer specifications (50mm aperture, 190mm focal length, f/3.8, 1400g mass, M48 camera thread connection). Added tests in `tests/unit/test_askar_audit.py` and static assertions in `scripts/verify_askar_static.py`.

---
*PR created automatically by Jules for task [16592840294148789522](https://jules.google.com/task/16592840294148789522) started by @pozar87*