### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Esprit 100ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -232,10 +232,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Female", # Verified via Sky-Watcher USA (focuser drawtube has female threads)
-            "cside_thread": "M74", # Verified via Sky-Watcher USA (Drawtube thread size is M74x1) - https://www.skywatcherusa.com/products/esprit-100edx
-            "focal_length_mm": 550,
-            "mass": 6300, # Verified via Sky-Watcher Global (6.3 kg tube weight) - http://skywatcher.com/product/esprit-100-ed-apo-triplet/
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA (focuser drawtube has female threads) - https://www.skywatcherusa.com/products/esprit-100edx
+            "cside_thread": "M74",  # Verified via Sky-Watcher USA (Drawtube thread size is M74x1) - https://www.skywatcherusa.com/products/esprit-100edx
+            "focal_length_mm": 550,  # Verified via Sky-Watcher Global (100mm aperture, 550mm focal length, f/5.5) - http://skywatcher.com/product/esprit-100-ed-apo-triplet/
+            "mass": 6300,  # Verified via Sky-Watcher Global (6.3 kg tube weight) - http://skywatcher.com/product/esprit-100-ed-apo-triplet/
             "name": "Esprit 100ED",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_esprit_100ed_audit.py
+++ b/tests/unit/test_sky_watcher_esprit_100ed_audit.py
@@ -1,0 +1,20 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils import ConnectionType, Gender
+
+
+class TestSkyWatcherEsprit100EDAudit(unittest.TestCase):
+    def test_esprit_100ed_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Esprit_100ED()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Esprit 100ED")
+        self.assertEqual(scope.aperture.to("mm").magnitude, 100)
+        self.assertEqual(scope.focal_length.to("mm").magnitude, 550)
+        self.assertAlmostEqual(scope.focal_ratio(), 5.5, places=2)
+        self.assertEqual(scope.central_obstruction.to("mm").magnitude, 0)
+        self.assertEqual(scope.mass.to("gram").magnitude, 6300)
+        self.assertEqual(scope.connection_type, ConnectionType.M74)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited, verified, and added documentation for Sky-Watcher Esprit 100ED specs in apts/opticalequipment/telescope/vendors/sky_watcher.py, along with a dedicated unit test suite.

---
*PR created automatically by Jules for task [12078262019262111943](https://jules.google.com/task/12078262019262111943) started by @pozar87*