### PR TITLE
🏗️ Architect: Extracted telescope optical calculations into calculations module

### DIFF
--- a/apts/opticalequipment/telescope/base.py
+++ b/apts/opticalequipment/telescope/base.py
@@ -154,21 +154,30 @@ class Telescope(OpticalEquipment):
         return self._outputs[0][1] if self._outputs else None
 
     def focal_ratio(self):
-        return self.focal_length / self.aperture
+        focal_length_mm = self.focal_length.to("mm").magnitude
+        aperture_mm = self.aperture.to("mm").magnitude
+        ratio = telescope_calc.calculate_focal_ratio(focal_length_mm, aperture_mm)
+        return ratio * get_unit_registry().dimensionless
 
     def aperture_area(self):
         """
         Calculate the light gathering area of the telescope, accounting for central obstruction.
         :return: area in mm^2
         """
-        return numpy.pi * (self.aperture**2 - self.central_obstruction**2) / 4.0
+        aperture_mm = self.aperture.to("mm").magnitude
+        central_obstruction_mm = self.central_obstruction.to("mm").magnitude
+        area_mm2 = telescope_calc.calculate_aperture_area(aperture_mm, central_obstruction_mm)
+        return area_mm2 * (get_unit_registry().mm ** 2)
 
     def effective_aperture(self):
         """
         Return the diameter of a clear aperture that would have the same light-gathering area.
         :return: effective aperture in mm
         """
-        return numpy.sqrt(self.aperture**2 - self.central_obstruction**2)
+        aperture_mm = self.aperture.to("mm").magnitude
+        central_obstruction_mm = self.central_obstruction.to("mm").magnitude
+        eff_mm = telescope_calc.calculate_effective_aperture(aperture_mm, central_obstruction_mm)
+        return eff_mm * get_unit_registry().mm
 
     def dawes_limit(self):
         """
@@ -208,8 +217,16 @@ class Telescope(OpticalEquipment):
         :param other_aperture: aperture in mm
         :return: ratio between telescope and other aperture
         """
-        other_aperture *= get_unit_registry().mm
-        return self.effective_aperture() ** 2 / other_aperture**2
+        aperture_mm = self.aperture.to("mm").magnitude
+        central_obstruction_mm = self.central_obstruction.to("mm").magnitude
+        if hasattr(other_aperture, "to"):
+            other_aperture_mm = other_aperture.to("mm").magnitude
+        else:
+            other_aperture_mm = float(other_aperture)
+        ratio = telescope_calc.calculate_light_grasp_ratio(
+            aperture_mm, other_aperture_mm, central_obstruction_mm
+        )
+        return ratio * get_unit_registry().dimensionless
 
     def highest_useful_magnification(self) -> float:
         """

--- a/apts/optics/calculations/__init__.py
+++ b/apts/optics/calculations/__init__.py
@@ -57,6 +57,17 @@ from .mechanical import (
     calculate_image_orientation,
     calculate_thermal_drift,
 )
+from .telescope import (
+    calculate_focal_ratio,
+    calculate_aperture_area,
+    calculate_effective_aperture,
+    calculate_light_grasp_ratio,
+    calculate_dawes_limit,
+    calculate_rayleigh_limit,
+    calculate_limiting_magnitude,
+    calculate_highest_useful_magnification,
+    calculate_lowest_useful_magnification,
+)
 
 __all__ = [
     "calculate_airmass",
@@ -100,4 +111,13 @@ __all__ = [
     "calculate_backfocus_gap",
     "calculate_image_orientation",
     "calculate_thermal_drift",
+    "calculate_focal_ratio",
+    "calculate_aperture_area",
+    "calculate_effective_aperture",
+    "calculate_light_grasp_ratio",
+    "calculate_dawes_limit",
+    "calculate_rayleigh_limit",
+    "calculate_limiting_magnitude",
+    "calculate_highest_useful_magnification",
+    "calculate_lowest_useful_magnification",
 ]

--- a/apts/optics/calculations/telescope.py
+++ b/apts/optics/calculations/telescope.py
@@ -48,6 +48,57 @@ def calculate_limiting_magnitude(aperture_mm: float, central_obstruction_mm: flo
     # Formula: 7.7 + 5 * log10(aperture_cm)
     return 7.7 + 5 * np.log10(effective_aperture_mm / 10.0)
 
+def calculate_focal_ratio(focal_length_mm: float, aperture_mm: float) -> float:
+    """
+    Calculate the focal ratio (f-number) of a telescope.
+    focal_ratio = focal_length / aperture
+
+    :param focal_length_mm: focal length in mm
+    :param aperture_mm: aperture in mm
+    :return: focal ratio (dimensionless)
+    """
+    if aperture_mm <= 0:
+        return 0.0
+    return float(focal_length_mm / aperture_mm)
+
+def calculate_aperture_area(aperture_mm: float, central_obstruction_mm: float = 0.0) -> float:
+    """
+    Calculate the light gathering area of the telescope in mm^2, accounting for central obstruction.
+
+    :param aperture_mm: aperture in mm
+    :param central_obstruction_mm: central obstruction in mm
+    :return: area in mm^2
+    """
+    eff_sq = max(0.0, aperture_mm**2 - central_obstruction_mm**2)
+    return float(np.pi * eff_sq / 4.0)
+
+def calculate_effective_aperture(aperture_mm: float, central_obstruction_mm: float = 0.0) -> float:
+    """
+    Return the diameter of a clear aperture in mm that would have the same light-gathering area.
+
+    :param aperture_mm: aperture in mm
+    :param central_obstruction_mm: central obstruction in mm
+    :return: effective aperture in mm
+    """
+    eff_sq = max(0.0, aperture_mm**2 - central_obstruction_mm**2)
+    return float(np.sqrt(eff_sq))
+
+def calculate_light_grasp_ratio(
+    aperture_mm: float, other_aperture_mm: float, central_obstruction_mm: float = 0.0
+) -> float:
+    """
+    Calculate the light grasp ratio between two telescopes using effective aperture area.
+
+    :param aperture_mm: aperture of primary telescope in mm
+    :param other_aperture_mm: aperture of comparison telescope in mm
+    :param central_obstruction_mm: central obstruction of primary telescope in mm
+    :return: light grasp ratio
+    """
+    if other_aperture_mm <= 0:
+        return 0.0
+    eff_ap = calculate_effective_aperture(aperture_mm, central_obstruction_mm)
+    return float((eff_ap / other_aperture_mm) ** 2)
+
 def calculate_highest_useful_magnification(aperture_mm: float) -> float:
     """
     Calculate the theoretical highest useful magnification for the telescope.

--- a/tests/unit/test_optics_calculations_telescope.py
+++ b/tests/unit/test_optics_calculations_telescope.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from apts.optics.calculations.telescope import (
+    calculate_focal_ratio,
+    calculate_aperture_area,
+    calculate_effective_aperture,
+    calculate_light_grasp_ratio,
+    calculate_dawes_limit,
+    calculate_rayleigh_limit,
+    calculate_limiting_magnitude,
+    calculate_highest_useful_magnification,
+    calculate_lowest_useful_magnification,
+)
+from apts.opticalequipment.telescope import Telescope
+
+
+def test_calculate_focal_ratio():
+    assert calculate_focal_ratio(1000.0, 200.0) == pytest.approx(5.0)
+    assert calculate_focal_ratio(500.0, 80.0) == pytest.approx(6.25)
+    assert calculate_focal_ratio(1000.0, 0.0) == 0.0
+
+
+def test_calculate_aperture_area():
+    # 200mm aperture without obstruction: pi * 100^2 = 31415.9265
+    area_clear = calculate_aperture_area(200.0, 0.0)
+    assert area_clear == pytest.approx(np.pi * 10000.0)
+
+    # 200mm aperture with 50mm obstruction
+    area_obs = calculate_aperture_area(200.0, 50.0)
+    assert area_obs == pytest.approx(np.pi * (40000.0 - 2500.0) / 4.0)
+
+
+def test_calculate_effective_aperture():
+    eff_clear = calculate_effective_aperture(200.0, 0.0)
+    assert eff_clear == pytest.approx(200.0)
+
+    eff_obs = calculate_effective_aperture(200.0, 50.0)
+    assert eff_obs == pytest.approx(np.sqrt(40000.0 - 2500.0))
+
+
+def test_calculate_light_grasp_ratio():
+    # Comparing 200mm to 100mm -> ratio = (200/100)^2 = 4.0
+    ratio = calculate_light_grasp_ratio(200.0, 100.0)
+    assert ratio == pytest.approx(4.0)
+
+    assert calculate_light_grasp_ratio(200.0, 0.0) == 0.0
+
+
+def test_telescope_class_delegations():
+    scope = Telescope(200.0, 1000.0, central_obstruction=50.0)
+
+    # Test focal_ratio
+    assert float(scope.focal_ratio().magnitude) == pytest.approx(5.0)
+
+    # Test aperture_area
+    expected_area = np.pi * (200.0**2 - 50.0**2) / 4.0
+    assert float(scope.aperture_area().magnitude) == pytest.approx(expected_area)
+
+    # Test effective_aperture
+    expected_eff = np.sqrt(200.0**2 - 50.0**2)
+    assert float(scope.effective_aperture().magnitude) == pytest.approx(expected_eff)
+
+    # Test light_grasp_ratio
+    assert float(scope.light_grasp_ratio(100.0)) == pytest.approx((expected_eff / 100.0) ** 2)


### PR DESCRIPTION
Extracted pure telescope calculation functions (calculate_focal_ratio, calculate_aperture_area, calculate_effective_aperture, calculate_light_grasp_ratio) into apts/optics/calculations/telescope.py and refactored Telescope in apts/opticalequipment/telescope/base.py to delegate to them while preserving public API compatibility and Pint quantity units. Added comprehensive unit tests in tests/unit/test_optics_calculations_telescope.py.

---
*PR created automatically by Jules for task [15517091129642088003](https://jules.google.com/task/15517091129642088003) started by @pozar87*