### PR TITLE
Add NGC targets, FOV hard filtering, and imaging recipes to DiscoveryService

### DIFF
--- a/apts/discovery/__init__.py
+++ b/apts/discovery/__init__.py
@@ -1,4 +1,11 @@
+from .recipes import ImagingRecipe, get_imaging_recipe, get_recommended_strategy
 from .service import DiscoveryService
 from .timeline import TimelineGenerator
 
-__all__ = ["DiscoveryService", "TimelineGenerator"]
+__all__ = [
+    "DiscoveryService",
+    "ImagingRecipe",
+    "TimelineGenerator",
+    "get_imaging_recipe",
+    "get_recommended_strategy",
+]

--- a/apts/discovery/recipes.py
+++ b/apts/discovery/recipes.py
@@ -1,0 +1,82 @@
+from enum import Enum
+from typing import cast
+
+from ..constants.strategies import DSOType, FilterStrategy
+
+
+class ImagingRecipe(str, Enum):
+    """
+    Recommended camera and filter equipment setup for astrophotography targets.
+    """
+
+    OSC_RGB = "OSC_RGB"  # One-Shot Color / Mono camera with RGB/L filters
+    OSC_DUALBAND = "OSC_DUALBAND"  # One-Shot Color with dual-band filter (e.g. Ha/OIII, L-eNhance)
+    MONO_HA_OIII = "MONO_HA_OIII"  # Mono camera with Ha and OIII narrowband filters
+    MONO_SHO = "MONO_SHO"  # Mono camera with SII, Ha, and OIII narrowband filters (Hubble Palette)
+
+
+def get_imaging_recipe(
+    dso_type: DSOType,
+    moon_illumination: float = 0.0,
+    bortle: float | None = None,
+) -> ImagingRecipe:
+    """
+    Determines the recommended imaging recipe based on target DSO type,
+    Moon illumination (0.0 to 1.0), and sky light pollution (Bortle scale 1 to 9).
+
+    Base mapping:
+    - GX, GC, OC, RN, SC, AST, DS, OTHER -> OSC_RGB
+    - EN, DN -> OSC_DUALBAND
+    - SNR -> MONO_HA_OIII (or MONO_SHO if bright Moon or high light pollution)
+    - PN -> MONO_HA_OIII
+
+    Contextual adjustments:
+    - High Bortle (>= 5) or bright Moon (>= 0.5) shifts EN/DN to MONO_HA_OIII and SNR to MONO_SHO.
+    """
+    high_light_pollution = bortle is not None and bortle >= 5.0
+    bright_moon = moon_illumination >= 0.5
+    challenging_conditions = high_light_pollution or bright_moon
+
+    if dso_type in (
+        DSOType.GX,
+        DSOType.GC,
+        DSOType.OC,
+        DSOType.RN,
+        DSOType.SC,
+        DSOType.AST,
+        DSOType.DS,
+        DSOType.OTHER,
+    ):
+        return ImagingRecipe.OSC_RGB
+
+    if dso_type in (DSOType.EN, DSOType.DN):
+        if challenging_conditions:
+            return ImagingRecipe.MONO_HA_OIII
+        return ImagingRecipe.OSC_DUALBAND
+
+    if dso_type == DSOType.SNR:
+        if challenging_conditions:
+            return ImagingRecipe.MONO_SHO
+        return ImagingRecipe.MONO_HA_OIII
+
+    if dso_type == DSOType.PN:
+        return ImagingRecipe.MONO_HA_OIII
+
+    return ImagingRecipe.OSC_RGB
+
+
+def get_recommended_strategy(
+    dso_type: DSOType,
+    moon_illumination: float = 0.0,
+    bortle: float | None = None,
+) -> FilterStrategy:
+    """
+    Determines the recommended FilterStrategy (BROADBAND or NARROWBAND)
+    corresponding to the recommended imaging recipe.
+    """
+    recipe = get_imaging_recipe(
+        dso_type, moon_illumination=moon_illumination, bortle=bortle
+    )
+    if recipe == ImagingRecipe.OSC_RGB:
+        return cast(FilterStrategy, FilterStrategy.BROADBAND)
+    return cast(FilterStrategy, FilterStrategy.NARROWBAND)

--- a/apts/discovery/service.py
+++ b/apts/discovery/service.py
@@ -7,12 +7,29 @@ import pandas as pd
 from ..constants import FilterStrategy, ObjectTableLabels
 from ..optics.utils import OpticsUtils
 from ..scoring import SuitabilityScorer
-from ..utils.astronomy.refraction import calculate_refraction
 from ..utils.astronomy.altaz import vectorized_geometric_altaz
-from ..utils.astronomy.separation import vectorized_angular_separation
 from ..utils.astronomy.calculations import vectorized_geometric_imaging_duration
+from ..utils.astronomy.refraction import calculate_refraction
+from ..utils.astronomy.separation import vectorized_angular_separation
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_arcmin_floats(arr) -> np.ndarray:
+    """Helper to convert raw catalog dimensions (Pint Quantities, floats, or NaNs) to float arcminutes."""
+    if arr is None or len(arr) == 0:
+        return np.array([], dtype=float)
+    res = np.empty(len(arr), dtype=float)
+    for i, val in enumerate(arr):
+        mag = getattr(val, "magnitude", val)
+        if mag is None or pd.isna(mag):
+            res[i] = np.nan
+        else:
+            try:
+                res[i] = float(mag)
+            except (ValueError, TypeError):
+                res[i] = np.nan
+    return res
 
 
 class DiscoveryService:
@@ -28,10 +45,13 @@ class DiscoveryService:
         date=None,
         strategy=FilterStrategy.BROADBAND,
         limit=20,
+        include_ngc: bool = False,
+        ngc_magnitude_limit: float | None = 13.0,
+        min_fov_ratio: float | None = None,
     ):
         """
         Returns a ranked list of objects sorted by the Multi-Factor Score.
-        Includes Messier and Solar objects.
+        Includes Messier and Solar objects, and optionally NGC objects.
         """
         scorer = SuitabilityScorer(place, equipment_path, filter_strategy=strategy)
 
@@ -44,10 +64,20 @@ class DiscoveryService:
 
         # Ensure date is converted to datetime for place helper methods that expect it
         from ..place.utils import get_scalar_datetime
+
         t_dt = get_scalar_datetime(t_sf)
 
-        # 1. Collect combined targets (Messier + Solar)
-        combined_df = DiscoveryService._get_combined_targets(place, catalogs, t_sf)
+        # 1. Collect combined targets (Messier + optional NGC + Solar)
+        combined_df = DiscoveryService._get_combined_targets(
+            place,
+            catalogs,
+            t_sf,
+            include_ngc=include_ngc,
+            ngc_magnitude_limit=ngc_magnitude_limit,
+        )
+
+        if combined_df.empty:
+            return []
 
         # 2. Pre-calculate astronomical twilight
         twilight_times = DiscoveryService._get_twilight_window(place, t_dt)
@@ -57,29 +87,77 @@ class DiscoveryService:
             place, equipment_path, combined_df, t_sf, twilight_times
         )
 
-        # 4. Vectorized Scoring
-        scores_df = scorer.calculate_scores_bulk(combined_df)
+        # 4. Hard FOV ratio filter if min_fov_ratio is specified
+        if min_fov_ratio is not None:
+            combined_df = combined_df[combined_df["fov_ratio"] >= min_fov_ratio].copy()
+            if combined_df.empty:
+                return []
+
+        # 5. Vectorized Scoring
+        scores_df = scorer.calculate_scores_bulk(cast(pd.DataFrame, combined_df))
         combined_df["Score"] = scores_df["total_score"]
 
-        # 5. Format and return results
+        # 6. Format and return results
         return DiscoveryService._format_discovery_results(combined_df, scores_df, limit)
 
     @staticmethod
-    def _get_combined_targets(place, catalogs, date) -> pd.DataFrame:
-        """Collects and combines Messier and Solar objects, excluding the Sun."""
-        from ..objects.messier import Messier
+    def _get_combined_targets(
+        place,
+        catalogs,
+        date,
+        include_ngc: bool = False,
+        ngc_magnitude_limit: float | None = 13.0,
+    ) -> pd.DataFrame:
+        """Collects and combines Messier, Solar, and optional NGC objects, excluding the Sun."""
         from ..objects import SolarObjects
+        from ..objects.messier import Messier
 
         # Optimization: Pass date to constructors to avoid redundant compute() calls.
         messier_obj = Messier(place, catalogs, calculation_date=date)
         messier_obj.compute(calculation_date=date)
 
+        dfs = [messier_obj.objects]
+
+        if include_ngc:
+            from ..catalogs.ngc import normalize_name
+            from ..objects.ngc import NGC
+
+            ngc_obj = NGC(place, catalogs, calculation_date=date)
+            ngc_df = ngc_obj.objects.copy()
+
+            # Deduplicate NGC entries against Messier catalog
+            messier_ngc_ids = list(
+                cast(pd.Series, normalize_name(messier_obj.objects["NGC"])).dropna()
+            )
+
+            ngc_col_norm = cast(
+                pd.Series, normalize_name("NGC" + ngc_df["NGC"].fillna(""))
+            )
+            ic_col_norm = cast(
+                pd.Series, normalize_name("IC" + ngc_df["IC"].fillna(""))
+            )
+
+            is_messier_dup = (
+                ngc_df["Name_norm"].isin(messier_ngc_ids)
+                | ngc_col_norm.reindex(ngc_df.index).isin(messier_ngc_ids)
+                | ic_col_norm.reindex(ngc_df.index).isin(messier_ngc_ids)
+                | ngc_df["M"].notna()
+            )
+            ngc_df = ngc_df[~is_messier_dup]
+
+            # Magnitude pre-filter
+            if ngc_magnitude_limit is not None:
+                ngc_df = ngc_df[ngc_df["Magnitude_float"] <= ngc_magnitude_limit]
+
+            # Compute vectorized geometric coordinates for the filtered NGC subset
+            ngc_df = ngc_obj.compute(calculation_date=date, df_to_compute=ngc_df)
+            dfs.append(ngc_df)
+
         # SolarObjects.compute() is already called in its __init__ with calculation_date.
         solar_obj = SolarObjects(place, calculation_date=date)
+        dfs.append(solar_obj.objects)
 
-        combined_df = pd.concat(
-            [messier_obj.objects, solar_obj.objects], ignore_index=True
-        )
+        combined_df = pd.concat(dfs, ignore_index=True)
         result = combined_df[combined_df["Name"] != "sun"].copy()
         return cast(pd.DataFrame, result)
 
@@ -124,16 +202,25 @@ class DiscoveryService:
             .magnitude
         )
 
-        size_major = df[ObjectTableLabels.SIZE_MAJOR].values
-        size_minor = df[ObjectTableLabels.SIZE_MINOR].values
+        size_major_raw = (
+            df[ObjectTableLabels.SIZE_MAJOR].values
+            if ObjectTableLabels.SIZE_MAJOR in df.columns
+            else np.full(len(df), np.nan)
+        )
+        size_minor_raw = (
+            df[ObjectTableLabels.SIZE_MINOR].values
+            if ObjectTableLabels.SIZE_MINOR in df.columns
+            else np.full(len(df), np.nan)
+        )
 
-        # If they are Quantities, extract magnitudes once in bulk
-        if len(size_major) > 0 and hasattr(size_major[0], "magnitude"):
-            size_major = np.array([getattr(s, "magnitude", s) for s in size_major])
-            size_minor = np.array([getattr(s, "magnitude", s) for s in size_minor])
+        size_major_floats = _extract_arcmin_floats(size_major_raw)
+        size_minor_floats = _extract_arcmin_floats(size_minor_raw)
+
+        df["size_major_arcmin"] = size_major_floats
+        df["size_minor_arcmin"] = size_minor_floats
 
         df["fov_ratio"] = OpticsUtils.calculate_fov_ratio(
-            (size_major, size_minor),
+            (size_major_floats, size_minor_floats),
             sensor_size,
             focal_length,
         )
@@ -217,15 +304,9 @@ class DiscoveryService:
 
         results_df = df.sort_values("Score", ascending=False).head(limit)
 
-        # Optimization: use itertuples() and a pre-converted details map instead of iterrows()
-        # and row-wise .to_dict() for a significant speedup.
         top_scores_dict = scores_df.loc[results_df.index].to_dict("index")
         type_col = ObjectTableLabels.DSO_TYPE
 
-        # Convert type column label to a valid itertuples name if needed,
-        # but better to use itertuples(index=True, name='Pandas') and getattr or index-based access.
-        # itertuples() can mangel column names with spaces.
-        # Using to_dict('records') is safer and still very fast for small result sets.
         top_results_list = results_df.to_dict("records")
 
         scored_objects = [
@@ -234,6 +315,15 @@ class DiscoveryService:
                 "Type": row[type_col],
                 "Score": row["Score"],
                 "Details": top_scores_dict[results_df.index[i]],
+                "fov_ratio": float(row["fov_ratio"])
+                if pd.notna(row.get("fov_ratio"))
+                else 0.0,
+                "size_major_arcmin": float(row["size_major_arcmin"])
+                if pd.notna(row.get("size_major_arcmin"))
+                else float("nan"),
+                "size_minor_arcmin": float(row["size_minor_arcmin"])
+                if pd.notna(row.get("size_minor_arcmin"))
+                else float("nan"),
             }
             for i, row in enumerate(top_results_list)
         ]

--- a/apts/discovery/timeline.py
+++ b/apts/discovery/timeline.py
@@ -1,6 +1,9 @@
 import datetime
+
 from skyfield import almanac
+
 from ..cache import get_ephemeris, get_timescale
+
 
 class TimelineGenerator:
     """

--- a/tests/unit/test_discovery_ngc.py
+++ b/tests/unit/test_discovery_ngc.py
@@ -1,0 +1,97 @@
+import math
+
+import pytest
+
+from apts import Catalogs, Place
+from apts.discovery import DiscoveryService
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.opticalequipment.telescope.vendors.william_optics import (
+    William_opticsTelescope,
+)
+from apts.optics import OpticalPath
+
+
+@pytest.fixture
+def test_setup():
+    place = Place(52.2297, 21.0122)  # Warsaw
+    telescope = William_opticsTelescope.William_Optics_RedCat_61()
+    camera = ZwoCamera.ZWO_ASI_2600MC_Pro()
+    path = OpticalPath(telescope, [], [], [], [], camera)
+    catalogs = Catalogs()
+    return place, path, catalogs
+
+
+def test_discovery_default_include_ngc_false(test_setup):
+    place, path, catalogs = test_setup
+    picks = DiscoveryService.get_top_picks(
+        place, path, catalogs, limit=20, include_ngc=False
+    )
+
+    assert len(picks) > 0
+    for item in picks:
+        assert "Name" in item
+        assert "Type" in item
+        assert "Score" in item
+        assert "Details" in item
+        assert "fov_ratio" in item
+        assert "size_major_arcmin" in item
+        assert "size_minor_arcmin" in item
+        assert isinstance(item["fov_ratio"], float)
+
+
+def test_discovery_include_ngc_true(test_setup):
+    place, path, catalogs = test_setup
+    picks_messier_only = DiscoveryService.get_top_picks(
+        place, path, catalogs, limit=100, include_ngc=False
+    )
+    messier_names = {p["Name"] for p in picks_messier_only}
+
+    picks_with_ngc = DiscoveryService.get_top_picks(
+        place, path, catalogs, limit=100, include_ngc=True, ngc_magnitude_limit=12.0
+    )
+
+    assert len(picks_with_ngc) > 0
+
+    # Should contain NGC objects that were not in Messier-only list
+    new_ngc_objects = [p for p in picks_with_ngc if p["Name"] not in messier_names]
+    assert len(new_ngc_objects) > 0, "Expected NGC objects to be recommended"
+
+    # Confirm formatting
+    for p in picks_with_ngc:
+        assert "fov_ratio" in p
+        assert "size_major_arcmin" in p
+        assert "size_minor_arcmin" in p
+
+
+def test_discovery_ngc_magnitude_limit(test_setup):
+    place, path, catalogs = test_setup
+    # Strict magnitude limit (only bright objects <= 7.0 mag)
+    picks_strict = DiscoveryService.get_top_picks(
+        place, path, catalogs, limit=100, include_ngc=True, ngc_magnitude_limit=7.0
+    )
+    # Lenient magnitude limit (up to 13.0 mag)
+    picks_lenient = DiscoveryService.get_top_picks(
+        place, path, catalogs, limit=100, include_ngc=True, ngc_magnitude_limit=13.0
+    )
+
+    assert len(picks_lenient) >= len(picks_strict)
+
+
+def test_discovery_min_fov_ratio_hard_filter(test_setup):
+    place, path, catalogs = test_setup
+    min_ratio = 30.0
+
+    picks_filtered = DiscoveryService.get_top_picks(
+        place,
+        path,
+        catalogs,
+        limit=50,
+        include_ngc=True,
+        ngc_magnitude_limit=13.0,
+        min_fov_ratio=min_ratio,
+    )
+
+    assert len(picks_filtered) > 0
+    for p in picks_filtered:
+        assert p["fov_ratio"] >= min_ratio
+        assert not math.isnan(p["fov_ratio"])

--- a/tests/unit/test_imaging_recipes.py
+++ b/tests/unit/test_imaging_recipes.py
@@ -1,0 +1,72 @@
+from apts.constants import DSOType, FilterStrategy
+from apts.discovery.recipes import (
+    ImagingRecipe,
+    get_imaging_recipe,
+    get_recommended_strategy,
+)
+
+
+def test_imaging_recipes_broadband_targets():
+    broadband_types = [
+        DSOType.GX,
+        DSOType.GC,
+        DSOType.OC,
+        DSOType.RN,
+        DSOType.SC,
+        DSOType.AST,
+        DSOType.DS,
+        DSOType.OTHER,
+    ]
+    for dso_type in broadband_types:
+        for moon in [0.0, 0.5, 1.0]:
+            for bortle in [None, 3, 7]:
+                assert get_imaging_recipe(dso_type, moon, bortle) == ImagingRecipe.OSC_RGB
+                assert (
+                    get_recommended_strategy(dso_type, moon, bortle)
+                    == FilterStrategy.BROADBAND
+                )
+
+
+def test_imaging_recipes_emission_nebulas():
+    # Under dark sky and low moon: OSC_DUALBAND
+    assert get_imaging_recipe(DSOType.EN, 0.1, 3) == ImagingRecipe.OSC_DUALBAND
+    assert (
+        get_recommended_strategy(DSOType.EN, 0.1, 3) == FilterStrategy.NARROWBAND
+    )
+
+    # Under bright moon (>=0.5): MONO_HA_OIII
+    assert get_imaging_recipe(DSOType.EN, 0.6, 3) == ImagingRecipe.MONO_HA_OIII
+    assert (
+        get_recommended_strategy(DSOType.EN, 0.6, 3) == FilterStrategy.NARROWBAND
+    )
+
+    # Under high Bortle (>=5): MONO_HA_OIII
+    assert get_imaging_recipe(DSOType.EN, 0.1, 6) == ImagingRecipe.MONO_HA_OIII
+
+    # Diffuse Nebula follows same rule
+    assert get_imaging_recipe(DSOType.DN, 0.1, 3) == ImagingRecipe.OSC_DUALBAND
+    assert get_imaging_recipe(DSOType.DN, 0.8, 2) == ImagingRecipe.MONO_HA_OIII
+
+
+def test_imaging_recipes_snr():
+    # Dark sky / low moon -> MONO_HA_OIII
+    assert get_imaging_recipe(DSOType.SNR, 0.2, 3) == ImagingRecipe.MONO_HA_OIII
+    assert (
+        get_recommended_strategy(DSOType.SNR, 0.2, 3) == FilterStrategy.NARROWBAND
+    )
+
+    # Bright moon -> MONO_SHO
+    assert get_imaging_recipe(DSOType.SNR, 0.7, 3) == ImagingRecipe.MONO_SHO
+
+    # High Bortle -> MONO_SHO
+    assert get_imaging_recipe(DSOType.SNR, 0.1, 5) == ImagingRecipe.MONO_SHO
+
+
+def test_imaging_recipes_planetary_nebula():
+    for moon in [0.0, 0.5, 1.0]:
+        for bortle in [None, 1, 8]:
+            assert get_imaging_recipe(DSOType.PN, moon, bortle) == ImagingRecipe.MONO_HA_OIII
+            assert (
+                get_recommended_strategy(DSOType.PN, moon, bortle)
+                == FilterStrategy.NARROWBAND
+            )


### PR DESCRIPTION
Added NGC target support with Messier deduplication, FOV ratio hard filtering, exposed dimensions/FOV in discovery results, and created imaging equipment recipe mapping helper.

---
*PR created automatically by Jules for task [18076861380011532307](https://jules.google.com/task/18076861380011532307) started by @pozar87*