### PR TITLE
Fix Finder Chart Horizon Rendering and Event Metadata Time-Shift

### DIFF
--- a/apts/events/event.py
+++ b/apts/events/event.py
@@ -289,9 +289,13 @@ class EventExportData:
     direction: DirectionData
     step_by_step_guide: list[str]
     sky_brightness: str = "NIGHT_DARK"
+    is_below_horizon: bool = False
+    chart_datetime_utc: str | None = None
+    chart_time_note: str | None = None
+    target_altitude_deg: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "category": self.category,
             "title": self.title,
             "datetime_utc": self.datetime_utc,
@@ -303,6 +307,15 @@ class EventExportData:
             "step_by_step_guide": self.step_by_step_guide,
             "sky_brightness": self.sky_brightness,
         }
+        if self.is_below_horizon:
+            d["is_below_horizon"] = self.is_below_horizon
+        if self.chart_datetime_utc:
+            d["chart_datetime_utc"] = self.chart_datetime_utc
+        if self.chart_time_note:
+            d["chart_time_note"] = self.chart_time_note
+        if self.target_altitude_deg is not None:
+            d["target_altitude_deg"] = round(float(self.target_altitude_deg), 1)
+        return d
 
 
 def _parse_event_datetime(data: dict[str, Any]) -> datetime:
@@ -455,6 +468,22 @@ class Event:
 
         self.sky_brightness = get_sky_brightness(sun_alt, moon_alt, phase_frac)
 
+        # Initialize horizon and chart metadata
+        self.is_below_horizon = bool(self.extra_data.get("is_below_horizon", False))
+        self.chart_datetime_utc = self.extra_data.get("chart_datetime_utc")
+        self.chart_time_note = self.extra_data.get("chart_time_note")
+        self.target_altitude_deg = (
+            float(self.extra_data["target_altitude_deg"])
+            if "target_altitude_deg" in self.extra_data and self.extra_data["target_altitude_deg"] is not None
+            else self.altitude_deg
+        )
+
+        if self.altitude_deg is not None:
+            if self.target_altitude_deg is None:
+                self.target_altitude_deg = float(self.altitude_deg)
+            if self.altitude_deg < 0.0:
+                self.is_below_horizon = True
+
         # Handle Direction
         if isinstance(direction, DirectionData):
             self.direction = direction
@@ -498,6 +527,10 @@ class Event:
             direction=self.direction,
             step_by_step_guide=self.step_by_step_guide,
             sky_brightness=getattr(self, "sky_brightness", "NIGHT_DARK"),
+            is_below_horizon=getattr(self, "is_below_horizon", False),
+            chart_datetime_utc=getattr(self, "chart_datetime_utc", None),
+            chart_time_note=getattr(self, "chart_time_note", None),
+            target_altitude_deg=getattr(self, "target_altitude_deg", self.altitude_deg),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/apts/place/calculations.py
+++ b/apts/place/calculations.py
@@ -55,5 +55,5 @@ def calculate_moon_phase_letter(eph: Any, date: Any) -> str:
     else:
         phase_angle_deg = float(phase_angle)  # type: ignore
     lunation = cast(float, phase_angle_deg) / 360.0
-    letter = chr(ord("A") + int(round(lunation * 26)))
+    letter = chr(ord("A") + (int(round(lunation * 26)) % 26))
     return letter

--- a/apts/visualization/finder_chart.py
+++ b/apts/visualization/finder_chart.py
@@ -519,6 +519,181 @@ def _draw_planet_alignment(
     ax.text(mid_az, max_alt + 3.0, "Planet Alignment Arc", color=theme["target_primary"], fontsize=11, fontweight="bold", ha="center", zorder=16)
 
 
+LONG_EVENT_CATEGORIES = {
+    "CONJUNCTION",
+    "PLANET_ALIGNMENT",
+    "OPPOSITION",
+    "CELESTIAL_CONFIGURATION",
+    "MOON_PHASE",
+    "SUPERMOON",
+    "MOON_LIBRATION",
+    "GREATEST_ELONGATION",
+    "VENUS_GREAT_BRILLIANCY",
+    "EQUINOX_SOLSTICE",
+    "METEOR_SHOWER",
+    "CELESTIAL_EVENT",
+}
+
+
+def is_long_event(category: str, title: str = "") -> bool:
+    """Checks if an event category or title represents a multi-hour / long-duration event."""
+    cat = str(category).upper()
+    title_lower = str(title).lower()
+    if cat in LONG_EVENT_CATEGORIES:
+        return True
+    long_keywords = [
+        "conjunction",
+        "alignment",
+        "opposition",
+        "elongation",
+        "phase",
+        "shower",
+        "solstice",
+        "equinox",
+    ]
+    return any(kw in title_lower for kw in long_keywords)
+
+
+def _compute_sky_brightness_at_time(
+    event_obj: "Event", observer: Any, ts_chart: Any
+) -> str:
+    """Computes topocentric sky brightness classification at a specific chart observation time."""
+    from apts.cache import get_ephemeris
+    from apts.events.event import get_sky_brightness
+
+    try:
+        eph = get_ephemeris()
+        obs_at_c = observer.at(ts_chart)
+        sun_alt = float(obs_at_c.observe(eph["sun"]).apparent().altaz()[0].degrees)
+        moon_alt = float(obs_at_c.observe(eph["moon"]).apparent().altaz()[0].degrees)
+        phase = (
+            float(event_obj.extra_data.get("phase", 0.0))
+            if isinstance(event_obj.extra_data.get("phase"), (int, float))
+            else 0.0
+        )
+        return get_sky_brightness(sun_alt, moon_alt, phase)
+    except (ValueError, KeyError, AttributeError, TypeError, RuntimeError):
+        return getattr(event_obj, "sky_brightness", "NIGHT_DARK")
+
+
+def _find_optimal_chart_time(
+    event_obj: "Event",
+    observer: Any,
+    ts_time: Any,
+    sf_obj1: Any | None,
+) -> tuple[Any, float, str | None, str | None]:
+    """
+    Evaluates target altitude at peak time and searches for an optimal observation time
+    when the target is at good altitude for long-lasting events.
+    Returns (ts_chart, target_alt_chart, chart_datetime_utc, chart_time_note).
+    """
+    from datetime import timedelta
+
+    from apts.i18n import gettext_
+
+    dt_utc = event_obj.dt_utc
+
+    alt_peak = 25.0
+    if sf_obj1 is not None:
+        try:
+            app_peak = observer.at(ts_time).observe(sf_obj1).apparent()
+            alt_o, _, _ = app_peak.altaz()
+            alt_peak = float(alt_o.degrees)
+        except (ValueError, KeyError, AttributeError, TypeError, RuntimeError):
+            alt_peak = (
+                float(event_obj.altitude_deg)
+                if event_obj.altitude_deg is not None
+                else 25.0
+            )
+    elif event_obj.altitude_deg is not None:
+        alt_peak = float(event_obj.altitude_deg)
+
+    if alt_peak < 0.0:
+        event_obj.is_below_horizon = True
+
+    if alt_peak >= 5.0:
+        event_obj.target_altitude_deg = float(alt_peak)
+        return ts_time, alt_peak, None, None
+
+    # Target is below or near horizon (< 5.0 deg).
+    if is_long_event(event_obj.category, event_obj.title) and sf_obj1 is not None:
+        try:
+            from apts.cache import get_ephemeris
+
+            eph = get_ephemeris()
+            sun = eph["sun"]
+
+            best_ts = ts_time
+            best_dt = dt_utc
+            best_score = -999999.0
+            best_alt = alt_peak
+
+            ts_factory = getattr(ts_time, "ts", None) or getattr(
+                getattr(event_obj, "place", None), "ts", None
+            )
+
+            offsets_hours = np.linspace(-12.0, 12.0, 97)
+            for dh in offsets_hours:
+                dt_cand = dt_utc + timedelta(hours=float(dh))
+                if ts_factory is not None:
+                    ts_c = ts_factory.utc(
+                        dt_cand.year,
+                        dt_cand.month,
+                        dt_cand.day,
+                        dt_cand.hour,
+                        dt_cand.minute,
+                        dt_cand.second,
+                    )
+                else:
+                    ts_c = ts_time
+
+                obs_c = observer.at(ts_c)
+                alt_c = float(obs_c.observe(sf_obj1).apparent().altaz()[0].degrees)
+                sun_alt_c = float(obs_c.observe(sun).apparent().altaz()[0].degrees)
+
+                if alt_c < 0.0:
+                    score = -1000.0 + alt_c
+                else:
+                    score = alt_c
+                    if sun_alt_c < -0.833:
+                        score += 100.0
+                    score -= abs(dh) * 0.5
+
+                if score > best_score:
+                    best_score = score
+                    best_ts = ts_c
+                    best_dt = dt_cand
+                    best_alt = alt_c
+
+            if best_alt >= 5.0 or (alt_peak < 0.0 and best_alt > 0.0):
+                chart_datetime_str = best_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+                time_peak_str = dt_utc.strftime("%H:%M")
+                time_chart_str = best_dt.strftime("%H:%M")
+                alt_peak_fmt = f"{round(alt_peak, 1)}°"
+                alt_chart_fmt = f"{round(best_alt, 1)}°"
+
+                note = gettext_(
+                    "Peak at {time_peak} UTC ({alt_peak}) is below horizon. Chart shown for {time_chart} UTC (Alt: {alt_chart})."
+                ).format(
+                    time_peak=time_peak_str,
+                    alt_peak=alt_peak_fmt,
+                    time_chart=time_chart_str,
+                    alt_chart=alt_chart_fmt,
+                )
+                return best_ts, best_alt, chart_datetime_str, note
+        except (ValueError, KeyError, AttributeError, TypeError, RuntimeError) as e:
+            logger.debug(f"Failed to find optimal chart time: {e}")
+
+    alt_peak_fmt = f"{round(alt_peak, 1)}°"
+    warn_note = None
+    if alt_peak < 0.0:
+        warn_note = gettext_(
+            "Warning: Target is below horizon ({alt_peak}) at event peak time."
+        ).format(alt_peak=alt_peak_fmt)
+
+    return ts_time, alt_peak, None, warn_note
+
+
 def _resolve_skyfield_object(name_str: str) -> Any | None:
     """Attempts to resolve any string object name to a Skyfield object."""
     from skyfield.api import Star
@@ -616,28 +791,47 @@ def _get_observer_for_event(event_obj: "Event") -> tuple[Any, Any]:
 def _resolve_target_coordinates(
     event_obj: "Event",
     sep_deg: float,
-) -> tuple[tuple[float, float], tuple[float, float] | None, list[tuple[float, float]]]:
+) -> tuple[
+    tuple[float, float],
+    tuple[float, float] | None,
+    list[tuple[float, float]],
+    str,
+]:
     """
-    Calculates topocentric Az/Alt for primary, secondary, and all listed target objects.
-    Returns (p1_pos, p2_pos, all_object_positions).
+    Calculates topocentric Az/Alt for target objects and evaluates optimal chart timing.
+    Returns (p1_pos, p2_pos, all_object_positions, sky_brightness).
     """
     main_objs = event_obj.objects or []
     all_positions: list[tuple[float, float]] = []
 
     try:
         observer, ts_time = _get_observer_for_event(event_obj)
-        obs_at_t = observer.at(ts_time)
+        sf_obj1 = _resolve_skyfield_object(str(main_objs[0])) if main_objs else None
+
+        ts_chart, alt_chart, chart_dt_str, chart_note = _find_optimal_chart_time(
+            event_obj, observer, ts_time, sf_obj1
+        )
+
+        event_obj.target_altitude_deg = float(alt_chart)
+        if chart_dt_str:
+            event_obj.chart_datetime_utc = chart_dt_str
+        if chart_note:
+            event_obj.chart_time_note = chart_note
+
+        sky_brightness = _compute_sky_brightness_at_time(event_obj, observer, ts_chart)
+        obs_at_chart = observer.at(ts_chart)
 
         for obj_name in main_objs:
             sf_obj = _resolve_skyfield_object(str(obj_name))
             if sf_obj is not None:
-                app = obs_at_t.observe(sf_obj).apparent()
+                app = obs_at_chart.observe(sf_obj).apparent()
                 alt_o, az_o, _ = app.altaz()
                 alt_v, az_v = float(alt_o.degrees), float(az_o.degrees)
                 if not math.isnan(alt_v) and not math.isnan(az_v):
                     all_positions.append((az_v, alt_v))
     except (ValueError, KeyError, AttributeError, TypeError, RuntimeError) as e:
         logger.debug(f"Could not compute topocentric positions for target objects: {e}")
+        sky_brightness = getattr(event_obj, "sky_brightness", "NIGHT_DARK")
 
     # Primary position priority:
     # 1. Computed topocentric position from primary object
@@ -652,15 +846,49 @@ def _resolve_target_coordinates(
     else:
         p1_pos = (90.0, 25.0)
 
+    # Clamp drawing altitude to >= 1.0 deg so no object is drawn below horizon
+    p1_pos_draw = (p1_pos[0], max(1.0, p1_pos[1]))
+
     # Secondary position priority:
     if len(all_positions) >= 2:
         p2_pos = all_positions[1]
+        p2_pos_draw = (p2_pos[0], max(1.0, p2_pos[1]))
     elif len(main_objs) >= 2 or event_obj.angular_separation:
         p2_pos = (p1_pos[0] + sep_deg * 0.8, p1_pos[1] + sep_deg * 0.6)
+        p2_pos_draw = (p2_pos[0], max(1.0, p2_pos[1]))
     else:
-        p2_pos = None
+        p2_pos_draw = None
 
-    return p1_pos, p2_pos, all_positions
+    all_positions_draw = [(az, max(1.0, alt)) for az, alt in all_positions]
+
+    return p1_pos_draw, p2_pos_draw, all_positions_draw, sky_brightness
+
+
+def _draw_chart_time_note_banner(ax: plt.Axes, note_text: str | None, theme: dict):
+    """Renders a prominent informational banner on top of the chart figure for time shift or warning notes."""
+    if not note_text:
+        return
+    ax.text(
+        0.5,
+        0.96,
+        note_text,
+        transform=ax.transAxes,
+        color="#FACC15"
+        if "warning" in str(note_text).lower() or " poniżej" in str(note_text).lower()
+        else theme["text_main"],
+        fontsize=9,
+        fontweight="bold",
+        ha="center",
+        va="top",
+        bbox={
+            "boxstyle": "round,pad=0.35",
+            "facecolor": theme["separation_bg"],
+            "edgecolor": theme["separation_line"],
+            "linewidth": 1.0,
+            "alpha": 0.9,
+        },
+        zorder=20,
+    )
 
 
 def _plot_primary_event_objects(
@@ -749,7 +977,9 @@ def generate_finder_chart(
     t_theme = THEMES.get(theme, THEMES["stargazer_dark"])
 
     sep_deg = _parse_separation_deg(event_obj.angular_separation)
-    p1_pos, p2_pos, all_target_positions = _resolve_target_coordinates(event_obj, sep_deg)
+    p1_pos, p2_pos, all_target_positions, sky_brightness = _resolve_target_coordinates(
+        event_obj, sep_deg
+    )
 
     if p2_pos is not None:
         center_az = (p1_pos[0] + p2_pos[0]) / 2.0
@@ -770,8 +1000,8 @@ def generate_finder_chart(
     fig.patch.set_facecolor(t_theme["sky_bg"])
     ax.set_facecolor(t_theme["sky_bg"])
 
-    sky_brightness = getattr(event_obj, "sky_brightness", "NIGHT_DARK")
     _setup_chart_axes_and_horizon(ax, az_min, az_max, alt_min, alt_max, sky_brightness, t_theme)
+    _draw_chart_time_note_banner(ax, getattr(event_obj, "chart_time_note", None), t_theme)
 
     if cat_upper in ("FLYBY", "ISS_FLYBY", "TIANGONG_FLYBY") or "flyby" in title_lower or "iss" in title_lower or "tiangong" in title_lower:
         _draw_satellite_flyby_trail(ax, center_az, center_alt, event_obj, t_theme)

--- a/tests/unit/test_event_dto.py
+++ b/tests/unit/test_event_dto.py
@@ -115,6 +115,35 @@ def test_event_dto_serialization():
     assert parsed["title"] == "Lunar occultation of Jupiter"
 
 
+def test_event_dto_horizon_metadata():
+    dt = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    event = Event(
+        category="CONJUNCTION",
+        title="Conjunction of Moon and Jupiter",
+        datetime_utc=dt,
+        best_viewing_time_local="12:00",
+        location_name="Warsaw",
+        altitude_deg=-10.5,
+        objects=["Moon", "Jupiter"],
+        extra_data={
+            "is_below_horizon": True,
+            "chart_datetime_utc": "2026-09-08T22:00:00Z",
+            "chart_time_note": "Peak at 12:00 UTC is below horizon. Chart shown for 22:00 UTC (Alt: 25.0°).",
+            "target_altitude_deg": 25.0,
+        },
+    )
+
+    d = event.to_dict()
+    assert d["is_below_horizon"] is True
+    assert d["chart_datetime_utc"] == "2026-09-08T22:00:00Z"
+    assert "below horizon" in d["chart_time_note"]
+    assert d["target_altitude_deg"] == 25.0
+
+    parsed = Event.from_dict(d)
+    assert parsed.is_below_horizon is True
+    assert parsed.chart_datetime_utc == "2026-09-08T22:00:00Z"
+
+
 def test_event_from_dict_and_row():
     raw_dict = {
         "event": "Conjunction",

--- a/tests/unit/test_finder_chart.py
+++ b/tests/unit/test_finder_chart.py
@@ -166,3 +166,48 @@ def test_sky_brightness_metadata_and_durations(sample_occultation_event):
 
     conj_duration = calculate_event_duration("Conjunction", {})
     assert conj_duration == 7200  # 2 hours
+
+
+def test_conjunction_below_horizon_time_shift():
+    # Conjunction of Moon and Jupiter at 20:00 UTC (Moon below horizon for Warsaw at -20.9°)
+    event = Event(
+        category="CONJUNCTION",
+        title="Conjunction of Moon and Jupiter",
+        datetime_utc=datetime(2026, 9, 8, 20, 0, tzinfo=timezone.utc),
+        best_viewing_time_local="20:00",
+        location_name="Warsaw",
+        objects=["Moon", "Jupiter"],
+        extra_data={"lat": 52.23, "lon": 21.01},
+    )
+
+    fig = plot_finder_chart(event, format="figure")
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+    # Metadata should be updated after chart generation
+    d = event.to_dict()
+    assert d.get("is_below_horizon") is True
+    assert "chart_time_note" in d
+    assert "chart_datetime_utc" in d
+    assert event.chart_datetime_utc is not None
+    assert "below horizon" in d["chart_time_note"].lower() or "poniżej" in d["chart_time_note"].lower()
+
+
+def test_short_event_below_horizon_warning():
+    # Occultation at 20:00 UTC (Moon below horizon for Warsaw)
+    event = Event(
+        category="OCCULTATION",
+        title="Lunar occultation of Saturn",
+        datetime_utc=datetime(2026, 9, 8, 20, 0, tzinfo=timezone.utc),
+        best_viewing_time_local="20:00",
+        location_name="Warsaw",
+        objects=["Moon", "Saturn"],
+        extra_data={"lat": 52.23, "lon": 21.01},
+    )
+
+    fig = plot_finder_chart(event, format="figure")
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+    d = event.to_dict()
+    assert d.get("is_below_horizon") is True
+    assert "chart_time_note" in d
+    assert "warning" in d["chart_time_note"].lower() or "poniżej" in d["chart_time_note"].lower() or "below horizon" in d["chart_time_note"].lower()


### PR DESCRIPTION
Fixes finder chart generation and event metadata when target objects occur below or near the horizon. Multi-hour events like conjunctions now automatically render chart maps at a nearby optimal observation time when target altitude is good, clamp object drawing positions above the horizon line, and inform users via both plot note banners and structured event metadata (`is_below_horizon`, `chart_datetime_utc`, `chart_time_note`, `target_altitude_deg`).

---
*PR created automatically by Jules for task [16805114067554413343](https://jules.google.com/task/16805114067554413343) started by @pozar87*