### PR TITLE
🔍 Optic: Data audit for ZWO ASI678MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -1826,9 +1826,9 @@ class ZwoCamera(Camera):
             "cside_thread": "",
             "full_well_e": 11270,
             "height": 2160,
-            "mass": 126,
+            "mass": 126,  # Verified via ZWO (126g) - https://www.zwoastro.com/product/asi678mc/
             "name": "ASI678MC",
-            "optical_length": 6.5,
+            "optical_length": 12.5,  # Verified via ZWO (12.5mm backfocus distance / CS thread) - https://www.zwoastro.com/product/asi678mc/
             "pixel_size_um": 2.0,
             "quantum_efficiency_pct": 83,
             "read_noise_e": 0.6,
@@ -1836,7 +1836,7 @@ class ZwoCamera(Camera):
             "sensor_height_mm": 4.32,
             "sensor_width_mm": 7.68,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",  # Verified via ZWO (CS-mount native thread with 12.5mm backfocus) - https://www.zwoastro.com/product/asi678mc/
             "type": "type_camera",
             "width": 3840,
         },

--- a/tests/unit/test_zwo_678mc_audit.py
+++ b/tests/unit/test_zwo_678mc_audit.py
@@ -1,0 +1,43 @@
+import unittest
+from pint import Quantity
+
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils.equipment import ConnectionType
+
+
+class TestZwoASI678MCAudit(unittest.TestCase):
+
+    def test_asi678mc_specs(self):
+        cam = ZwoCamera.ZWO_ASI_678MC()
+
+        # Mass: 126g
+        self.assertEqual(cam.mass.to("gram").magnitude, 126)
+
+        # Optical length / backfocus: 12.5mm
+        self.assertEqual(cam.optical_length.to("mm").magnitude, 12.5)
+        self.assertEqual(cam.backfocus, Quantity(12.5, "millimeter"))
+
+        # Connection thread: CS
+        self.assertEqual(cam.connection_type, ConnectionType.CS)
+
+        # Resolution: 3840 x 2160 (4K UHD)
+        self.assertEqual(cam.width, 3840)
+        self.assertEqual(cam.height, 2160)
+
+        # Sensor dimensions & pixel size: 2.0µm, 7.68mm x 4.32mm
+        self.assertEqual(cam.pixel_size().to("micrometer").magnitude, 2.0)
+        self.assertEqual(cam.sensor_width.to("mm").magnitude, 7.68)
+        self.assertEqual(cam.sensor_height.to("mm").magnitude, 4.32)
+
+        # Full well capacity: 11270 e-
+        self.assertEqual(cam.full_well, 11270)
+
+        # Read noise: 0.6 e-
+        self.assertEqual(cam.read_noise, 0.6)
+
+        # Peak Quantum Efficiency: 83%
+        self.assertEqual(cam.quantum_efficiency, 83)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Data audit and spec verification for ZWO ASI678MC camera against official ZWO technical specs. Corrected backfocus distance / optical length to 12.5mm and thread connection to CS-mount. Added test coverage in `tests/unit/test_zwo_678mc_audit.py`.

---
*PR created automatically by Jules for task [5923208701370969949](https://jules.google.com/task/5923208701370969949) started by @pozar87*