### PR TITLE
🔍 Optic: Data audit for SVBony SV550 80ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/svbony.py
+++ b/apts/opticalequipment/telescope/vendors/svbony.py
@@ -73,17 +73,18 @@ class SvbonyTelescope(Telescope):
             "brand": "SVBony",
             "name": "SV550 80ED",
             "type": "type_refractor",
-            "optical_length": 0,
-            "mass": 2450,
+            "optical_length": 90, # Verified via SVBony (90mm backfocus length)
+            "mass": 2450, # Verified via SVBony (2450g OTA weight)
             "tside_thread": "",
             "tside_gender": "",
-            "cside_thread": "M48",
-            "cside_gender": "Male",
+            "cside_thread": "2\"", # Verified via SVBony (2" dual-speed rack and pinion focuser visual back)
+            "cside_gender": "Female",
             "reversible": False,
-            "bf_role": "",
+            "bf_role": "start",
             "aperture_mm": 80,
             "focal_length_mm": 480,
             "central_obstruction_mm": 0,
+            # Source: https://www.svbony.com/sv550-80F6-APO-triplet-refractor-telescope/
         },
         "SVBony_SV550_122ED": {
             "brand": "SVBony",

--- a/tests/unit/test_svbony_sv550_80ed_audit.py
+++ b/tests/unit/test_svbony_sv550_80ed_audit.py
@@ -1,0 +1,24 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.svbony import SvbonyTelescope
+from apts.opticalequipment.telescope.enums import TelescopeType
+from apts.utils import ConnectionType, Gender
+
+
+class TestSVBonySV55080EDAudit(unittest.TestCase):
+    def test_sv550_80ed_specs(self):
+        scope = SvbonyTelescope.SVBony_SV550_80ED()
+        self.assertEqual(scope.get_vendor(), "SVBony SV550 80ED")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 80)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 480)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 6.0)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2450)
+        self.assertEqual(scope.optical_length.to('mm').magnitude, 90)
+        self.assertEqual(scope.backfocus.to('mm').magnitude, 90)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audited, verified, and updated specifications for the SVBony SV550 80ED APO Triplet refractor telescope based on official manufacturer documentation, and added unit test suite.

---
*PR created automatically by Jules for task [1870054469197115158](https://jules.google.com/task/1870054469197115158) started by @pozar87*