### PR TITLE
🏗️ Architect: Modularized Event Coordinator Dispatch

### DIFF
--- a/apts/events/coordinator/__init__.py
+++ b/apts/events/coordinator/__init__.py
@@ -1,3 +1,4 @@
 from .base import AstronomicalEvents
+from .dispatch import build_event_dispatch_map
 
-__all__ = ["AstronomicalEvents"]
+__all__ = ["AstronomicalEvents", "build_event_dispatch_map"]

--- a/apts/events/coordinator/base.py
+++ b/apts/events/coordinator/base.py
@@ -19,6 +19,7 @@ from ..calculations import lunar, planetary as planetary_calc, space, sky
 
 from .settings import EventSettingsManager
 from .precomputation import PrecomputationEngine
+from .dispatch import build_event_dispatch_map
 
 logger = logging.getLogger(__name__)
 
@@ -230,49 +231,8 @@ class AstronomicalEvents:
 
         precomputed = self._precompute_positions()
 
-        # Dispatch mapping for event calculations to reduce cyclomatic complexity
-        event_dispatch = {
-            "moon_phases": self.calculate_moon_phases,
-            "conjunctions": lambda: self.calculate_conjunctions(precomputed),
-            "oppositions": self.calculate_oppositions,
-            "meteor_showers": self.calculate_meteor_showers,
-            "highest_altitudes": self.calculate_highest_altitudes,
-            "lunar_occultations": self.calculate_lunar_occultations,
-            "aphelion_perihelion": self.calculate_aphelion_perihelion,
-            "moon_apogee_perigee": self.calculate_moon_apogee_perigee,
-            "mercury_inferior_conjunctions": self.calculate_mercury_inferior_conjunctions,
-            "moon_messier_conjunctions": lambda: self.calculate_moon_messier_conjunctions(precomputed),
-            "moon_star_conjunctions": lambda: self.calculate_moon_star_conjunctions(precomputed),
-            "space_launches": self.calculate_space_launches,
-            "space_events": self.calculate_space_events,
-            "iss_flybys": self.calculate_iss_flybys,
-            "tiangong_flybys": self.calculate_tiangong_flybys,
-            "solar_eclipses": self.calculate_solar_eclipses,
-            "lunar_eclipses": self.calculate_lunar_eclipses,
-            "nasa_comets": self.calculate_nasa_comets,
-            "planet_alignments": self.calculate_planet_alignments,
-            "lunar_planetary_occultations": self.calculate_lunar_planetary_occultations,
-            "messier_culminations": self.calculate_messier_culminations,
-            "jovian_moon_events": self.calculate_jovian_moon_events,
-            "saturn_ring_crossings": self.calculate_saturn_ring_crossings,
-            "jupiter_grs_transits": self.calculate_jupiter_grs_transits,
-            "planet_messier_conjunctions": lambda: self.calculate_planet_messier_conjunctions(precomputed),
-            "planet_star_conjunctions": lambda: self.calculate_planet_star_conjunctions(precomputed),
-            "planet_stationary_points": self.calculate_planet_stationary_points,
-            "planet_solar_conjunctions": self.calculate_planet_solar_conjunctions,
-            "lunar_features": self.calculate_lunar_features,
-            "moon_libration_maxima": self.calculate_moon_libration_maxima,
-            "planet_planet_occultations": self.calculate_planet_planet_occultations,
-            "venus_great_brilliancy": self.calculate_venus_greatest_brilliancy,
-            "supermoons": self.calculate_supermoons,
-            "mars_closest_approach": self.calculate_mars_closest_approach,
-            "jovian_mutual_events": self.calculate_jovian_mutual_events,
-            "greatest_elongations": self.calculate_greatest_elongations,
-            "planetary_dichotomy": lambda: self.calculate_planetary_dichotomy(precomputed),
-            "seasons": self.calculate_seasons,
-            "culminations": self.calculate_culminations,
-            "celestial_configurations": self.calculate_celestial_configurations,
-        }
+        # Dispatch mapping for event calculations built by helper
+        event_dispatch = build_event_dispatch_map(self, precomputed)
 
         for event_key, func in event_dispatch.items():
             if self.event_settings.get(event_key):

--- a/apts/events/coordinator/dispatch.py
+++ b/apts/events/coordinator/dispatch.py
@@ -1,0 +1,61 @@
+from typing import Any, Callable, Dict, Optional
+
+
+def build_event_dispatch_map(
+    events_obj: Any, precomputed: Optional[Dict[str, Any]] = None
+) -> Dict[str, Callable[[], Any]]:
+    """
+    Builds the event calculation dispatch mapping for an AstronomicalEvents instance.
+    """
+    return {
+        "moon_phases": events_obj.calculate_moon_phases,
+        "conjunctions": lambda: events_obj.calculate_conjunctions(precomputed),
+        "oppositions": events_obj.calculate_oppositions,
+        "meteor_showers": events_obj.calculate_meteor_showers,
+        "highest_altitudes": events_obj.calculate_highest_altitudes,
+        "lunar_occultations": events_obj.calculate_lunar_occultations,
+        "aphelion_perihelion": events_obj.calculate_aphelion_perihelion,
+        "moon_apogee_perigee": events_obj.calculate_moon_apogee_perigee,
+        "mercury_inferior_conjunctions": events_obj.calculate_mercury_inferior_conjunctions,
+        "moon_messier_conjunctions": lambda: events_obj.calculate_moon_messier_conjunctions(
+            precomputed
+        ),
+        "moon_star_conjunctions": lambda: events_obj.calculate_moon_star_conjunctions(
+            precomputed
+        ),
+        "space_launches": events_obj.calculate_space_launches,
+        "space_events": events_obj.calculate_space_events,
+        "iss_flybys": events_obj.calculate_iss_flybys,
+        "tiangong_flybys": events_obj.calculate_tiangong_flybys,
+        "solar_eclipses": events_obj.calculate_solar_eclipses,
+        "lunar_eclipses": events_obj.calculate_lunar_eclipses,
+        "nasa_comets": events_obj.calculate_nasa_comets,
+        "planet_alignments": events_obj.calculate_planet_alignments,
+        "lunar_planetary_occultations": events_obj.calculate_lunar_planetary_occultations,
+        "messier_culminations": events_obj.calculate_messier_culminations,
+        "jovian_moon_events": events_obj.calculate_jovian_moon_events,
+        "saturn_ring_crossings": events_obj.calculate_saturn_ring_crossings,
+        "jupiter_grs_transits": events_obj.calculate_jupiter_grs_transits,
+        "planet_messier_conjunctions": lambda: events_obj.calculate_planet_messier_conjunctions(
+            precomputed
+        ),
+        "planet_star_conjunctions": lambda: events_obj.calculate_planet_star_conjunctions(
+            precomputed
+        ),
+        "planet_stationary_points": events_obj.calculate_planet_stationary_points,
+        "planet_solar_conjunctions": events_obj.calculate_planet_solar_conjunctions,
+        "lunar_features": events_obj.calculate_lunar_features,
+        "moon_libration_maxima": events_obj.calculate_moon_libration_maxima,
+        "planet_planet_occultations": events_obj.calculate_planet_planet_occultations,
+        "venus_great_brilliancy": events_obj.calculate_venus_greatest_brilliancy,
+        "supermoons": events_obj.calculate_supermoons,
+        "mars_closest_approach": events_obj.calculate_mars_closest_approach,
+        "jovian_mutual_events": events_obj.calculate_jovian_mutual_events,
+        "greatest_elongations": events_obj.calculate_greatest_elongations,
+        "planetary_dichotomy": lambda: events_obj.calculate_planetary_dichotomy(
+            precomputed
+        ),
+        "seasons": events_obj.calculate_seasons,
+        "culminations": events_obj.calculate_culminations,
+        "celestial_configurations": events_obj.calculate_celestial_configurations,
+    }

--- a/tests/unit/test_events_coordinator_dispatch.py
+++ b/tests/unit/test_events_coordinator_dispatch.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import MagicMock
+
+from apts.events.coordinator.dispatch import build_event_dispatch_map
+
+
+class TestEventsCoordinatorDispatch(unittest.TestCase):
+    def test_build_event_dispatch_map(self):
+        mock_events = MagicMock()
+        mock_precomputed = {"mars": MagicMock()}
+
+        dispatch_map = build_event_dispatch_map(mock_events, mock_precomputed)
+
+        # Ensure dispatch_map is a dictionary with expected keys
+        self.assertIsInstance(dispatch_map, dict)
+        expected_keys = [
+            "moon_phases",
+            "conjunctions",
+            "oppositions",
+            "meteor_showers",
+            "highest_altitudes",
+            "lunar_occultations",
+            "aphelion_perihelion",
+            "moon_apogee_perigee",
+            "mercury_inferior_conjunctions",
+            "moon_messier_conjunctions",
+            "moon_star_conjunctions",
+            "space_launches",
+            "space_events",
+            "iss_flybys",
+            "tiangong_flybys",
+            "solar_eclipses",
+            "lunar_eclipses",
+            "nasa_comets",
+            "planet_alignments",
+            "lunar_planetary_occultations",
+            "messier_culminations",
+            "jovian_moon_events",
+            "saturn_ring_crossings",
+            "jupiter_grs_transits",
+            "planet_messier_conjunctions",
+            "planet_star_conjunctions",
+            "planet_stationary_points",
+            "planet_solar_conjunctions",
+            "lunar_features",
+            "moon_libration_maxima",
+            "planet_planet_occultations",
+            "venus_great_brilliancy",
+            "supermoons",
+            "mars_closest_approach",
+            "jovian_mutual_events",
+            "greatest_elongations",
+            "planetary_dichotomy",
+            "seasons",
+            "culminations",
+            "celestial_configurations",
+        ]
+
+        for key in expected_keys:
+            self.assertIn(key, dispatch_map)
+            self.assertTrue(callable(dispatch_map[key]))
+
+        # Test execution of lambda/wrapped dispatchers
+        dispatch_map["conjunctions"]()
+        mock_events.calculate_conjunctions.assert_called_once_with(mock_precomputed)
+
+        dispatch_map["planetary_dichotomy"]()
+        mock_events.calculate_planetary_dichotomy.assert_called_once_with(mock_precomputed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extract event calculation dispatch map construction into build_event_dispatch_map in apts/events/coordinator/dispatch.py. Update AstronomicalEvents.get_events to delegate map building to dispatch.py, re-export in apts/events/coordinator/__init__.py, and add unit tests in tests/unit/test_events_coordinator_dispatch.py.

---
*PR created automatically by Jules for task [11552447590507087768](https://jules.google.com/task/11552447590507087768) started by @pozar87*