### PR TITLE
🔍 Optic: Data audit for Celestron NexStar 8SE

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -775,16 +775,16 @@ class CelestronTelescope(Telescope):
             "name": "NexStar 8SE",
             "type": "schmidt_cassegrain",
             "optical_length": 0,
-            "mass": 5443,
+            "mass": 5443,  # Verified via Celestron.com (12 lbs / 5.44 kg OTA weight) - https://www.celestron.com/products/nexstar-8se-computerized-telescope
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "SC (Schmidt-Cassegrain)",
             "cside_gender": "Male",
             "reversible": False,
             "bf_role": "",
-            "aperture_mm": 203.2,
-            "focal_length_mm": 2032,
-            "central_obstruction_mm": 64,
+            "aperture_mm": 203.2,  # Verified via Celestron.com (203.2mm / 8")
+            "focal_length_mm": 2032,  # Verified via Celestron.com (2032mm / f/10)
+            "central_obstruction_mm": 64,  # Verified via Celestron.com (64mm / 2.5" / 31% secondary obstruction) - https://www.celestron.com/products/nexstar-8se-computerized-telescope
         },
         "Celestron_NexStar_Evolution_6": {
             "brand": "Celestron",

--- a/tests/unit/test_celestron_nexstar_8se_audit.py
+++ b/tests/unit/test_celestron_nexstar_8se_audit.py
@@ -1,0 +1,17 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+
+
+class TestCelestronNexStar8SEAudit(unittest.TestCase):
+    def test_nexstar_8se_specs(self):
+        scope = CelestronTelescope.Celestron_NexStar_8SE()
+        self.assertEqual(scope.get_vendor(), "Celestron NexStar 8SE")
+        self.assertEqual(scope.aperture.to("mm").magnitude, 203.2)
+        self.assertEqual(scope.focal_length.to("mm").magnitude, 2032)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 10.0, places=2)
+        self.assertEqual(scope.central_obstruction.to("mm").magnitude, 64)
+        self.assertEqual(scope.mass.to("gram").magnitude, 5443)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🔍 Optic: Data audit for Celestron NexStar 8SE

💡 Fix: Cross-referenced aperture (203.2mm), focal length (2032mm), focal ratio (f/10), central obstruction (64mm / 31%), OTA weight (5443g / 12 lbs), and visual back connection (SC Male) against official Celestron documentation.
🎯 Source: https://www.celestron.com/products/nexstar-8se-computerized-telescope
✅ Test: Added unit test suite `tests/unit/test_celestron_nexstar_8se_audit.py`.

---
*PR created automatically by Jules for task [7818761351213429688](https://jules.google.com/task/7818761351213429688) started by @pozar87*