### PR TITLE
Fix finder chart plot alignment and expand multilingual event guidelines

### DIFF
--- a/apts/events/event.py
+++ b/apts/events/event.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -7,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from apts.place import Place
 
+logger = logging.getLogger(__name__)
 utc = timezone.utc
 
 
@@ -55,27 +57,29 @@ def get_sky_brightness(sun_alt_deg: float | None, moon_alt_deg: float | None = N
 
 def get_direction_data(azimuth_deg: float | None) -> DirectionData:
     """Converts an azimuth in degrees into cardinal direction code and description."""
+    from apts.i18n import gettext_
+
     if azimuth_deg is None or math.isnan(azimuth_deg):
-        return DirectionData(code="E", name="Look East", azimuth_deg=90.0)
+        return DirectionData(code="E", name=gettext_("Look East"), azimuth_deg=90.0)
 
     az = float(azimuth_deg) % 360.0
 
     directions = [
-        (11.25, 33.75, "NNE", "Look North-Northeast"),
-        (33.75, 56.25, "NE", "Look Northeast"),
-        (56.25, 78.75, "ENE", "Look East-Northeast"),
-        (78.75, 101.25, "E", "Look East"),
-        (101.25, 123.75, "ESE", "Look East-Southeast"),
-        (123.75, 146.25, "SE", "Look Southeast"),
-        (146.25, 168.75, "SSE", "Look South-Southeast"),
-        (168.75, 191.25, "S", "Look South"),
-        (191.25, 213.75, "SSW", "Look South-Southwest"),
-        (213.75, 236.25, "SW", "Look Southwest"),
-        (236.25, 258.75, "WSW", "Look West-Southwest"),
-        (258.75, 281.25, "W", "Look West"),
-        (281.25, 303.75, "WNW", "Look West-Northwest"),
-        (303.75, 326.25, "NW", "Look Northwest"),
-        (326.25, 348.75, "NNW", "Look North-Northwest"),
+        (11.25, 33.75, "NNE", gettext_("Look North-Northeast")),
+        (33.75, 56.25, "NE", gettext_("Look Northeast")),
+        (56.25, 78.75, "ENE", gettext_("Look East-Northeast")),
+        (78.75, 101.25, "E", gettext_("Look East")),
+        (101.25, 123.75, "ESE", gettext_("Look East-Southeast")),
+        (123.75, 146.25, "SE", gettext_("Look Southeast")),
+        (146.25, 168.75, "SSE", gettext_("Look South-Southeast")),
+        (168.75, 191.25, "S", gettext_("Look South")),
+        (191.25, 213.75, "SSW", gettext_("Look South-Southwest")),
+        (213.75, 236.25, "SW", gettext_("Look Southwest")),
+        (236.25, 258.75, "WSW", gettext_("Look West-Southwest")),
+        (258.75, 281.25, "W", gettext_("Look West")),
+        (281.25, 303.75, "WNW", gettext_("Look West-Northwest")),
+        (303.75, 326.25, "NW", gettext_("Look Northwest")),
+        (326.25, 348.75, "NNW", gettext_("Look North-Northwest")),
     ]
 
     for low, high, code, name in directions:
@@ -83,7 +87,7 @@ def get_direction_data(azimuth_deg: float | None) -> DirectionData:
             return DirectionData(code=code, name=name, azimuth_deg=az)
 
     # Wrap-around for North (348.75 to 360 / 0 to 11.25)
-    return DirectionData(code="N", name="Look North", azimuth_deg=az)
+    return DirectionData(code="N", name=gettext_("Look North"), azimuth_deg=az)
 
 
 CATEGORY_RULES = [
@@ -127,68 +131,113 @@ def get_event_category(event_name: str, event_type: str = "") -> str:
 
 def get_step_by_step_guide(category: str, title: str = "", objects: list[str] | None = None) -> list[str]:
     """Generates step-by-step observational guide instructions for an event."""
-    cat = category.upper()
-    obj_str = " or ".join(objects) if objects else "target"
+    from apts.i18n import gettext_
 
-    if cat == "OCCULTATION":
+    cat = category.upper()
+    title_lower = str(title).lower()
+    obj_str = " or ".join([gettext_(o) for o in objects]) if objects else gettext_("target")
+
+    if cat in ("FLYBY", "ISS_FLYBY", "TIANGONG_FLYBY") or "flyby" in title_lower or "iss" in title_lower:
         return [
-            "Verify that the occultation is visible from your location.",
-            "Arrive and set up equipment at least 15–30 minutes before the event.",
-            "Focus carefully before the occultation begins.",
-            "Watch continuously near the predicted disappearance time.",
-            "If possible, record the event with a camera or video setup.",
+            gettext_("Find an open viewing location with a clear view of the sky in the pass direction."),
+            gettext_("Check the exact rise time and direction before heading outside."),
+            gettext_("Watch the horizon for a bright, steady, non-blinking point of light moving across the sky."),
+            gettext_("Track the satellite visually with naked eye or wide-field binoculars."),
+            gettext_("Note the time and peak altitude as it passes overhead."),
+        ]
+    elif cat in ("ROCKET_LAUNCH", "SPACE_LAUNCH") or "launch" in title_lower or "rocket" in title_lower:
+        return [
+            gettext_("Confirm the launch schedule and trajectory azimuth prior to liftoff."),
+            gettext_("Find an elevated or unobstructed location facing the launch direction."),
+            gettext_("Look low near the horizon at T+2 to T+3 minutes for the rising exhaust plume."),
+            gettext_("Use binoculars to spot stage separation or twilight expansion effects."),
+        ]
+    elif cat == "METEOR_SHOWER" or "shower" in title_lower or "meteor" in title_lower:
+        return [
+            gettext_("Choose a dark location away from city lights."),
+            gettext_("Allow 20–30 minutes for your eyes to fully adapt to darkness."),
+            gettext_("Lie back comfortably on a reclining chair facing the radiant direction."),
+            gettext_("Observe with the naked eye for the widest field of view."),
+            gettext_("Keep warm and count the number of meteors per hour."),
+        ]
+    elif cat == "OCCULTATION":
+        return [
+            gettext_("Verify that the occultation is visible from your location."),
+            gettext_("Arrive and set up equipment at least 15–30 minutes before the event."),
+            gettext_("Focus carefully before the occultation begins."),
+            gettext_("Watch continuously near the predicted disappearance time."),
+            gettext_("If possible, record the event with a camera or video setup."),
         ]
     elif cat == "CONJUNCTION":
         return [
-            "Find an observing location with an unobstructed horizon in the specified direction.",
-            "Set up binoculars or a telescope 15–20 minutes before peak alignment.",
-            "Locate the brighter object first, then scan near it to find the companion.",
-            "Observe both objects together within the same field of view.",
-            "Capture wide-field photographs during twilight or dark sky hours.",
+            gettext_("Find an observing location with an unobstructed horizon in the specified direction."),
+            gettext_("Set up binoculars or a telescope 15–20 minutes before peak alignment."),
+            gettext_("Locate the brighter object first, then scan near it to find the companion."),
+            gettext_("Observe both objects together within the same field of view."),
+            gettext_("Capture wide-field photographs during twilight or dark sky hours."),
         ]
-    elif cat == "METEOR_SHOWER":
+    elif cat in ("PLANET_ALIGNMENT", "CELESTIAL_CONFIGURATION") or "alignment" in title_lower:
         return [
-            "Choose a dark location away from city lights.",
-            "Allow 20–30 minutes for your eyes to fully adapt to darkness.",
-            "Lie back comfortably on a reclining chair facing the radiant direction.",
-            "Observe with the naked eye for the widest field of view.",
-            "Keep warm and count the number of meteors per hour.",
+            gettext_("Find a site with a clear view spanning East to West along the ecliptic arc."),
+            gettext_("Begin observing during early twilight as the brightest planets emerge."),
+            gettext_("Scan along the ecliptic line to identify all participating planets."),
+            gettext_("Use wide-angle camera gear or binoculars to capture the full parade."),
+        ]
+    elif "jovian" in cat.lower() or "jovian" in title_lower or "grs" in title_lower or "jupiter" in title_lower:
+        return [
+            gettext_("Set up a telescope with medium-to-high magnification (100x–200x)."),
+            gettext_("Allow your optical tube time to thermally stabilize outdoors."),
+            gettext_("Locate Jupiter and identify the equatorial dark cloud bands."),
+            gettext_("Observe the positions of the four Galilean moons (Io, Europa, Ganymede, Callisto)."),
+            gettext_("Look for moon shadow transits or the Great Red Spot during peak visibility."),
         ]
     elif cat == "SOLAR_ECLIPSE":
         return [
-            "Ensure you have ISO-certified solar viewing glasses or solar filters.",
-            "Inspect all solar filters for damage before looking at the Sun.",
-            "Set up your viewing area in advance with a clear line of sight.",
-            "Observe the progression of solar coverage safely.",
-            "Never look directly at the Sun without approved solar filtration.",
+            gettext_("Ensure you have ISO-certified solar viewing glasses or solar filters."),
+            gettext_("Inspect all solar filters for damage before looking at the Sun."),
+            gettext_("Set up your viewing area in advance with a clear line of sight."),
+            gettext_("Observe the progression of solar coverage safely."),
+            gettext_("Never look directly at the Sun without approved solar filtration."),
         ]
     elif cat == "LUNAR_ECLIPSE":
         return [
-            "Find a comfortable viewing spot with a clear view of the Moon.",
-            "No special eye protection is needed; binoculars or small telescopes enhance the view.",
-            "Observe the gradual darkening and copper-red color shift during totality.",
-            "Take long-exposure photographs as the Moon passes through Earth's umbra.",
+            gettext_("Find a comfortable viewing spot with a clear view of the Moon."),
+            gettext_("No special eye protection is needed; binoculars or small telescopes enhance the view."),
+            gettext_("Observe the gradual darkening and copper-red color shift during totality."),
+            gettext_("Take long-exposure photographs as the Moon passes through Earth's umbra."),
         ]
     elif cat == "OPPOSITION":
         return [
-            "Plan your observation around midnight when the planet reaches its highest altitude.",
-            "Use a telescope with moderate to high magnification for fine surface details.",
-            "Allow your telescope to thermally acclimate to outdoor temperatures.",
-            "Observe during periods of steady atmospheric seeing.",
+            gettext_("Plan your observation around midnight when the planet reaches its highest altitude."),
+            gettext_("Use a telescope with moderate to high magnification for fine surface details."),
+            gettext_("Allow your telescope to thermally acclimate to outdoor temperatures."),
+            gettext_("Observe during periods of steady atmospheric seeing."),
         ]
     elif cat == "TRANSIT":
         return [
-            "Equip your optical setup with safe, dedicated solar filters.",
-            "Track the ingress and egress times of the transit carefully.",
-            "Use high magnification to resolve the silhouette against the solar disk.",
-            "Record timestamped images throughout the transit progression.",
+            gettext_("Equip your optical setup with safe, dedicated solar filters."),
+            gettext_("Track the ingress and egress times of the transit carefully."),
+            gettext_("Use high magnification to resolve the silhouette against the solar disk."),
+            gettext_("Record timestamped images throughout the transit progression."),
+        ]
+    elif cat in ("GREATEST_ELONGATION", "VENUS_GREAT_BRILLIANCY"):
+        return [
+            gettext_("Locate the planet low near the horizon in early morning or evening twilight."),
+            gettext_("Use binoculars or a small telescope to observe its crescent or gibbous phase."),
+            gettext_("Observe before sunrise or after sunset when contrast is optimal."),
+        ]
+    elif cat in ("MOON_PHASE", "SUPERMOON", "MOON_LIBRATION", "LUNAR_FEATURE"):
+        return [
+            gettext_("Choose a viewing spot with clear sky access toward the Moon."),
+            gettext_("Use binoculars or a telescope along the lunar terminator line for shadow details."),
+            gettext_("Observe prominent craters, mountain ranges, and maria surface features."),
         ]
     else:
         return [
-            "Check local weather and cloud cover prior to the event.",
-            f"Locate {obj_str} in the sky using cardinal directions and altitude.",
-            "Use appropriate optical aid (naked eye, binoculars, or telescope).",
-            "Observe near the predicted peak viewing time for the best view.",
+            gettext_("Check local weather and cloud cover prior to the event."),
+            gettext_("Locate {target} in the sky using cardinal directions and altitude.").format(target=obj_str),
+            gettext_("Use appropriate optical aid (naked eye, binoculars, or telescope)."),
+            gettext_("Observe near the predicted peak viewing time for the best view."),
         ]
 
 
@@ -201,26 +250,30 @@ def build_event_description(
     angular_separation: str | None = None,
 ) -> str:
     """Generates a narrative description for the event."""
-    sep_text = f" with an angular separation of {angular_separation}" if angular_separation else ""
+    from apts.i18n import gettext_
+
+    sep_text = f" {gettext_('with an angular separation of')} {angular_separation}" if angular_separation else ""
+    o1 = gettext_(objects[0]) if len(objects) >= 1 else gettext_("Target")
+    o2 = gettext_(objects[1]) if len(objects) >= 2 else gettext_("Companion")
+    loc = gettext_(location_name)
 
     if category == "OCCULTATION" and len(objects) >= 2:
-        return (
-            f"The {objects[0]} will pass directly in front of {objects[1]}, creating a lunar occultation "
-            f"visible from {location_name} at {datetime_utc_str}."
+        return gettext_("The {object1} will pass directly in front of {object2}, creating a lunar occultation visible from {location} at {time}.").format(
+            object1=o1, object2=o2, location=loc, time=datetime_utc_str
         )
     elif category == "CONJUNCTION" and len(objects) >= 2:
-        return (
-            f"{objects[0]} and {objects[1]} will share a close celestial conjunction{sep_text}, "
-            f"visible in the sky from {location_name}."
+        return gettext_("{object1} and {object2} will share a close celestial conjunction{separation}, visible in the sky from {location}.").format(
+            object1=o1, object2=o2, separation=sep_text, location=loc
         )
     elif category == "METEOR_SHOWER":
-        shower_name = objects[0] if objects else title
-        return (
-            f"Peak activity for the {shower_name} meteor shower, offering optimal viewing conditions "
-            f"from {location_name}."
+        shower_name = o1 if objects else title
+        return gettext_("Peak activity for the {shower} meteor shower, offering optimal viewing conditions from {location}.").format(
+            shower=shower_name, location=loc
         )
     else:
-        return f"{title} occurring on {datetime_utc_str}, visible from {location_name}."
+        return gettext_("{title} occurring on {time}, visible from {location}.").format(
+            title=title, time=datetime_utc_str, location=loc
+        )
 
 
 @dataclass
@@ -385,13 +438,20 @@ class Event:
         phase = self.extra_data.get("phase", 0.0)
         phase_frac = float(phase) if isinstance(phase, (int, float)) else 0.0
 
-        if place is not None and hasattr(place, "get_altitude") and (sun_alt is None):
+        if place is not None and hasattr(place, "get_altitude"):
             try:
                 t_sf = place.ts.utc(self.dt_utc.year, self.dt_utc.month, self.dt_utc.day, self.dt_utc.hour, self.dt_utc.minute, self.dt_utc.second)
-                sun_alt = place.get_altitude(place.sun, t_sf)
-                moon_alt = place.get_altitude(place.moon, t_sf)
-            except Exception:
-                pass
+                if sun_alt is None:
+                    sun_alt = place.get_altitude(place.sun, t_sf)
+                    moon_alt = place.get_altitude(place.moon, t_sf)
+                if (self.azimuth_deg is None or self.altitude_deg is None) and self.objects:
+                    alt_primary = place.get_altitude(self.objects[0], t_sf)
+                    az_primary = place.get_azimuth(self.objects[0], t_sf)
+                    if not math.isnan(alt_primary) and not math.isnan(az_primary):
+                        self.altitude_deg = float(alt_primary)
+                        self.azimuth_deg = float(az_primary)
+            except (ValueError, KeyError, AttributeError, TypeError) as e:
+                logger.debug(f"Could not resolve topocentric position for primary object: {e}")
 
         self.sky_brightness = get_sky_brightness(sun_alt, moon_alt, phase_frac)
 
@@ -402,10 +462,10 @@ class Event:
             self.direction = DirectionData(
                 code=direction.get("code", "E"),
                 name=direction.get("name", "Look East"),
-                azimuth_deg=float(direction.get("azimuth_deg", azimuth_deg if azimuth_deg is not None else 90.0)),
+                azimuth_deg=float(direction.get("azimuth_deg", self.azimuth_deg if self.azimuth_deg is not None else 90.0)),
             )
         else:
-            self.direction = get_direction_data(azimuth_deg)
+            self.direction = get_direction_data(self.azimuth_deg)
 
         # Handle Step-by-step guide
         if step_by_step_guide:

--- a/apts/locale/de/LC_MESSAGES/messages.po
+++ b/apts/locale/de/LC_MESSAGES/messages.po
@@ -1028,3 +1028,150 @@ msgstr "Seeing von %(seeing)s Bogensekunden überschreitet das Limit von %(max_s
 
 msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
 msgstr "Himmelshelligkeit von %(sqm)s mag/arcsec² unter dem Limit von %(min_sqm)s mag/arcsec²"
+
+msgid "Look East"
+msgstr "Blick nach Osten"
+
+msgid "Look North-Northeast"
+msgstr "Blick nach Nord-Nordost"
+
+msgid "Look Northeast"
+msgstr "Blick nach Nordost"
+
+msgid "Look East-Northeast"
+msgstr "Blick nach Ost-Nordost"
+
+msgid "Look East-Southeast"
+msgstr "Blick nach Ost-Südost"
+
+msgid "Look Southeast"
+msgstr "Blick nach Südost"
+
+msgid "Look South-Southeast"
+msgstr "Blick nach Süd-Südost"
+
+msgid "Look South"
+msgstr "Blick nach Süden"
+
+msgid "Look South-Southwest"
+msgstr "Blick nach Süd-Südwest"
+
+msgid "Look Southwest"
+msgstr "Blick nach Südwest"
+
+msgid "Look West-Southwest"
+msgstr "Blick nach West-Südwest"
+
+msgid "Look West"
+msgstr "Blick nach Westen"
+
+msgid "Look West-Northwest"
+msgstr "Blick nach West-Nordwest"
+
+msgid "Look Northwest"
+msgstr "Blick nach Nordwest"
+
+msgid "Look North-Northwest"
+msgstr "Blick nach Nord-Nordwest"
+
+msgid "Look North"
+msgstr "Blick nach Norden"
+
+msgid "Find an open viewing location with a clear view of the sky in the pass direction."
+msgstr "Suchen Sie einen offenen Beobachtungsort mit freier Sicht in Überflugsrichtung."
+
+msgid "Check the exact rise time and direction before heading outside."
+msgstr "Überprüfen Sie die genaue Aufgangszeit und Richtung, bevor Sie nach draußen gehen."
+
+msgid "Watch the horizon for a bright, steady, non-blinking point of light moving across the sky."
+msgstr "Beobachten Sie den Horizont nach einem hellen, stetigen Lichtpunkt, der sich bewegt."
+
+msgid "Track the satellite visually with naked eye or wide-field binoculars."
+msgstr "Verfolgen Sie den Satelliten mit bloßem Auge oder einem Weitfeld-Fernglas."
+
+msgid "Note the time and peak altitude as it passes overhead."
+msgstr "Notieren Sie die Zeit und die maximale Höhe beim Überflug."
+
+msgid "Confirm the launch schedule and trajectory azimuth prior to liftoff."
+msgstr "Bestätigen Sie den Startplan und den Trajektorien-Azimut vor dem Abheben."
+
+msgid "Find an elevated or unobstructed location facing the launch direction."
+msgstr "Finden Sie einen erhöhten oder freien Ort mit Blick in Startrichtung."
+
+msgid "Look low near the horizon at T+2 to T+3 minutes for the rising exhaust plume."
+msgstr "Suchen Sie bei T+2 bis T+3 Minuten tief am Horizont nach der Abgasfahne."
+
+msgid "Use binoculars to spot stage separation or twilight expansion effects."
+msgstr "Nutzen Sie ein Fernglas, um Stufentrennung oder Dämmerungseffekte zu erkennen."
+
+msgid "Find a site with a clear view spanning East to West along the ecliptic arc."
+msgstr "Finden Sie einen Ort mit freier Sicht von Ost nach West entlang der Ekliptik."
+
+msgid "Begin observing during early twilight as the brightest planets emerge."
+msgstr "Beginnen Sie die Beobachtung in der frühen Dämmerung, wenn die hellsten Planeten erscheinen."
+
+msgid "Scan along the ecliptic line to identify all participating planets."
+msgstr "Scannen Sie entlang der Ekliptiklinie, um alle Planeten zu identifizieren."
+
+msgid "Use wide-angle camera gear or binoculars to capture the full parade."
+msgstr "Verwenden Sie eine Weitwinkelkamera oder ein Fernglas, um die Parade festzuhalten."
+
+msgid "Set up a telescope with medium-to-high magnification (100x–200x)."
+msgstr "Bauen Sie ein Teleskop mit mittlerer bis hoher Vergrößerung auf (100x–200x)."
+
+msgid "Allow your optical tube time to thermally stabilize outdoors."
+msgstr "Lassen Sie dem Optiktubus Zeit, sich im Freien thermisch zu stabilisieren."
+
+msgid "Locate Jupiter and identify the equatorial dark cloud bands."
+msgstr "Finden Sie Jupiter und identifizieren Sie die dunklen Äquatorialbänder."
+
+msgid "Observe the positions of the four Galilean moons (Io, Europa, Ganymede, Callisto)."
+msgstr "Beobachten Sie die Positionen der vier Galileischen Monde (Io, Europa, Ganymed, Kallisto)."
+
+msgid "Look for moon shadow transits or the Great Red Spot during peak visibility."
+msgstr "Achten Sie auf Mondschattendurchgänge oder den Großen Roten Fleck."
+
+msgid "Locate the planet low near the horizon in early morning or evening twilight."
+msgstr "Suchen Sie den Planeten tief am Horizont in der Morgen- oder Abenddämmerung."
+
+msgid "Use binoculars or a small telescope to observe its crescent or gibbous phase."
+msgstr "Verwenden Sie ein Fernglas oder Teleskop, um die Sichel- oder Bauchphase zu beobachten."
+
+msgid "Observe before sunrise or after sunset when contrast is optimal."
+msgstr "Beobachten Sie vor Sonnenaufgang oder nach Sonnenuntergang bei optimalem Kontrast."
+
+msgid "Choose a viewing spot with clear sky access toward the Moon."
+msgstr "Wählen Sie einen Beobachtungsort mit freier Sicht auf den Mond."
+
+msgid "Use binoculars or a telescope along the lunar terminator line for shadow details."
+msgstr "Nutzen Sie ein Fernglas oder Teleskop entlang des Terminators für Schattendetails."
+
+msgid "Observe prominent craters, mountain ranges, and maria surface features."
+msgstr "Beobachten Sie prominente Krater, Gebirgszüge und Mondmeere."
+
+msgid "Locate {target} in the sky using cardinal directions and altitude."
+msgstr "Finden Sie {target} am Himmel mithilfe von Himmelsrichtungen und Höhe."
+
+msgid "with an angular separation of"
+msgstr "mit einem Winkelabstand von"
+
+msgid "The {object1} will pass directly in front of {object2}, creating a lunar occultation visible from {location} at {time}."
+msgstr "{object1} zieht direkt vor {object2} vorbei und erzeugt eine Okkultation, sichtbar von {location} um {time}."
+
+msgid "{object1} and {object2} will share a close celestial conjunction{separation}, visible in the sky from {location}."
+msgstr "{object1} und {object2} stehen in einer engen Konjunktion{separation}, sichtbar von {location}."
+
+msgid "Peak activity for the {shower} meteor shower, offering optimal viewing conditions from {location}."
+msgstr "Aktivitätsmaximum des Meteorstroms {shower}, mit optimalen Bedingungen von {location}."
+
+msgid "{title} occurring on {time}, visible from {location}."
+msgstr "{title} am {time}, sichtbar von {location}."
+
+msgid "target"
+msgstr "Zielobjekt"
+
+msgid "Target"
+msgstr "Zielobjekt"
+
+msgid "Companion"
+msgstr "Begleiter"

--- a/apts/locale/es/LC_MESSAGES/messages.po
+++ b/apts/locale/es/LC_MESSAGES/messages.po
@@ -1051,3 +1051,150 @@ msgstr "El seeing de %(seeing)s arcsec supera el límite de %(max_seeing)s arcse
 
 msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
 msgstr "Brillo del cielo de %(sqm)s mag/arcsec² por debajo del límite de %(min_sqm)s mag/arcsec²"
+
+msgid "Look East"
+msgstr "Mire hacia el Este"
+
+msgid "Look North-Northeast"
+msgstr "Mire hacia el Norte-Nordeste"
+
+msgid "Look Northeast"
+msgstr "Mire hacia el Nordeste"
+
+msgid "Look East-Northeast"
+msgstr "Mire hacia el Este-Nordeste"
+
+msgid "Look East-Southeast"
+msgstr "Mire hacia el Este-Sudeste"
+
+msgid "Look Southeast"
+msgstr "Mire hacia el Sudeste"
+
+msgid "Look South-Southeast"
+msgstr "Mire hacia el Sur-Sudeste"
+
+msgid "Look South"
+msgstr "Mire hacia el Sur"
+
+msgid "Look South-Southwest"
+msgstr "Mire hacia el Sur-Sudoeste"
+
+msgid "Look Southwest"
+msgstr "Mire hacia el Sudoeste"
+
+msgid "Look West-Southwest"
+msgstr "Mire hacia el Oeste-Sudoeste"
+
+msgid "Look West"
+msgstr "Mire hacia el Oeste"
+
+msgid "Look West-Northwest"
+msgstr "Mire hacia el Oeste-Noroeste"
+
+msgid "Look Northwest"
+msgstr "Mire hacia el Noroeste"
+
+msgid "Look North-Northwest"
+msgstr "Mire hacia el Norte-Noroeste"
+
+msgid "Look North"
+msgstr "Mire hacia el Norte"
+
+msgid "Find an open viewing location with a clear view of the sky in the pass direction."
+msgstr "Busque un lugar abierto con vista despejada al cielo en la dirección del paso."
+
+msgid "Check the exact rise time and direction before heading outside."
+msgstr "Verifique la hora exacta de salida y la dirección antes de salir."
+
+msgid "Watch the horizon for a bright, steady, non-blinking point of light moving across the sky."
+msgstr "Observe el horizonte buscando un punto de luz brillante y constante que se mueve."
+
+msgid "Track the satellite visually with naked eye or wide-field binoculars."
+msgstr "Siga el satélite a simple vista o con prismáticos de campo amplio."
+
+msgid "Note the time and peak altitude as it passes overhead."
+msgstr "Anote la hora y la altitud máxima a medida que pasa por encima."
+
+msgid "Confirm the launch schedule and trajectory azimuth prior to liftoff."
+msgstr "Confirme el horario del lanzamiento y el acimut de trayectoria antes del despegue."
+
+msgid "Find an elevated or unobstructed location facing the launch direction."
+msgstr "Encuentre un lugar elevado o despejado orientado hacia el lanzamiento."
+
+msgid "Look low near the horizon at T+2 to T+3 minutes for the rising exhaust plume."
+msgstr "Mire bajo cerca del horizonte a los T+2 o T+3 minutos para ver la estela."
+
+msgid "Use binoculars to spot stage separation or twilight expansion effects."
+msgstr "Use prismáticos para detectar la separación de etapas o efectos crepusculares."
+
+msgid "Find a site with a clear view spanning East to West along the ecliptic arc."
+msgstr "Busque un sitio con vista clara de Este a Oeste a lo largo de la eclíptica."
+
+msgid "Begin observing during early twilight as the brightest planets emerge."
+msgstr "Comience a observar en el crepúsculo temprano cuando emergen los planetas."
+
+msgid "Scan along the ecliptic line to identify all participating planets."
+msgstr "Escanee a lo largo de la línea eclíptica para identificar los planetas."
+
+msgid "Use wide-angle camera gear or binoculars to capture the full parade."
+msgstr "Use una cámara gran angular o prismáticos para capturar toda la alineación."
+
+msgid "Set up a telescope with medium-to-high magnification (100x–200x)."
+msgstr "Prepare un telescopio con aumento medio a alto (100x–200x)."
+
+msgid "Allow your optical tube time to thermally stabilize outdoors."
+msgstr "Permita que el tubo óptico se estabilice térmicamente en el exterior."
+
+msgid "Locate Jupiter and identify the equatorial dark cloud bands."
+msgstr "Localice a Júpiter e identifique las bandas oscuras ecuatoriales."
+
+msgid "Observe the positions of the four Galilean moons (Io, Europa, Ganymede, Callisto)."
+msgstr "Observe las posiciones de las cuatro lunas galileanas (Ío, Europa, Ganímedes, Calisto)."
+
+msgid "Look for moon shadow transits or the Great Red Spot during peak visibility."
+msgstr "Busque tránsitos de sombras de lunas o la Gran Mancha Roja."
+
+msgid "Locate the planet low near the horizon in early morning or evening twilight."
+msgstr "Localice el planeta bajo cerca del horizonte en el crepúsculo matutino o vespertino."
+
+msgid "Use binoculars or a small telescope to observe its crescent or gibbous phase."
+msgstr "Use prismáticos o un telescopio pequeño para observar su fase creciente o gibosa."
+
+msgid "Observe before sunrise or after sunset when contrast is optimal."
+msgstr "Observe antes del amanecer o después del atardecer para un contraste óptimo."
+
+msgid "Choose a viewing spot with clear sky access toward the Moon."
+msgstr "Elija un punto de observación con vista despejada hacia la Luna."
+
+msgid "Use binoculars or a telescope along the lunar terminator line for shadow details."
+msgstr "Use prismáticos o un telescopio a lo largo del terminador lunar para ver detalles."
+
+msgid "Observe prominent craters, mountain ranges, and maria surface features."
+msgstr "Observe cráteres destacados, cadenas montañosas y mares lunares."
+
+msgid "Locate {target} in the sky using cardinal directions and altitude."
+msgstr "Localice {target} en el cielo usando los puntos cardinales y la altitud."
+
+msgid "with an angular separation of"
+msgstr "con una separación angular de"
+
+msgid "The {object1} will pass directly in front of {object2}, creating a lunar occultation visible from {location} at {time}."
+msgstr "{object1} pasará directamente delante de {object2}, creando una ocultación visible desde {location} a las {time}."
+
+msgid "{object1} and {object2} will share a close celestial conjunction{separation}, visible in the sky from {location}."
+msgstr "{object1} y {object2} compartirán una estrecha conjunción{separation}, visible desde {location}."
+
+msgid "Peak activity for the {shower} meteor shower, offering optimal viewing conditions from {location}."
+msgstr "Pico de actividad de la lluvia de meteoros {shower}, con condiciones óptimas desde {location}."
+
+msgid "{title} occurring on {time}, visible from {location}."
+msgstr "{title} el {time}, visible desde {location}."
+
+msgid "target"
+msgstr "objeto destino"
+
+msgid "Target"
+msgstr "Objeto destino"
+
+msgid "Companion"
+msgstr "Compañero"

--- a/apts/locale/pl/LC_MESSAGES/messages.po
+++ b/apts/locale/pl/LC_MESSAGES/messages.po
@@ -1056,3 +1056,150 @@ msgstr "Seeing %(seeing)s arcsec przekracza limit %(max_seeing)s arcsec"
 
 msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
 msgstr "Jasność nieba %(sqm)s mag/arcsec² poniżej limitu %(min_sqm)s mag/arcsec²"
+
+msgid "Look East"
+msgstr "Patrz na wschód"
+
+msgid "Look North-Northeast"
+msgstr "Patrz na północny północny wschód"
+
+msgid "Look Northeast"
+msgstr "Patrz na północny wschód"
+
+msgid "Look East-Northeast"
+msgstr "Patrz na wschodni północny wschód"
+
+msgid "Look East-Southeast"
+msgstr "Patrz na wschodni południowy wschód"
+
+msgid "Look Southeast"
+msgstr "Patrz na południowy wschód"
+
+msgid "Look South-Southeast"
+msgstr "Patrz na południowy południowy wschód"
+
+msgid "Look South"
+msgstr "Patrz na południe"
+
+msgid "Look South-Southwest"
+msgstr "Patrz na południowy południowy zachód"
+
+msgid "Look Southwest"
+msgstr "Patrz na południowy zachód"
+
+msgid "Look West-Southwest"
+msgstr "Patrz na zachodni południowy zachód"
+
+msgid "Look West"
+msgstr "Patrz na zachód"
+
+msgid "Look West-Northwest"
+msgstr "Patrz na zachodni północny zachód"
+
+msgid "Look Northwest"
+msgstr "Patrz na północny zachód"
+
+msgid "Look North-Northwest"
+msgstr "Patrz na północny północny zachód"
+
+msgid "Look North"
+msgstr "Patrz na północ"
+
+msgid "Find an open viewing location with a clear view of the sky in the pass direction."
+msgstr "Znajdź otwarte miejsce z czystym widokiem na niebo w kierunku przelotu."
+
+msgid "Check the exact rise time and direction before heading outside."
+msgstr "Sprawdź dokładny czas wschodu i kierunek przed wyjściem na zewnątrz."
+
+msgid "Watch the horizon for a bright, steady, non-blinking point of light moving across the sky."
+msgstr "Obserwuj horyzont w poszukiwaniu jasnego, stałego punktu światła poruszającego się po niebie."
+
+msgid "Track the satellite visually with naked eye or wide-field binoculars."
+msgstr "Śledź satelitę gołym okiem lub lornetką o szerokim polu widzenia."
+
+msgid "Note the time and peak altitude as it passes overhead."
+msgstr "Zanotuj czas i maksymalną wysokość podczas przelotu nad głową."
+
+msgid "Confirm the launch schedule and trajectory azimuth prior to liftoff."
+msgstr "Potwierdź harmonogram startu i azymut trajektorii przed startem."
+
+msgid "Find an elevated or unobstructed location facing the launch direction."
+msgstr "Znajdź wzniesienie lub odsłonięte miejsce skierowane w stronę startu."
+
+msgid "Look low near the horizon at T+2 to T+3 minutes for the rising exhaust plume."
+msgstr "Spoglądaj nisko nad horyzont w czasie T+2 do T+3 minut, wypatrując smug spalin."
+
+msgid "Use binoculars to spot stage separation or twilight expansion effects."
+msgstr "Użyj lornetki, aby dostrzec rozdzielenie stopni lub efekty rozpraszania w zmierzchu."
+
+msgid "Find a site with a clear view spanning East to West along the ecliptic arc."
+msgstr "Znajdź miejsce z czystym widokiem od wschodu do zachodu wzdłuż ekliptyki."
+
+msgid "Begin observing during early twilight as the brightest planets emerge."
+msgstr "Rozpocznij obserwacje we wczesnym zmierzchu, gdy pojawiają się najjaśniejsze planety."
+
+msgid "Scan along the ecliptic line to identify all participating planets."
+msgstr "Przeszukuj linię ekliptyki, aby zidentyfikować wszystkie widoczne planety."
+
+msgid "Use wide-angle camera gear or binoculars to capture the full parade."
+msgstr "Użyj aparatu szerokokątnego lub lornetki, aby uwiecznić pełną paradę planet."
+
+msgid "Set up a telescope with medium-to-high magnification (100x–200x)."
+msgstr "Ustaw teleskop z średnim lub dużym powiększeniem (100x–200x)."
+
+msgid "Allow your optical tube time to thermally stabilize outdoors."
+msgstr "Pozwól tubie optycznej na schłodzenie i stabilizację termiczną."
+
+msgid "Locate Jupiter and identify the equatorial dark cloud bands."
+msgstr "Zlokalizuj Jowisza i zidentyfikuj równikowe pasy chmur."
+
+msgid "Observe the positions of the four Galilean moons (Io, Europa, Ganymede, Callisto)."
+msgstr "Obserwuj pozycje czterech księżyców galileuszowych (Io, Europa, Ganimedes, Kalisto)."
+
+msgid "Look for moon shadow transits or the Great Red Spot during peak visibility."
+msgstr "Wypatruj tranzytów cieni księżyców lub Wielkiej Czerwonej Plamy w momencie najlepszej widoczności."
+
+msgid "Locate the planet low near the horizon in early morning or evening twilight."
+msgstr "Zlokalizuj planetę nisko nad horyzontem we wczesnym świcie lub zmierzchu."
+
+msgid "Use binoculars or a small telescope to observe its crescent or gibbous phase."
+msgstr "Użyj lornetki lub małego teleskopu, aby zaobserwować fazę sierpa lub garbu."
+
+msgid "Observe before sunrise or after sunset when contrast is optimal."
+msgstr "Obserwuj przed wschodem lub po zachodzie słońca, gdy kontrast jest optymalny."
+
+msgid "Choose a viewing spot with clear sky access toward the Moon."
+msgstr "Wybierz miejsce z czystym widokiem na Księżyc."
+
+msgid "Use binoculars or a telescope along the lunar terminator line for shadow details."
+msgstr "Użyj lornetki lub teleskopu wzdłuż linii terminatora, aby zobaczyć szczegóły cieni."
+
+msgid "Observe prominent craters, mountain ranges, and maria surface features."
+msgstr "Obserwuj kratery, pasma górskie oraz morza księżycowe."
+
+msgid "Locate {target} in the sky using cardinal directions and altitude."
+msgstr "Zlokalizuj {target} na niebie za pomocą kierunków świata i wysokości."
+
+msgid "with an angular separation of"
+msgstr "w odległości kątowej"
+
+msgid "The {object1} will pass directly in front of {object2}, creating a lunar occultation visible from {location} at {time}."
+msgstr "{object1} przejdzie bezpośrednio przed {object2}, tworząc zakrycie widoczne z {location} o {time}."
+
+msgid "{object1} and {object2} will share a close celestial conjunction{separation}, visible in the sky from {location}."
+msgstr "{object1} i {object2} znajdą się w bliskiej koniunkcji{separation}, widocznej z {location}."
+
+msgid "Peak activity for the {shower} meteor shower, offering optimal viewing conditions from {location}."
+msgstr "Maksimum roju meteorów {shower}, oferujące optymalne warunki obserwacyjne z {location}."
+
+msgid "{title} occurring on {time}, visible from {location}."
+msgstr "{title} w dniu {time}, widoczne z {location}."
+
+msgid "target"
+msgstr "obiekt docelowy"
+
+msgid "Target"
+msgstr "Obiekt docelowy"
+
+msgid "Companion"
+msgstr "Towarzysz"

--- a/apts/locale/pt/LC_MESSAGES/messages.po
+++ b/apts/locale/pt/LC_MESSAGES/messages.po
@@ -1051,3 +1051,150 @@ msgstr "O seeing de %(seeing)s arcsec excede o limite de %(max_seeing)s arcsec"
 
 msgid "Sky brightness %(sqm)s mag/arcsec² below limit of %(min_sqm)s mag/arcsec²"
 msgstr "O brilho do céu de %(sqm)s mag/arcsec² está abaixo do limite de %(min_sqm)s mag/arcsec²"
+
+msgid "Look East"
+msgstr "Olhe para Este"
+
+msgid "Look North-Northeast"
+msgstr "Olhe para Norte-Nordeste"
+
+msgid "Look Northeast"
+msgstr "Olhe para Nordeste"
+
+msgid "Look East-Northeast"
+msgstr "Olhe para Este-Nordeste"
+
+msgid "Look East-Southeast"
+msgstr "Olhe para Este-Sudeste"
+
+msgid "Look Southeast"
+msgstr "Olhe para Sudeste"
+
+msgid "Look South-Southeast"
+msgstr "Olhe para Sul-Sudeste"
+
+msgid "Look South"
+msgstr "Olhe para Sul"
+
+msgid "Look South-Southwest"
+msgstr "Olhe para Sul-Sudoeste"
+
+msgid "Look Southwest"
+msgstr "Olhe para Sudoeste"
+
+msgid "Look West-Southwest"
+msgstr "Olhe para Oeste-Sudoeste"
+
+msgid "Look West"
+msgstr "Olhe para Oeste"
+
+msgid "Look West-Northwest"
+msgstr "Olhe para Oeste-Noroeste"
+
+msgid "Look Northwest"
+msgstr "Olhe para Noroeste"
+
+msgid "Look North-Northwest"
+msgstr "Olhe para Norte-Noroeste"
+
+msgid "Look North"
+msgstr "Olhe para Norte"
+
+msgid "Find an open viewing location with a clear view of the sky in the pass direction."
+msgstr "Encontre um local aberto com vista clara do céu na direção da passagem."
+
+msgid "Check the exact rise time and direction before heading outside."
+msgstr "Verifique a hora exata do nascente e a direção antes de sair."
+
+msgid "Watch the horizon for a bright, steady, non-blinking point of light moving across the sky."
+msgstr "Observe o horizonte à procura de um ponto de luz brilhante e constante a mover-se."
+
+msgid "Track the satellite visually with naked eye or wide-field binoculars."
+msgstr "Siga o satélite a olho nu ou com binóculos de amplo campo."
+
+msgid "Note the time and peak altitude as it passes overhead."
+msgstr "Anote a hora e a altitude máxima à medida que passa por cima."
+
+msgid "Confirm the launch schedule and trajectory azimuth prior to liftoff."
+msgstr "Confirme o horário de lançamento e o azimute da trajetória antes da descolagem."
+
+msgid "Find an elevated or unobstructed location facing the launch direction."
+msgstr "Encontre um local elevado ou desimpedido voltado para a direção de lançamento."
+
+msgid "Look low near the horizon at T+2 to T+3 minutes for the rising exhaust plume."
+msgstr "Olhe baixo perto do horizonte aos T+2 a T+3 minutos para ver a pluma de exaustão."
+
+msgid "Use binoculars to spot stage separation or twilight expansion effects."
+msgstr "Use binóculos para detetar a separação de estágios ou efeitos crepusculares."
+
+msgid "Find a site with a clear view spanning East to West along the ecliptic arc."
+msgstr "Encontre um local com vista clara de Este a Oeste ao longo da eclíptica."
+
+msgid "Begin observing during early twilight as the brightest planets emerge."
+msgstr "Comece a observar durante o crepúsculo inicial quando os planetas surgem."
+
+msgid "Scan along the ecliptic line to identify all participating planets."
+msgstr "Percorra a linha da eclíptica para identificar todos os planetas."
+
+msgid "Use wide-angle camera gear or binoculars to capture the full parade."
+msgstr "Use uma câmara grande angular ou binóculos para capturar o alinhamento."
+
+msgid "Set up a telescope with medium-to-high magnification (100x–200x)."
+msgstr "Prepare um telescópio com ampliação média a alta (100x–200x)."
+
+msgid "Allow your optical tube time to thermally stabilize outdoors."
+msgstr "Permita que o tubo ótico estabilize termicamente no exterior."
+
+msgid "Locate Jupiter and identify the equatorial dark cloud bands."
+msgstr "Localize Júpiter e identifique as faixas escuras equatoriais."
+
+msgid "Observe the positions of the four Galilean moons (Io, Europa, Ganymede, Callisto)."
+msgstr "Observe as posições das quatro luas galileanas (Io, Europa, Ganimedes, Calisto)."
+
+msgid "Look for moon shadow transits or the Great Red Spot during peak visibility."
+msgstr "Procure trânsitos de sombras das luas ou a Grande Mancha Vermelha."
+
+msgid "Locate the planet low near the horizon in early morning or evening twilight."
+msgstr "Localize o planeta baixo perto do horizonte no crepúsculo matutino ou vespertino."
+
+msgid "Use binoculars or a small telescope to observe its crescent or gibbous phase."
+msgstr "Use binóculos ou um pequeno telescópio para observar a sua fase crescente ou gibosa."
+
+msgid "Observe before sunrise or after sunset when contrast is optimal."
+msgstr "Observe antes do nascer ou após o pôr do sol para um contraste ideal."
+
+msgid "Choose a viewing spot with clear sky access toward the Moon."
+msgstr "Escolha um local de observação com vista clara para a Lua."
+
+msgid "Use binoculars or a telescope along the lunar terminator line for shadow details."
+msgstr "Use binóculos ou um telescópio ao longo do terminador lunar para ver detalhes."
+
+msgid "Observe prominent craters, mountain ranges, and maria surface features."
+msgstr "Observe crateras proeminentes, cadeias de montanhas e mares lunares."
+
+msgid "Locate {target} in the sky using cardinal directions and altitude."
+msgstr "Localize {target} no céu usando os pontos cardeais e a altitude."
+
+msgid "with an angular separation of"
+msgstr "com uma separação angular de"
+
+msgid "The {object1} will pass directly in front of {object2}, creating a lunar occultation visible from {location} at {time}."
+msgstr "{object1} passará diretamente à frente de {object2}, criando uma ocultação visível de {location} às {time}."
+
+msgid "{object1} and {object2} will share a close celestial conjunction{separation}, visible in the sky from {location}."
+msgstr "{object1} e {object2} partilharão uma conjunção próxima{separation}, visível de {location}."
+
+msgid "Peak activity for the {shower} meteor shower, offering optimal viewing conditions from {location}."
+msgstr "Pico de atividade da chuva de meteoros {shower}, oferecendo condições ideais de {location}."
+
+msgid "{title} occurring on {time}, visible from {location}."
+msgstr "{title} a {time}, visível de {location}."
+
+msgid "target"
+msgstr "objeto de destino"
+
+msgid "Target"
+msgstr "Objeto de destino"
+
+msgid "Companion"
+msgstr "Companheiro"

--- a/apts/visualization/finder_chart.py
+++ b/apts/visualization/finder_chart.py
@@ -2,7 +2,7 @@ import io
 import logging
 import math
 from datetime import timezone
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -261,7 +261,7 @@ def _plot_background_stars(
     from apts.catalogs.stars import get_bright_stars_raw
 
     p1_az, p1_alt = p1_pos
-    p2_az, p2_alt = p2_pos
+    p2_az, p2_alt = p2_pos if p2_pos is not None else (None, None)
 
     place = getattr(event_obj, "place", None)
     plotted_real = False
@@ -307,7 +307,7 @@ def _plot_background_stars(
                         zorder=6,
                     )
             plotted_real = True
-        except Exception as e:
+        except (ValueError, KeyError, AttributeError, TypeError, RuntimeError) as e:
             logger.debug(f"Failed to plot real background stars: {e}")
 
     if not plotted_real:
@@ -358,56 +358,321 @@ def _draw_single_object(
     )
 
 
-def _resolve_target_coordinates(
-    event_obj: "Event",
+def _draw_satellite_flyby_trail(
+    ax: plt.Axes,
     center_az: float,
     center_alt: float,
-    sep_deg: float,
-) -> tuple[tuple[float, float], tuple[float, float] | None]:
-    """Calculates topocentric Az/Alt for primary and secondary targets."""
+    event_obj: "Event",
+    theme: dict,
+):
+    """Renders a satellite flyby trajectory trail across the sky with arrows and peak marker."""
+    az_start, alt_start = center_az - 14.0, max(2.0, center_alt - 15.0)
+    az_peak, alt_peak = center_az, center_alt
+    az_end, alt_end = center_az + 14.0, max(2.0, center_alt - 12.0)
+
+    t_vals = np.linspace(0, 1, 100)
+    az_curve = (1 - t_vals) ** 2 * az_start + 2 * (1 - t_vals) * t_vals * az_peak + t_vals ** 2 * az_end
+    alt_curve = (1 - t_vals) ** 2 * alt_start + 2 * (1 - t_vals) * t_vals * alt_peak + t_vals ** 2 * alt_end
+
+    ax.plot(az_curve, alt_curve, color=theme["target_primary"], linewidth=4.0, alpha=0.3, zorder=10)
+    ax.plot(az_curve, alt_curve, color="#38BDF8", linestyle="-", linewidth=2.0, zorder=11)
+
+    for frac in (0.3, 0.7):
+        idx = int(frac * 100)
+        ax.annotate(
+            "",
+            xy=(az_curve[idx + 1], alt_curve[idx + 1]),
+            xytext=(az_curve[idx], alt_curve[idx]),
+            arrowprops={"arrowstyle": "->", "color": "#FACC15", "lw": 2},
+            zorder=12,
+        )
+
+    ax.scatter([az_start, az_end], [alt_start, alt_end], s=40, color=theme["text_sub"], zorder=12)
+    ax.text(az_start, alt_start - 1.5, "Rise", color=theme["text_sub"], fontsize=9, ha="center", zorder=12)
+    ax.text(az_end, alt_end - 1.5, "Set", color=theme["text_sub"], fontsize=9, ha="center", zorder=12)
+
+    ax.scatter(az_peak, alt_peak, s=160, color="#FACC15", edgecolors="#FFFFFF", linewidth=1.5, zorder=14)
+    ax.scatter(az_peak, alt_peak, s=400, color="#FACC15", alpha=0.25, zorder=13)
+    sat_name = event_obj.objects[0] if event_obj.objects else "ISS"
+    ax.text(az_peak, alt_peak + 1.8, f"{sat_name} Peak", color=theme["text_main"], fontsize=12, fontweight="bold", ha="center", zorder=15)
+
+
+def _draw_meteor_shower_radiant(
+    ax: plt.Axes,
+    center_az: float,
+    center_alt: float,
+    event_obj: "Event",
+    theme: dict,
+):
+    """Renders a meteor shower radiant point with radiating shooting star streaks."""
+    shower_name = event_obj.objects[0] if event_obj.objects else "Meteor Shower"
+
+    ax.scatter(center_az, center_alt, s=500, facecolors="none", edgecolors="#FACC15", linewidth=1.5, alpha=0.8, zorder=11)
+    ax.scatter(center_az, center_alt, s=200, facecolors="none", edgecolors="#F87171", linewidth=1.2, alpha=0.9, zorder=12)
+    ax.scatter(center_az, center_alt, s=50, color="#FACC15", zorder=13)
+
+    angles = np.array([20, 65, 110, 155, 205, 245, 290, 335])
+    np.random.seed(int(center_az * 10) % 1000)
+
+    for angle_deg in angles:
+        rad = np.radians(angle_deg)
+        dist_start = np.random.uniform(2.5, 4.0)
+        dist_len = np.random.uniform(5.0, 9.0)
+
+        x0 = center_az + dist_start * np.cos(rad)
+        y0 = center_alt + dist_start * np.sin(rad)
+        x1 = center_az + (dist_start + dist_len) * np.cos(rad)
+        y1 = center_alt + (dist_start + dist_len) * np.sin(rad)
+
+        if y1 > 0.5:
+            ax.plot([x0, x1], [y0, y1], color="#FDE047", linewidth=1.8, alpha=0.85, zorder=10)
+            ax.plot([x0, x1], [y0, y1], color="#FFFFFF", linewidth=0.8, alpha=0.95, zorder=11)
+            ax.scatter(x1, y1, s=15, color="#F87171", alpha=0.9, zorder=12)
+
+    ax.text(center_az, center_alt + 2.2, f"{shower_name} Radiant", color=theme["text_main"], fontsize=12, fontweight="bold", ha="center", zorder=15)
+
+
+def _draw_jovian_system(
+    ax: plt.Axes,
+    center_az: float,
+    center_alt: float,
+    event_obj: "Event",
+    theme: dict,
+):
+    """Renders Jupiter with equatorial cloud bands, Galilean Moons, and optional GRS marker."""
+    jup_disk = patches.Circle((center_az, center_alt), radius=1.0, facecolor="#EAB308", edgecolor="#FACC15", linewidth=1.2, zorder=12)
+    ax.add_patch(jup_disk)
+
+    band1 = patches.Rectangle((center_az - 0.95, center_alt + 0.25), 1.9, 0.25, facecolor="#9A3412", alpha=0.7, zorder=13)
+    band2 = patches.Rectangle((center_az - 0.95, center_alt - 0.50), 1.9, 0.25, facecolor="#9A3412", alpha=0.7, zorder=13)
+    ax.add_patch(band1)
+    ax.add_patch(band2)
+
+    title_lower = str(event_obj.title).lower()
+    if "grs" in title_lower or "red spot" in title_lower:
+        grs = patches.Ellipse((center_az + 0.35, center_alt - 0.38), width=0.45, height=0.3, facecolor="#DC2626", edgecolor="#991B1B", zorder=14)
+        ax.add_patch(grs)
+
+    moons_offsets = [(-3.2, "Io"), (-1.8, "Europa"), (2.2, "Ganymede"), (4.0, "Callisto")]
+    for dx, m_name in moons_offsets:
+        mx, my = center_az + dx, center_alt + (dx * 0.08)
+        ax.scatter(mx, my, s=35, color="#F8FAFC", edgecolors="#38BDF8", linewidth=0.8, zorder=14)
+        ax.text(mx, my - 1.2, m_name, color=theme["text_sub"], fontsize=8, ha="center", zorder=15)
+
+    ax.text(center_az, center_alt + 1.8, "Jupiter", color=theme["text_main"], fontsize=12, fontweight="bold", ha="center", zorder=15)
+
+
+def _draw_rocket_launch_trajectory(
+    ax: plt.Axes,
+    center_az: float,
+    center_alt: float,
+    event_obj: "Event",
+    theme: dict,
+):
+    """Renders a rising rocket launch trajectory vector curving upward from the horizon."""
+    az_start = center_az - 4.0
+    az_apex, alt_apex = center_az, center_alt
+
+    t_vals = np.linspace(0, 1, 80)
+    az_curve = (1 - t_vals) * az_start + t_vals * az_apex
+    alt_curve = (1 - (1 - t_vals) ** 2) * alt_apex
+
+    ax.plot(az_curve, alt_curve, color="#F97316", linewidth=5.0, alpha=0.3, zorder=10)
+    ax.plot(az_curve, alt_curve, color="#FACC15", linewidth=2.5, zorder=11)
+    ax.plot(az_curve, alt_curve, color="#FFFFFF", linewidth=1.0, zorder=12)
+
+    ax.scatter(az_apex, alt_apex, s=180, color="#EF4444", edgecolors="#FFFFFF", linewidth=1.5, zorder=14)
+    ax.annotate(
+        "",
+        xy=(az_curve[-1], alt_curve[-1]),
+        xytext=(az_curve[-5], alt_curve[-5]),
+        arrowprops={"arrowstyle": "-|>", "color": "#FFFFFF", "lw": 2, "mutation_scale": 15},
+        zorder=15,
+    )
+
+    title_txt = event_obj.title or "Space Launch"
+    ax.text(az_apex, alt_apex + 2.0, title_txt, color=theme["text_main"], fontsize=12, fontweight="bold", ha="center", zorder=15)
+
+
+def _draw_planet_alignment(
+    ax: plt.Axes,
+    all_positions: list[tuple[float, float]],
+    event_obj: "Event",
+    theme: dict,
+):
+    """Renders an ecliptic arc line connecting aligned planets in the sky."""
+    main_objs = event_obj.objects or ["Planet 1", "Planet 2"]
+
+    sorted_pairs = sorted(zip(all_positions, main_objs), key=lambda p: p[0][0])
+    az_vals = [p[0][0] for p in sorted_pairs]
+    alt_vals = [p[0][1] for p in sorted_pairs]
+
+    if len(az_vals) >= 2:
+        ax.plot(az_vals, alt_vals, color="#38BDF8", linestyle="--", linewidth=1.5, alpha=0.8, zorder=10)
+
+    for (az, alt), name in sorted_pairs:
+        ax.scatter(az, alt, s=120, color="#FACC15", edgecolors="#FFFFFF", linewidth=1.0, zorder=12)
+        ax.text(az, alt + 1.4, str(name).title(), color=theme["text_main"], fontsize=10, fontweight="bold", ha="center", zorder=15)
+
+    mid_az = np.mean(az_vals) if az_vals else 90.0
+    max_alt = max(alt_vals) if alt_vals else 25.0
+    ax.text(mid_az, max_alt + 3.0, "Planet Alignment Arc", color=theme["target_primary"], fontsize=11, fontweight="bold", ha="center", zorder=16)
+
+
+def _resolve_skyfield_object(name_str: str) -> Any | None:
+    """Attempts to resolve any string object name to a Skyfield object."""
+    from skyfield.api import Star
+
+    from apts.catalogs.messier import get_messier_raw
+    from apts.catalogs.stars import get_bright_stars_raw
+    from apts.utils import planetary
+
+    if not name_str or not isinstance(name_str, str):
+        return None
+
+    clean = name_str.strip()
+    clean_lower = clean.lower()
+
+    # Common synonym mapping across languages
+    synonyms = {
+        "księżyc": "moon",
+        "mond": "moon",
+        "luna": "moon",
+        "słońce": "sun",
+        "sonne": "sun",
+        "sol": "sun",
+        "jowisz": "jupiter",
+        "wenus": "venus",
+        "mars": "mars",
+        "saturn": "saturn",
+        "merkury": "mercury",
+        "merkur": "mercurio",
+        "uran": "uranus",
+        "neptun": "neptune",
+    }
+    lookup_name = synonyms.get(clean_lower, clean)
+
+    # 1. Ephemeris (major / minor planets, Sun, Moon)
+    try:
+        return planetary.get_skyfield_obj(lookup_name)
+    except (ValueError, KeyError, RuntimeError, AttributeError):
+        pass
+
+    # 2. Messier catalog
+    try:
+        messier_df = get_messier_raw()
+        m_match = messier_df[
+            messier_df["Messier"].str.lower() == clean_lower
+        ]
+        if m_match.empty:
+            m_match = messier_df[
+                messier_df["Messier"].str.lower() == f"m{clean_lower.replace('messier', '').strip()}"
+            ]
+        if not m_match.empty:
+            row = m_match.iloc[0]
+            return Star(ra_hours=float(row["ra_hours"]), dec_degrees=float(row["dec_degrees"]))
+    except (ValueError, KeyError, RuntimeError, AttributeError):
+        pass
+
+    # 3. Bright stars catalog
+    try:
+        stars_df = get_bright_stars_raw()
+        s_match = stars_df[stars_df["Name"].str.lower() == clean_lower]
+        if not s_match.empty:
+            row = s_match.iloc[0]
+            st_obj = row.get("skyfield_object")
+            if st_obj is not None:
+                return st_obj
+            return Star(ra_hours=float(row["ra_hours"]), dec_degrees=float(row["dec_degrees"]))
+    except (ValueError, KeyError, RuntimeError, AttributeError):
+        pass
+
+    return None
+
+
+def _get_observer_for_event(event_obj: "Event") -> tuple[Any, Any]:
+    """Returns Skyfield observer object and Skyfield time for the event moment."""
     place = getattr(event_obj, "place", None)
+    if place is not None and hasattr(place, "observer") and hasattr(place, "ts"):
+        dt_utc = event_obj.dt_utc
+        ts_time = place.ts.utc(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour, dt_utc.minute, dt_utc.second)
+        return place.observer, ts_time
+
+    # Default Topos observer if place is missing
+    from skyfield.api import Topos
+
+    from apts.cache import get_ephemeris, get_timescale
+
+    ts = get_timescale()
+    eph = get_ephemeris()
+    dt_utc = event_obj.dt_utc
+    ts_time = ts.utc(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour, dt_utc.minute, dt_utc.second)
+    lat = float(getattr(event_obj, "extra_data", {}).get("lat", 52.2))
+    lon = float(getattr(event_obj, "extra_data", {}).get("lon", 21.0))
+    observer = eph["earth"] + Topos(latitude_degrees=lat, longitude_degrees=lon)
+    return observer, ts_time
+
+
+def _resolve_target_coordinates(
+    event_obj: "Event",
+    sep_deg: float,
+) -> tuple[tuple[float, float], tuple[float, float] | None, list[tuple[float, float]]]:
+    """
+    Calculates topocentric Az/Alt for primary, secondary, and all listed target objects.
+    Returns (p1_pos, p2_pos, all_object_positions).
+    """
     main_objs = event_obj.objects or []
+    all_positions: list[tuple[float, float]] = []
 
-    # If place and skyfield objects available, compute exact coordinates
-    if place is not None and len(main_objs) >= 2 and hasattr(place, "get_altitude") and hasattr(place, "get_azimuth"):
-        try:
-            dt_utc = event_obj.dt_utc
-            ts_time = place.ts.utc(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour, dt_utc.minute, dt_utc.second)
+    try:
+        observer, ts_time = _get_observer_for_event(event_obj)
+        obs_at_t = observer.at(ts_time)
 
-            obj1 = main_objs[0]
-            obj2 = main_objs[1]
+        for obj_name in main_objs:
+            sf_obj = _resolve_skyfield_object(str(obj_name))
+            if sf_obj is not None:
+                app = obs_at_t.observe(sf_obj).apparent()
+                alt_o, az_o, _ = app.altaz()
+                alt_v, az_v = float(alt_o.degrees), float(az_o.degrees)
+                if not math.isnan(alt_v) and not math.isnan(az_v):
+                    all_positions.append((az_v, alt_v))
+    except (ValueError, KeyError, AttributeError, TypeError, RuntimeError) as e:
+        logger.debug(f"Could not compute topocentric positions for target objects: {e}")
 
-            alt1 = place.get_altitude(obj1, ts_time)
-            az1 = place.get_azimuth(obj1, ts_time)
-            alt2 = place.get_altitude(obj2, ts_time)
-            az2 = place.get_azimuth(obj2, ts_time)
+    # Primary position priority:
+    # 1. Computed topocentric position from primary object
+    # 2. Event azimuth_deg / altitude_deg if explicitly provided
+    # 3. Fallback default (90.0, 25.0)
+    if all_positions:
+        p1_pos = all_positions[0]
+    elif event_obj.azimuth_deg is not None and event_obj.altitude_deg is not None:
+        p1_pos = (float(event_obj.azimuth_deg), float(event_obj.altitude_deg))
+    elif event_obj.azimuth_deg is not None:
+        p1_pos = (float(event_obj.azimuth_deg), 25.0)
+    else:
+        p1_pos = (90.0, 25.0)
 
-            if not math.isnan(alt1) and not math.isnan(az1) and not math.isnan(alt2) and not math.isnan(az2):
-                return (az1, alt1), (az2, alt2)
-        except Exception as e:
-            logger.debug(f"Could not compute exact target topocentric coordinates: {e}")
+    # Secondary position priority:
+    if len(all_positions) >= 2:
+        p2_pos = all_positions[1]
+    elif len(main_objs) >= 2 or event_obj.angular_separation:
+        p2_pos = (p1_pos[0] + sep_deg * 0.8, p1_pos[1] + sep_deg * 0.6)
+    else:
+        p2_pos = None
 
-    # Fallback to event coordinates and angular separation offset
-    p1_az, p1_alt = center_az, center_alt
-    if len(main_objs) >= 2 or event_obj.angular_separation:
-        p2_az = center_az + sep_deg * 0.8
-        p2_alt = center_alt + sep_deg * 0.6
-        return (p1_az, p1_alt), (p2_az, p2_alt)
-
-    return (p1_az, p1_alt), None
+    return p1_pos, p2_pos, all_positions
 
 
 def _plot_primary_event_objects(
     ax: plt.Axes,
     event_obj: "Event",
-    center_az: float,
-    center_alt: float,
+    p1_pos: tuple[float, float],
+    p2_pos: tuple[float, float] | None,
     sep_deg: float,
     theme: dict,
 ) -> tuple[tuple[float, float], tuple[float, float] | None]:
     """Plots primary and secondary targets and separation indicator line."""
     main_objs = event_obj.objects or ["Target"]
-    p1_pos, p2_pos = _resolve_target_coordinates(event_obj, center_az, center_alt, sep_deg)
 
     p1_az, p1_alt = p1_pos
     obj1_name = main_objs[0] if len(main_objs) > 0 else "Target"
@@ -478,16 +743,22 @@ def generate_finder_chart(
 
     event_obj = event if isinstance(event, Event) else Event.from_dict(dict(event))
 
-    # Finder charts are not applicable for rocket/space launches
     cat_upper = str(event_obj.category).upper()
     title_lower = str(event_obj.title).lower()
-    if cat_upper in ("ROCKET_LAUNCH", "SPACE_LAUNCH") or "launch" in title_lower or "rocket" in title_lower:
-        return None
 
     t_theme = THEMES.get(theme, THEMES["stargazer_dark"])
 
-    center_az = float(event_obj.azimuth_deg) if event_obj.azimuth_deg is not None else 90.0
-    center_alt = max(10.0, min(80.0, float(event_obj.altitude_deg) if event_obj.altitude_deg is not None else 25.0))
+    sep_deg = _parse_separation_deg(event_obj.angular_separation)
+    p1_pos, p2_pos, all_target_positions = _resolve_target_coordinates(event_obj, sep_deg)
+
+    if p2_pos is not None:
+        center_az = (p1_pos[0] + p2_pos[0]) / 2.0
+        center_alt = (p1_pos[1] + p2_pos[1]) / 2.0
+    else:
+        center_az = p1_pos[0]
+        center_alt = p1_pos[1]
+
+    center_alt = max(10.0, min(80.0, center_alt))
 
     h_fov = float(fov_deg) if fov_deg is not None else 36.0
     v_fov = h_fov * (figsize[1] / figsize[0] if len(figsize) >= 2 and figsize[0] > 0 else 0.8)
@@ -502,8 +773,19 @@ def generate_finder_chart(
     sky_brightness = getattr(event_obj, "sky_brightness", "NIGHT_DARK")
     _setup_chart_axes_and_horizon(ax, az_min, az_max, alt_min, alt_max, sky_brightness, t_theme)
 
-    sep_deg = _parse_separation_deg(event_obj.angular_separation)
-    p1_pos, p2_pos = _plot_primary_event_objects(ax, event_obj, center_az, center_alt, sep_deg, t_theme)
+    if cat_upper in ("FLYBY", "ISS_FLYBY", "TIANGONG_FLYBY") or "flyby" in title_lower or "iss" in title_lower or "tiangong" in title_lower:
+        _draw_satellite_flyby_trail(ax, center_az, center_alt, event_obj, t_theme)
+    elif cat_upper == "METEOR_SHOWER" or "shower" in title_lower or "meteor" in title_lower:
+        _draw_meteor_shower_radiant(ax, center_az, center_alt, event_obj, t_theme)
+    elif cat_upper in ("ROCKET_LAUNCH", "SPACE_LAUNCH") or "launch" in title_lower or "rocket" in title_lower:
+        _draw_rocket_launch_trajectory(ax, center_az, center_alt, event_obj, t_theme)
+    elif (cat_upper in ("PLANET_ALIGNMENT", "CELESTIAL_CONFIGURATION") or "alignment" in title_lower) and len(all_target_positions) >= 2:
+        _draw_planet_alignment(ax, all_target_positions, event_obj, t_theme)
+    elif "jovian" in cat_upper.lower() or "jovian" in title_lower or "grs" in title_lower or ("jupiter" in title_lower and ("moon" in title_lower or "transit" in title_lower)):
+        _draw_jovian_system(ax, center_az, center_alt, event_obj, t_theme)
+    else:
+        _plot_primary_event_objects(ax, event_obj, p1_pos, p2_pos, sep_deg, t_theme)
+
     _plot_background_stars(ax, az_min, az_max, alt_max, center_az, center_alt, p1_pos, p2_pos, event_obj, t_theme)
 
     plt.subplots_adjust(left=0, right=1, bottom=0, top=1)

--- a/tests/unit/test_event_dto.py
+++ b/tests/unit/test_event_dto.py
@@ -2,7 +2,11 @@ import json
 from datetime import datetime, timezone
 
 from apts.events import Event
-from apts.events.event import get_direction_data, get_event_category, get_step_by_step_guide
+from apts.events.event import (
+    get_direction_data,
+    get_event_category,
+    get_step_by_step_guide,
+)
 
 
 def test_direction_data():
@@ -35,6 +39,49 @@ def test_step_by_step_guide():
 
     conjunction_guide = get_step_by_step_guide("CONJUNCTION")
     assert len(conjunction_guide) >= 4
+
+    flyby_guide = get_step_by_step_guide("FLYBY", title="Bright ISS Pass", objects=["ISS"])
+    assert len(flyby_guide) >= 4
+    assert "Find an open viewing location" in flyby_guide[0]
+
+    launch_guide = get_step_by_step_guide("ROCKET_LAUNCH", title="Falcon 9 Rocket Launch")
+    assert len(launch_guide) >= 3
+    assert "launch schedule" in launch_guide[0].lower()
+
+    alignment_guide = get_step_by_step_guide("PLANET_ALIGNMENT", title="Planetary Alignment")
+    assert len(alignment_guide) >= 3
+
+
+def test_multilingual_guidelines_and_directions():
+    from apts.i18n import language_context
+
+    # Test Polish
+    with language_context("pl"):
+        dir_e = get_direction_data(90.0)
+        assert dir_e.name == "Patrz na wschód"
+        guide_flyby = get_step_by_step_guide("FLYBY", title="Przelot ISS")
+        assert "Znajdź otwarte miejsce" in guide_flyby[0]
+
+    # Test German
+    with language_context("de"):
+        dir_e = get_direction_data(90.0)
+        assert dir_e.name == "Blick nach Osten"
+        guide_flyby = get_step_by_step_guide("FLYBY", title="ISS Überflug")
+        assert "Suchen Sie einen offenen Beobachtungsort" in guide_flyby[0]
+
+    # Test Spanish
+    with language_context("es"):
+        dir_e = get_direction_data(90.0)
+        assert dir_e.name == "Mire hacia el Este"
+        guide_flyby = get_step_by_step_guide("FLYBY", title="Paso de la ISS")
+        assert "Busque un lugar abierto" in guide_flyby[0]
+
+    # Test Portuguese
+    with language_context("pt"):
+        dir_e = get_direction_data(90.0)
+        assert dir_e.name == "Olhe para Este"
+        guide_flyby = get_step_by_step_guide("FLYBY", title="Passagem da ISS")
+        assert "Encontre um local aberto" in guide_flyby[0]
 
 
 def test_event_dto_serialization():

--- a/tests/unit/test_finder_chart.py
+++ b/tests/unit/test_finder_chart.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+
 import matplotlib.figure
 import pytest
 
@@ -48,7 +49,7 @@ def test_generate_finder_chart_light_theme(sample_occultation_event):
     assert len(png_bytes) > 0
 
 
-def test_rocket_launch_chart_suppression():
+def test_rocket_launch_chart_rendering():
     launch_event = Event(
         category="ROCKET_LAUNCH",
         title="Falcon 9 Rocket Launch",
@@ -57,10 +58,96 @@ def test_rocket_launch_chart_suppression():
         location_name="Cape Canaveral",
     )
     png_bytes = launch_event.generate_finder_chart(format="png")
-    assert png_bytes == b""
+    assert isinstance(png_bytes, bytes)
+    assert len(png_bytes) > 0
+    assert png_bytes[:4] == b"\x89PNG"
 
     fig = plot_finder_chart(launch_event, format="figure")
-    assert fig is None
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+
+def test_iss_flyby_chart_rendering():
+    flyby_event = Event(
+        category="FLYBY",
+        title="Bright ISS Pass",
+        datetime_utc=datetime(2026, 9, 8, 22, 15, tzinfo=timezone.utc),
+        best_viewing_time_local="22:15",
+        location_name="Berlin",
+        azimuth_deg=140.0,
+        altitude_deg=45.0,
+        objects=["ISS"],
+    )
+    png_bytes = flyby_event.generate_finder_chart(format="png")
+    assert isinstance(png_bytes, bytes)
+    assert len(png_bytes) > 0
+    assert png_bytes[:4] == b"\x89PNG"
+
+
+def test_meteor_shower_chart_rendering():
+    shower_event = Event(
+        category="METEOR_SHOWER",
+        title="Perseids Meteor Shower Peak",
+        datetime_utc=datetime(2026, 8, 12, 2, 0, tzinfo=timezone.utc),
+        best_viewing_time_local="02:00",
+        location_name="Warsaw",
+        azimuth_deg=45.0,
+        altitude_deg=50.0,
+        objects=["Perseids"],
+    )
+    png_bytes = shower_event.generate_finder_chart(format="png")
+    assert isinstance(png_bytes, bytes)
+    assert len(png_bytes) > 0
+
+
+def test_jovian_moon_event_chart_rendering():
+    jovian_event = Event(
+        category="JOVIAN_MOON_EVENT",
+        title="Io Shadow Transit on Jupiter",
+        datetime_utc=datetime(2026, 9, 8, 1, 30, tzinfo=timezone.utc),
+        best_viewing_time_local="01:30",
+        location_name="Madrid",
+        azimuth_deg=180.0,
+        altitude_deg=35.0,
+        objects=["Jupiter", "Io"],
+    )
+    png_bytes = jovian_event.generate_finder_chart(format="png")
+    assert isinstance(png_bytes, bytes)
+    assert len(png_bytes) > 0
+
+
+def test_planet_alignment_chart_rendering():
+    alignment_event = Event(
+        category="PLANET_ALIGNMENT",
+        title="Planetary Alignment of Venus, Mars, and Jupiter",
+        datetime_utc=datetime(2026, 9, 8, 4, 30, tzinfo=timezone.utc),
+        best_viewing_time_local="04:30",
+        location_name="Lisbon",
+        azimuth_deg=105.0,
+        altitude_deg=20.0,
+        objects=["Venus", "Mars", "Jupiter"],
+    )
+    png_bytes = alignment_event.generate_finder_chart(format="png")
+    assert isinstance(png_bytes, bytes)
+    assert len(png_bytes) > 0
+
+
+def test_east_conjunction_azimuth_alignment():
+    east_event = Event(
+        category="CONJUNCTION",
+        title="Conjunction of Moon and Jupiter",
+        datetime_utc=datetime(2026, 9, 8, 5, 0, tzinfo=timezone.utc),
+        best_viewing_time_local="05:00",
+        location_name="Warsaw",
+        azimuth_deg=108.5,
+        altitude_deg=22.0,
+        objects=["Moon", "Jupiter"],
+    )
+    fig = plot_finder_chart(east_event, format="figure")
+    ax = fig.axes[0]
+    xlim = ax.get_xlim()
+    center_az = (xlim[0] + xlim[1]) / 2.0
+    # Chart should be centered near 108.5° azimuth, NOT forced to 90.0°
+    assert abs(center_az - 108.5) < 5.0
 
 
 def test_sky_brightness_metadata_and_durations(sample_occultation_event):


### PR DESCRIPTION
This change addresses three issues with Finder Chart Generation and Event Metadata:
1. Rendered specialized visual finder charts for ALL event types (satellite flybys with pass trails, meteor showers with radiants, Jovian system events with Jupiter cloud bands & Galilean moons, planet alignments, and rising rocket launches).
2. Fixed finder chart plot alignment so celestial objects (e.g. Moon in East conjunction) are resolved and centered on their exact topocentric azimuth rather than defaulting to 90 degrees.
3. Expanded step-by-step observational guides and narrative descriptions by event category and translated all guide steps and cardinal directions into all 4 supported languages (German, Spanish, Polish, Portuguese).

---
*PR created automatically by Jules for task [2310641817122127206](https://jules.google.com/task/2310641817122127206) started by @pozar87*