### PR TITLE
Separate public and raw catalog accessors

### DIFF
--- a/apts/catalogs/messier.py
+++ b/apts/catalogs/messier.py
@@ -107,6 +107,26 @@ def _load_messier_with_units():
 
 
 def get_messier() -> pd.DataFrame:
+    """
+    Returns the Messier catalog without internal technical columns.
+
+    Derived/calculation-only columns (ra_hours, sin_dec, skyfield_object, ...)
+    are stripped before the catalog is handed to callers. Code that needs them
+    (visibility gating, skymap resolution, conjunctions) must use
+    get_messier_raw().
+    """
+    from ..objects.utils import filter_technical_columns
+
+    return filter_technical_columns(get_messier_raw())
+
+
+def get_messier_raw() -> pd.DataFrame:
+    """
+    Returns the raw Messier catalog including internal technical columns.
+
+    Intended for internal calculations that rely on the precomputed
+    ra_hours/dec_degrees/sin_dec/skyfield_object columns for performance.
+    """
     global _messier_df
     if _messier_df is None:
         logger.info("Loading Messier catalog...")

--- a/apts/catalogs/ngc.py
+++ b/apts/catalogs/ngc.py
@@ -181,6 +181,25 @@ def _load_ngc_with_units():
 
 
 def get_ngc() -> pd.DataFrame:
+    """
+    Returns the NGC catalog without internal technical columns.
+
+    Derived/calculation-only columns (ra_hours, sin_dec, *_norm, ...) are
+    stripped before the catalog is handed to callers. Code that needs them
+    (visibility gating, skymap resolution, discovery) must use get_ngc_raw().
+    """
+    from ..objects.utils import filter_technical_columns
+
+    return filter_technical_columns(get_ngc_raw())
+
+
+def get_ngc_raw() -> pd.DataFrame:
+    """
+    Returns the raw NGC catalog including internal technical columns.
+
+    Intended for internal calculations that rely on the precomputed
+    ra_hours/dec_degrees/sin_dec/*_norm columns for performance.
+    """
     global _ngc_df
     if _ngc_df is None:
         logger.info("Loading NGC catalog...")

--- a/apts/catalogs/stars.py
+++ b/apts/catalogs/stars.py
@@ -60,6 +60,26 @@ def _load_bright_stars_with_units():
 
 
 def get_bright_stars() -> pd.DataFrame:
+    """
+    Returns the Bright Stars catalog without internal technical columns.
+
+    Derived/calculation-only columns (ra_hours, sin_dec, skyfield_object, ...)
+    are stripped before the catalog is handed to callers. Code that needs them
+    (visibility gating, skymap resolution, conjunctions) must use
+    get_bright_stars_raw().
+    """
+    from ..objects.utils import filter_technical_columns
+
+    return filter_technical_columns(get_bright_stars_raw())
+
+
+def get_bright_stars_raw() -> pd.DataFrame:
+    """
+    Returns the raw Bright Stars catalog including internal technical columns.
+
+    Intended for internal calculations that rely on the precomputed
+    ra_hours/dec_degrees/sin_dec/skyfield_object columns for performance.
+    """
     global _bright_stars_df
     if _bright_stars_df is None:
         logger.info("Loading Bright Stars catalog...")

--- a/apts/events/calculations/planetary/utils.py
+++ b/apts/events/calculations/planetary/utils.py
@@ -3,6 +3,8 @@ from typing import cast
 import pandas as pd
 
 from ....catalogs import Catalogs
+from ....catalogs.messier import get_messier_raw
+from ....catalogs.stars import get_bright_stars_raw
 from ....utils import planetary
 
 
@@ -30,6 +32,16 @@ class BodyResolver:
             self._catalogs = Catalogs()
         return self._catalogs
 
+    @property
+    def bright_stars_raw(self):
+        """Raw Bright Stars frame (the public Catalogs view strips technical columns)."""
+        return get_bright_stars_raw()
+
+    @property
+    def messier_raw(self):
+        """Raw Messier frame (the public Catalogs view strips technical columns)."""
+        return get_messier_raw()
+
     def resolve(self, name, body_type="planet"):
         """
         Resolves a body by name and type.
@@ -48,9 +60,7 @@ class BodyResolver:
             # Handle multiple names or single name
             names = [name] if isinstance(name, str) else name
             for n in names:
-                row = self.catalogs.BRIGHT_STARS[
-                    self.catalogs.BRIGHT_STARS["Name"] == n
-                ]
+                row = self.bright_stars_raw[self.bright_stars_raw["Name"] == n]
                 if not row.empty:
                     # Optimization: Reuse the pre-calculated skyfield_object column
                     # instead of re-instantiating the Star class.
@@ -60,7 +70,7 @@ class BodyResolver:
                     return result
 
         if body_type == "messier":
-            row = self.catalogs.MESSIER[self.catalogs.MESSIER["Messier"] == name]
+            row = self.messier_raw[self.messier_raw["Messier"] == name]
             if not row.empty:
                 # Optimization: Reuse the pre-calculated skyfield_object column
                 # instead of re-instantiating the Star class.

--- a/apts/events/coordinator/base.py
+++ b/apts/events/coordinator/base.py
@@ -9,6 +9,8 @@ from skyfield.api import Topos
 
 from ...cache import get_ephemeris, get_timescale
 from ...catalogs import Catalogs
+from ...catalogs.messier import get_messier_raw
+from ...catalogs.stars import get_bright_stars_raw
 from ...constants.event_types import EventType
 from ..rarity import get_rarity
 from ..duration import get_duration
@@ -124,7 +126,7 @@ class AstronomicalEvents:
         return planetary_calc.calculate_highest_altitudes(self.observer, self.start_date, self.end_date, self.executor)
 
     def calculate_lunar_occultations(self):
-        return lunar.calculate_lunar_occultations(self.observer, self.start_date, self.end_date, self.catalogs.BRIGHT_STARS)
+        return lunar.calculate_lunar_occultations(self.observer, self.start_date, self.end_date, get_bright_stars_raw())
 
     def calculate_lunar_planetary_occultations(self):
         return lunar.calculate_lunar_planetary_occultations(self.observer, self.start_date, self.end_date)
@@ -139,10 +141,10 @@ class AstronomicalEvents:
         return planetary_calc.calculate_mercury_inferior_conjunctions(self.observer, self.start_date, self.end_date)
 
     def calculate_moon_messier_conjunctions(self, precomputed_positions=None):
-        return lunar.calculate_moon_messier_conjunctions(self.observer, self.start_date, self.end_date, self.catalogs.MESSIER, precomputed_positions)
+        return lunar.calculate_moon_messier_conjunctions(self.observer, self.start_date, self.end_date, get_messier_raw(), precomputed_positions)
 
     def calculate_moon_star_conjunctions(self, precomputed_positions=None):
-        return lunar.calculate_moon_star_conjunctions(self.ts, self.observer, self.start_date, self.end_date, self.catalogs.BRIGHT_STARS, precomputed_positions)
+        return lunar.calculate_moon_star_conjunctions(self.ts, self.observer, self.start_date, self.end_date, get_bright_stars_raw(), precomputed_positions)
 
     def calculate_nasa_comets(self):
         return sky.calculate_nasa_comets(self.start_date, self.end_date)
@@ -157,7 +159,7 @@ class AstronomicalEvents:
         return sky.calculate_culminations(self.observer, self.start_date, self.end_date)
 
     def calculate_messier_culminations(self):
-        return sky.calculate_messier_culminations(self.observer, self.start_date, self.end_date, self.catalogs.MESSIER)
+        return sky.calculate_messier_culminations(self.observer, self.start_date, self.end_date, get_messier_raw())
 
     def calculate_jovian_moon_events(self):
         return planetary_calc.calculate_jovian_moon_events(self.observer, self.start_date, self.end_date)

--- a/apts/objects/messier.py
+++ b/apts/objects/messier.py
@@ -1,6 +1,7 @@
 import functools
 from .base import Objects
 from ..catalogs import Catalogs
+from ..catalogs.messier import get_messier_raw
 from ..constants import ObjectTableLabels
 
 
@@ -9,7 +10,8 @@ class Messier(Objects):
 
     def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(Messier, self).__init__(place, calculation_date=calculation_date)
-        self.objects = catalogs.MESSIER.copy()  # type: ignore
+        # Use the raw catalog: Catalogs.MESSIER strips technical columns.
+        self.objects = get_messier_raw().copy()  # type: ignore
         self.objects[ObjectTableLabels.TRANSIT] = None
         self.objects[ObjectTableLabels.RISING] = None
         self.objects[ObjectTableLabels.SETTING] = None

--- a/apts/objects/ngc.py
+++ b/apts/objects/ngc.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from ..catalogs import Catalogs
+from ..catalogs.ngc import get_ngc_raw
 from ..catalogs.ngc import normalize_name as internal_normalize_name
 from ..constants import ObjectTableLabels
 from .base import Objects
@@ -15,7 +16,9 @@ class NGC(Objects):
 
     def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(NGC, self).__init__(place, calculation_date=calculation_date)
-        self.objects = catalogs.NGC.copy()  # type: ignore
+        # Use the raw catalog: Catalogs.NGC exposes the cleaned view without
+        # the technical columns (ra_hours, *_norm, sin_dec, ...) needed here.
+        self.objects = get_ngc_raw().copy()  # type: ignore
         self.objects[ObjectTableLabels.TRANSIT] = None
         self.objects[ObjectTableLabels.RISING] = None
         self.objects[ObjectTableLabels.SETTING] = None

--- a/apts/objects/stars.py
+++ b/apts/objects/stars.py
@@ -1,5 +1,6 @@
 from .base import Objects
 from ..catalogs import Catalogs
+from ..catalogs.stars import get_bright_stars_raw
 from ..constants import ObjectTableLabels
 
 
@@ -8,7 +9,8 @@ class Stars(Objects):
 
     def __init__(self, place, catalogs: Catalogs, calculation_date=None):
         super(Stars, self).__init__(place, calculation_date=calculation_date)
-        self.objects = catalogs.BRIGHT_STARS.copy()  # type: ignore
+        # Use the raw catalog: Catalogs.BRIGHT_STARS strips technical columns.
+        self.objects = get_bright_stars_raw().copy()  # type: ignore
         self.objects[ObjectTableLabels.TRANSIT] = None
         self.objects[ObjectTableLabels.ALTITUDE] = None
         self.calculation_date = (

--- a/apts/skyfield_searches/conjunctions/objects.py
+++ b/apts/skyfield_searches/conjunctions/objects.py
@@ -2,6 +2,8 @@ import numpy as np
 from skyfield.api import Star
 
 from ...cache import get_timescale
+from ...catalogs.messier import get_messier_raw
+from ...catalogs.stars import get_bright_stars_raw
 from ...utils import planetary
 from .stars import find_conjunctions_with_stars
 
@@ -17,9 +19,6 @@ def find_planet_star_conjunctions(
     Finds conjunctions between major planets and bright stars.
     Vectorized over stars for each planet for high performance.
     """
-    from ...catalogs import Catalogs
-
-    catalogs = Catalogs()
     planets = [
         "mercury",
         "venus",
@@ -36,9 +35,11 @@ def find_planet_star_conjunctions(
     t_ref = ts.utc(start_date)
 
     # Optimized filtering: avoid iterative ra/dec extraction
-    v_ra_hours = catalogs.BRIGHT_STARS["ra_hours"].to_numpy()
-    v_dec_degrees = catalogs.BRIGHT_STARS["dec_degrees"].to_numpy()
-    star_names_all = catalogs.BRIGHT_STARS["Name"].to_numpy()
+    # Use the raw catalog (Catalogs.BRIGHT_STARS strips the technical columns)
+    bright_stars = get_bright_stars_raw()
+    v_ra_hours = bright_stars["ra_hours"].to_numpy()
+    v_dec_degrees = bright_stars["dec_degrees"].to_numpy()
+    star_names_all = bright_stars["Name"].to_numpy()
 
     stars_vector_all = Star(ra_hours=v_ra_hours, dec_degrees=v_dec_degrees)
     spos_at_t_ref = observer.at(t_ref).observe(stars_vector_all)
@@ -85,9 +86,6 @@ def find_planet_messier_conjunctions(
     observer, start_date, end_date, precomputed_positions=None
 ):
     """Finds conjunctions between major planets and Messier objects."""
-    from ...catalogs import Catalogs
-
-    catalogs = Catalogs()
     planets = [
         "mercury",
         "venus",
@@ -104,9 +102,11 @@ def find_planet_messier_conjunctions(
     ts = get_timescale()
     t_ref = ts.utc(start_date)
 
-    v_ra_hours = catalogs.MESSIER["ra_hours"].to_numpy()
-    v_dec_degrees = catalogs.MESSIER["dec_degrees"].to_numpy()
-    messier_names_all = catalogs.MESSIER["Messier"].to_numpy()
+    # Use the raw catalog (Catalogs.MESSIER strips the technical columns)
+    messier = get_messier_raw()
+    v_ra_hours = messier["ra_hours"].to_numpy()
+    v_dec_degrees = messier["dec_degrees"].to_numpy()
+    messier_names_all = messier["Messier"].to_numpy()
 
     messier_vector_all = Star(ra_hours=v_ra_hours, dec_degrees=v_dec_degrees)
     spos_at_t_ref = observer.at(t_ref).observe(messier_vector_all)

--- a/tests/unit/test_catalogs.py
+++ b/tests/unit/test_catalogs.py
@@ -2,6 +2,7 @@ import pandas as pd
 from typing import cast
 from apts.catalogs import Catalogs
 from apts.constants import ObjectTableLabels
+from apts.constants.objecttablelabels import TECHNICAL_COLUMNS
 
 
 def test_messier_catalog():
@@ -84,3 +85,36 @@ def test_ngc_catalog():
     assert ic1["SIMBAD"] == "https://simbad.u-strasbg.fr/simbad/sim-basic?Ident=IC0001"
     assert ic1["ALADIN"] == "https://aladin.cds.unistra.fr/AladinLite/?target=IC0001"
     assert ic1["Astrobin"] == "https://www.astrobin.com/search/?q=IC0001"
+
+
+def test_catalogs_do_not_expose_technical_columns():
+    c = Catalogs()
+    for catalog in [c.NGC, c.MESSIER, c.BRIGHT_STARS]:
+        for col in TECHNICAL_COLUMNS:
+            assert col not in catalog.columns
+
+
+def test_raw_catalogs_keep_technical_columns():
+    from apts.catalogs.ngc import get_ngc, get_ngc_raw
+    from apts.catalogs.messier import get_messier, get_messier_raw
+    from apts.catalogs.stars import get_bright_stars, get_bright_stars_raw
+
+    for clean, raw in [
+        (get_ngc(), get_ngc_raw()),
+        (get_messier(), get_messier_raw()),
+        (get_bright_stars(), get_bright_stars_raw()),
+    ]:
+        for col in TECHNICAL_COLUMNS:
+            assert col not in clean.columns
+        for col in ("ra_hours", "dec_degrees", "Magnitude_float",
+                    "sin_dec", "cos_dec_cos_ra", "cos_dec_sin_ra"):
+            assert col in raw.columns
+
+    # NGC additionally pre-computes normalized identifiers; Messier/Stars
+    # additionally pre-compute Skyfield objects.
+    assert all(
+        col in get_ngc_raw().columns for col in ("NGC_norm", "IC_norm", "Name_norm")
+    )
+    assert "skyfield_object" in get_messier_raw().columns
+    assert "skyfield_object" in get_bright_stars_raw().columns
+

--- a/tests/unit/test_searches.py
+++ b/tests/unit/test_searches.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime
 from skyfield.api import load, Topos, utc
 from apts import searches
-from apts.catalogs import Catalogs
+from apts.catalogs.stars import get_bright_stars_raw
 
 
 class SearchesTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class SearchesTest(unittest.TestCase):
         # on a very short time scale and a single bright star.
         short_start = datetime(2023, 1, 1, tzinfo=utc)
         short_end = datetime(2023, 1, 2, tzinfo=utc)
-        sirius = Catalogs().BRIGHT_STARS[Catalogs().BRIGHT_STARS["Name"] == "Sirius"]
+        sirius = get_bright_stars_raw()[get_bright_stars_raw()["Name"] == "Sirius"]
         events = searches.find_lunar_occultations(
             self.observer, self.eph, sirius, short_start, short_end
         )

--- a/tests/unit/test_skyfield_searches.py
+++ b/tests/unit/test_skyfield_searches.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from skyfield.api import load, Topos, utc
 from apts import skyfield_searches
 from apts.catalogs import Catalogs
+from apts.catalogs.stars import get_bright_stars_raw
 from apts.cache import get_ephemeris
 from apts.utils import planetary
 from skyfield.api import Star
@@ -40,7 +41,7 @@ class SkyfieldSearchesTest(unittest.TestCase):
     def test_find_lunar_occultations(self):
         short_start = datetime(2023, 1, 1, tzinfo=utc)
         short_end = datetime(2023, 1, 2, tzinfo=utc)
-        sirius = Catalogs().BRIGHT_STARS[Catalogs().BRIGHT_STARS["Name"] == "Sirius"]
+        sirius = get_bright_stars_raw()[get_bright_stars_raw()["Name"] == "Sirius"]
         events = skyfield_searches.find_lunar_occultations(
             self.observer, sirius, short_start, short_end
         )


### PR DESCRIPTION
The public Catalogs class now strips technical columns (ra_hours, sin_dec,
skyfield_object, etc.) to present a cleaner API. Internal code that requires
these precomputed columns for performance now uses the new *_raw() accessors
instead of accessing Catalogs directly.