### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Evostar 100ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -296,10 +296,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA (2" dual-speed Crayford focuser visual back) - https://www.skywatcherusa.com/products/evostar-100ed
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA (Includes 2" Crayford focuser with 2" visual back) - https://www.skywatcherusa.com/products/evostar-100ed
             "focal_length_mm": 900,
-            "mass": 3000,
+            "mass": 3000,  # Verified via Sky-Watcher USA / Astronomics (6.6 lbs / 3.0 kg OTA weight) - https://www.skywatcherusa.com/products/evostar-100ed
             "name": "Evostar 100ED",
             "optical_length": 0,
             "reversible": False,
@@ -312,10 +312,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA / OVL UK (2" dual-speed Crayford focuser visual back) - https://www.skywatcherusa.com/products/evostar-100ed
+            "cside_thread": "2\"",  # Verified via Sky-Watcher USA / OVL UK (Includes 2" Crayford focuser with 2" visual back) - https://www.skywatcherusa.com/products/evostar-100ed
             "focal_length_mm": 900,
-            "mass": 3000,
+            "mass": 3000,  # Verified via Sky-Watcher USA / Astronomics (6.6 lbs / 3.0 kg OTA weight) - https://www.skywatcherusa.com/products/evostar-100ed
             "name": "Evostar 100ED DS-Pro",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_evostar_100ed_audit.py
+++ b/tests/unit/test_sky_watcher_evostar_100ed_audit.py
@@ -1,0 +1,34 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.opticalequipment.telescope.enums import TelescopeType
+from apts.utils import ConnectionType, Gender
+
+
+class TestSkyWatcherEvostar100EDAudit(unittest.TestCase):
+    def test_evostar_100ed_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_100ED()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 100ED")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 100)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 900)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 9.0)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 3000)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+    def test_evostar_100ed_ds_pro_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_100ED_DS_Pro()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 100ED DS-Pro")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 100)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 900)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 9.0)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 3000)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited and corrected the Sky-Watcher Evostar 100ED and Evostar 100ED DS-Pro entries in apts/opticalequipment/telescope/vendors/sky_watcher.py by cross-referencing official Sky-Watcher documentation. Updated cside_thread to '2"' and cside_gender to 'Female' (representing the native 2" Crayford focuser visual back). Added unit test suite in tests/unit/test_sky_watcher_evostar_100ed_audit.py.

---
*PR created automatically by Jules for task [15520697403931996195](https://jules.google.com/task/15520697403931996195) started by @pozar87*