### PR TITLE
🔍 Optic: Data audit for ZWO ASI664MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -1782,11 +1782,11 @@ class ZwoCamera(Camera):
             "brand": "ZWO",
             "cside_gender": "",
             "cside_thread": "",
-            "full_well_e": 38500,
+            "full_well_e": 38500,  # Verified via ZWO official product specs (38.5ke) - https://www.zwoastro.com/product/asi664mc/
             "height": 1536,
-            "mass": 126,
+            "mass": 126,  # Verified via ZWO (126g) - https://www.zwoastro.com/product/asi664mc/
             "name": "ASI664MC",
-            "optical_length": 12.5,
+            "optical_length": 12.5,  # Verified via ZWO (12.5mm backfocus distance / CS thread) - https://www.zwoastro.com/product/asi664mc/
             "pixel_size_um": 2.9,
             "quantum_efficiency_pct": 91,
             "read_noise_e": 0.46,
@@ -1794,7 +1794,7 @@ class ZwoCamera(Camera):
             "sensor_height_mm": 4.45,
             "sensor_width_mm": 7.84,
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",  # Verified via ZWO (CS-mount native thread with 12.5mm backfocus) - https://www.zwoastro.com/product/asi664mc/
             "type": "type_camera",
             "width": 2704,
         },

--- a/tests/unit/test_zwo_664mc_audit.py
+++ b/tests/unit/test_zwo_664mc_audit.py
@@ -1,0 +1,44 @@
+import unittest
+
+from pint import Quantity
+
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils.equipment import ConnectionType
+
+
+class TestZwoASI664MCAudit(unittest.TestCase):
+
+    def test_asi664mc_specs(self):
+        cam = ZwoCamera.ZWO_ASI_664MC()
+
+        # Mass: 126g
+        self.assertEqual(cam.mass.to("gram").magnitude, 126)
+
+        # Optical length / backfocus: 12.5mm
+        self.assertEqual(cam.optical_length.to("mm").magnitude, 12.5)
+        self.assertEqual(cam.backfocus, Quantity(12.5, "millimeter"))
+
+        # Connection thread: CS
+        self.assertEqual(cam.connection_type, ConnectionType.CS)
+
+        # Resolution: 2704 x 1536 (4.15MP)
+        self.assertEqual(cam.width, 2704)
+        self.assertEqual(cam.height, 1536)
+
+        # Sensor dimensions & pixel size: 2.9µm, 7.84mm x 4.45mm
+        self.assertEqual(cam.pixel_size().to("micrometer").magnitude, 2.9)
+        self.assertEqual(cam.sensor_width.to("mm").magnitude, 7.84)
+        self.assertEqual(cam.sensor_height.to("mm").magnitude, 4.45)
+
+        # Full well capacity: 38500 e-
+        self.assertEqual(cam.full_well, 38500)
+
+        # Read noise: 0.46 e-
+        self.assertEqual(cam.read_noise, 0.46)
+
+        # Peak Quantum Efficiency: 91%
+        self.assertEqual(cam.quantum_efficiency, 91)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited and verified ZWO ASI664MC camera specifications against official ZWO technical documentation. Corrected tside_thread from M42 to CS to match its native 12.5mm CS-mount backfocus housing, added source reference comments, and added unit test coverage in tests/unit/test_zwo_664mc_audit.py.

---
*PR created automatically by Jules for task [15013493467469298709](https://jules.google.com/task/15013493467469298709) started by @pozar87*