### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Esprit 120ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -248,9 +248,9 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
-            "focal_length_mm": 840,
+            "cside_gender": "Female",  # Verified via Sky-Watcher USA (focuser drawtube has female threads) - https://www.skywatcherusa.com/products/esprit-120edx
+            "cside_thread": "M74",  # Verified via Sky-Watcher USA (Drawtube thread size is M74x1) - https://www.skywatcherusa.com/products/esprit-120edx
+            "focal_length_mm": 840,  # Verified via Sky-Watcher Global (120mm aperture, 840mm focal length, f/7.0) - http://skywatcher.com/product/esprit-120-ed-apo-triplet/
             "mass": 10300,  # Verified via Sky-Watcher Global (10.3 kg Tube Weight) - http://skywatcher.com/product/esprit-120-ed-apo-triplet/
             "name": "Esprit 120ED",
             "optical_length": 0,

--- a/tests/unit/test_sky_watcher_esprit_120_audit.py
+++ b/tests/unit/test_sky_watcher_esprit_120_audit.py
@@ -3,13 +3,11 @@ from apts.utils import ConnectionType, Gender
 
 def test_esprit_120ed_audit():
     telescope = Sky_watcherTelescope.Sky_Watcher_Esprit_120ED()
-    # Verified via Sky-Watcher Global (10.3 kg Tube Weight)
-    assert telescope.mass.to('g').magnitude == 10300
+    assert telescope.get_vendor() == "Sky-Watcher Esprit 120ED"
     assert telescope.aperture.to('mm').magnitude == 120
     assert telescope.focal_length.to('mm').magnitude == 840
-    # Current database has M48 Male (likely flattener output)
-    # We'll stick to what's expected after my change if I decide to keep M48 Male
-    # or change it to 3" Female.
-    # Given the existing pattern for Esprit in the file, I'll keep M48 Male but update the mass.
-    assert telescope.connection_type == ConnectionType.M48
-    assert telescope.connection_gender == Gender.MALE
+    assert abs(telescope.focal_ratio() - 7.0) < 0.01
+    assert telescope.central_obstruction.to('mm').magnitude == 0
+    assert telescope.mass.to('g').magnitude == 10300
+    assert telescope.connection_type == ConnectionType.M74
+    assert telescope.connection_gender == Gender.FEMALE


### PR DESCRIPTION
Audited and corrected the hardware entry for Sky-Watcher Esprit 120ED telescope in `apts/opticalequipment/telescope/vendors/sky_watcher.py` based on official manufacturer documentation (Sky-Watcher Global and Sky-Watcher USA). Updated connection properties (`cside_gender` to 'Female' and `cside_thread` to 'M74') and added official spec sheet source references. Updated test assertions in `tests/unit/test_sky_watcher_esprit_120_audit.py`.

---
*PR created automatically by Jules for task [16812182493913477733](https://jules.google.com/task/16812182493913477733) started by @pozar87*