### PR TITLE
🔍 Optic: Data audit for Sky-Watcher Evostar 72ED

### DIFF
--- a/apts/opticalequipment/telescope/vendors/sky_watcher.py
+++ b/apts/opticalequipment/telescope/vendors/sky_watcher.py
@@ -376,10 +376,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via Sky-Watcher Global (2" dual-speed Crayford focuser visual back) - http://skywatcher.com/product/evostar-72ed/
+            "cside_thread": "2\"",  # Verified via Sky-Watcher Global (Includes 2" Crayford focuser with 2" visual back) - http://skywatcher.com/product/evostar-72ed/
             "focal_length_mm": 420,
-            "mass": 2000,  # Verified via Sky-Watcher Global (2.0 kg OTA Weight)
+            "mass": 2000,  # Verified via Sky-Watcher Global (2.0 kg tube weight with rings & dovetail) - http://skywatcher.com/product/evostar-72ed/
             "name": "Evostar 72ED",
             "optical_length": 0,
             "reversible": False,
@@ -392,10 +392,10 @@ class Sky_watcherTelescope(Telescope):
             "bf_role": "",
             "brand": "Sky-Watcher",
             "central_obstruction_mm": 0,
-            "cside_gender": "Male",
-            "cside_thread": "M48",
+            "cside_gender": "Female",  # Verified via OVL UK / First Light Optics (2" dual-speed Crayford focuser visual back) - https://www.firstlightoptics.com/telescopes-in-stock/skywatcher-evostar-72ed-ds-pro-ota.html
+            "cside_thread": "2\"",  # Verified via OVL UK / First Light Optics (Includes 2" Crayford focuser with 2" visual back) - https://www.firstlightoptics.com/telescopes-in-stock/skywatcher-evostar-72ed-ds-pro-ota.html
             "focal_length_mm": 420,
-            "mass": 1955,
+            "mass": 1955,  # Verified via OVL UK / First Light Optics (1.955 kg / 1955g OTA weight) - https://www.firstlightoptics.com/telescopes-in-stock/skywatcher-evostar-72ed-ds-pro-ota.html
             "name": "Evostar 72ED DS-Pro",
             "optical_length": 0,
             "reversible": False,

--- a/tests/unit/test_sky_watcher_evostar_72ed_audit.py
+++ b/tests/unit/test_sky_watcher_evostar_72ed_audit.py
@@ -1,0 +1,35 @@
+import unittest
+
+from apts.opticalequipment.telescope.enums import TelescopeType
+from apts.opticalequipment.telescope.vendors.sky_watcher import Sky_watcherTelescope
+from apts.utils import ConnectionType, Gender
+
+
+class TestSkyWatcherEvostar72EDAudit(unittest.TestCase):
+    def test_evostar_72ed_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_72ED()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 72ED")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 72)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 420)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 5.833333333333333, places=2)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 2000)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+    def test_evostar_72ed_ds_pro_specs(self):
+        scope = Sky_watcherTelescope.Sky_Watcher_Evostar_72ED_DS_Pro()
+        self.assertEqual(scope.get_vendor(), "Sky-Watcher Evostar 72ED DS-Pro")
+        self.assertEqual(scope.aperture.to('mm').magnitude, 72)
+        self.assertEqual(scope.focal_length.to('mm').magnitude, 420)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 5.833333333333333, places=2)
+        self.assertEqual(scope.central_obstruction.to('mm').magnitude, 0)
+        self.assertEqual(scope.mass.to('gram').magnitude, 1955)
+        self.assertEqual(scope.connection_type, ConnectionType.F_2)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+        self.assertEqual(scope.telescope_type, TelescopeType.REFRACTOR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🔍 Optic: Data audit for Sky-Watcher Evostar 72ED

💡 Fix: Corrected connection thread and gender for Sky-Watcher Evostar 72ED and Evostar 72ED DS-Pro from male M48 to 2" female visual back (reflecting native 2" dual-speed Crayford focuser).
🎯 Source: Reference to official Sky-Watcher Global product page and OVL UK technical documentation.

---
*PR created automatically by Jules for task [17675440469696816343](https://jules.google.com/task/17675440469696816343) started by @pozar87*