### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Evostar 120ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -328,10 +328,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA / Astronomics (2" dual-speed Crayford focuser visual back) - https://www.skywatcherusa.com/products/evostar-120edx
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Includes 2" Crayford focuser with 2" visual back) - https://www.skywatcherusa.com/products/evostar-120edx
             "focal_length_mm": 900,
-            "mass": 5130,
+            "mass": 5130,  # Verified via Sky-Watcher USA / Astronomics (11.3 lbs / 5.13 kg OTA weight) - https://astronomics.com/products/sky-watcher-evostar-120mm-f-7-5-ed-doublet-apochromatic-refractor
             "name": "Evostar 120ED",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_evostar_120ed_audit.py
+++ b/tests/unit/test_sky_watcher_evostar_120ed_audit.py
@@ -1,0 +1,20 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils import ConnectionType, Gender
+
+
+class TestSkyWatcherEvostar120EDAudit(unittest.TestCase):
+    def test_evostar_120ed_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_120ED()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 120ED")
+        self.assertEqual(scope.aperture.to("mm").magnitude, 120)
+        self.assertEqual(scope.focal_length.to("mm").magnitude, 900)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 7.5, places=2)
+        self.assertEqual(scope.central_obstruction.to("mm").magnitude, 0)
+        self.assertEqual(scope.mass.to("gram").magnitude, 5130)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited and updated the Sky-Watcher Evostar 120ED telescope specification entry in apts/opticalequipment/telescope/vendors/sky_watcher.py by setting cside_thread to "2"" and cside_gender to "Female" (reflecting the 2" Crayford focuser visual back) and adding source reference documentation comments. Added a dedicated unit test in tests/unit/test_sky_watcher_evostar_120ed_audit.py.

---
*PR created automatically by Jules for task [3080280399500573800](https://jules.google.com/task/3080280399500573800) started by @pozar87*