### PR TITLE
🔍 Optic: Data audit for Celestron NexStar 6SE

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -759,7 +759,7 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 6SE",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 3629, # Verified via Celestron.com (8 lbs OTA weight - https://www.celestron.com/products/nexstar-6se-computerized-telescope)
+            "mass": 3629,  # Verified via Celestron.com (8 lbs / 3.6 kg OTA weight, 150mm aperture, 1500mm focal length, f/10, 56mm central obstruction - https://www.celestron.com/products/nexstar-6se-computerized-telescope)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",

--- a/tests/unit/test_celestron_nexstar_6se_audit.py
+++ b/tests/unit/test_celestron_nexstar_6se_audit.py
@@ -1,0 +1,21 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+from apts.utils import ConnectionType, Gender
+
+
+class TestCelestronNexStar6SEAudit(unittest.TestCase):
+    def test_nexstar_6se_audited_specs(self):
+        """Verify the audited hardware specifications for Celestron NexStar 6SE."""
+        scope = CelestronTelescope.Celestron_NexStar_6SE()
+        self.assertEqual(scope.get_vendor(), "Celestron NexStar 6SE")
+        self.assertEqual(scope.aperture.to("mm").magnitude, 150)
+        self.assertEqual(scope.focal_length.to("mm").magnitude, 1500)
+        self.assertAlmostEqual(scope.focal_ratio(), 10.0, places=2)
+        self.assertEqual(scope.central_obstruction.to("mm").magnitude, 56)
+        self.assertEqual(scope.mass.to("gram").magnitude, 3629)
+        self.assertEqual(scope.connection_type, ConnectionType.SC)
+        self.assertEqual(scope.connection_gender, Gender.MALE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited, verified, and added dedicated unit tests for the Celestron NexStar 6SE telescope specifications in apts/opticalequipment/telescope/vendors/celestron.py against official Celestron documentation.

---
*PR created automatically by Jules for task [14590613241923111279](https://jules.google.com/task/14590613241923111279) started by @pozar87*