### PR TITLE
Fix Finder Chart Horizon Rendering for Moon Quarters and Solar Equinoxes

### DIFF
--- a/apts/events/calculations/lunar.py
+++ b/apts/events/calculations/lunar.py
@@ -24,6 +24,8 @@ def calculate_moon_phases(ts, start_date, end_date, eph):
             "date": ti.utc_datetime().astimezone(utc),
             "event": almanac.MOON_PHASES[yi],
             "type": "Moon Phase",
+            "object": "Moon",
+            "phase": yi * 0.25,
         }
         event_data["rarity"] = get_rarity("Moon Phase", event_data)
         event_data["duration"] = get_duration("Moon Phase", event_data)

--- a/apts/events/event.py
+++ b/apts/events/event.py
@@ -112,6 +112,17 @@ CATEGORY_RULES = [
     ("solstice", None, "EQUINOX_SOLSTICE"),
     ("equinox", None, "EQUINOX_SOLSTICE"),
     ("season", None, "EQUINOX_SOLSTICE"),
+    ("moon phase", None, "MOON_PHASE"),
+    (None, "moon phase", "MOON_PHASE"),
+    (None, "moon_phases", "MOON_PHASE"),
+    ("first quarter", None, "MOON_PHASE"),
+    ("third quarter", None, "MOON_PHASE"),
+    ("last quarter", None, "MOON_PHASE"),
+    ("new moon", None, "MOON_PHASE"),
+    ("full moon", None, "MOON_PHASE"),
+    ("supermoon", None, "SUPERMOON"),
+    ("libration", None, "MOON_LIBRATION"),
+    ("lunar feature", None, "LUNAR_FEATURE"),
 ]
 
 
@@ -357,6 +368,20 @@ def _extract_event_objects(data: dict[str, Any]) -> list[str]:
             objs.extend([str(p) for p in p_val])
         elif isinstance(p_val, str):
             objs.append(p_val)
+
+    if not objs:
+        event_name = str(data.get("event") or data.get("title") or "").lower()
+        event_type = str(data.get("type") or "").lower()
+        category = str(data.get("category") or get_event_category(event_name, event_type)).upper()
+
+        moon_kws = ["moon", "quarter", "crescent", "gibbous", "full moon", "new moon", "księżyc", "mond", "luna", "libration", "supermoon", "lunar"]
+        sun_kws = ["sun", "solstice", "equinox", "słońce", "sonne", "sol", "autumnal", "vernal", "equinoccio", "solsticio", "tagundnachtgleiche", "równonoc", "przesilenie"]
+
+        if category in ("MOON_PHASE", "SUPERMOON", "MOON_LIBRATION", "LUNAR_FEATURE", "LUNAR_ECLIPSE") or any(kw in event_name or kw in event_type for kw in moon_kws):
+            objs.append("Moon")
+        elif category in ("EQUINOX_SOLSTICE", "SOLAR_ECLIPSE") or any(kw in event_name or kw in event_type for kw in sun_kws):
+            objs.append("Sun")
+
     return objs
 
 

--- a/apts/locale/de/LC_MESSAGES/messages.po
+++ b/apts/locale/de/LC_MESSAGES/messages.po
@@ -1175,3 +1175,21 @@ msgstr "Zielobjekt"
 
 msgid "Companion"
 msgstr "Begleiter"
+
+msgid "Peak at {time_peak} UTC ({alt_peak}) is below horizon. Chart shown for {time_chart} UTC (Alt: {alt_chart})."
+msgstr "Höhepunkt um {time_peak} UTC ({alt_peak}) liegt unter dem Horizont. Karte gezeigt für {time_chart} UTC (Höhe: {alt_chart})."
+
+msgid "Warning: Target is below horizon ({alt_peak}) at event peak time."
+msgstr "Warnung: Ziel liegt zum Zeitpunkt des Höhepunkts unter dem Horizont ({alt_peak})."
+
+msgid "Autumnal Equinox"
+msgstr "Herbst-Tagundnachtgleiche"
+
+msgid "Vernal Equinox"
+msgstr "Frühlings-Tagundnachtgleiche"
+
+msgid "Summer Solstice"
+msgstr "Sommersonnenwende"
+
+msgid "Winter Solstice"
+msgstr "Wintersonnenwende"

--- a/apts/locale/es/LC_MESSAGES/messages.po
+++ b/apts/locale/es/LC_MESSAGES/messages.po
@@ -1198,3 +1198,21 @@ msgstr "Objeto destino"
 
 msgid "Companion"
 msgstr "Compañero"
+
+msgid "Peak at {time_peak} UTC ({alt_peak}) is below horizon. Chart shown for {time_chart} UTC (Alt: {alt_chart})."
+msgstr "El pico a las {time_peak} UTC ({alt_peak}) está por debajo del horizonte. Gráfico mostrado para las {time_chart} UTC (Alt: {alt_chart})."
+
+msgid "Warning: Target is below horizon ({alt_peak}) at event peak time."
+msgstr "Advertencia: El objetivo está por debajo del horizonte ({alt_peak}) en el momento cumbre del evento."
+
+msgid "Autumnal Equinox"
+msgstr "Equinoccio de Otoño"
+
+msgid "Vernal Equinox"
+msgstr "Equinoccio de Primavera"
+
+msgid "Summer Solstice"
+msgstr "Solsticio de Verano"
+
+msgid "Winter Solstice"
+msgstr "Solsticio de Invierno"

--- a/apts/locale/pl/LC_MESSAGES/messages.po
+++ b/apts/locale/pl/LC_MESSAGES/messages.po
@@ -1203,3 +1203,21 @@ msgstr "Obiekt docelowy"
 
 msgid "Companion"
 msgstr "Towarzysz"
+
+msgid "Peak at {time_peak} UTC ({alt_peak}) is below horizon. Chart shown for {time_chart} UTC (Alt: {alt_chart})."
+msgstr "Szczyt o {time_peak} UTC ({alt_peak}) znajduje się poniżej horyzontu. Wykres pokazano dla {time_chart} UTC (Wys: {alt_chart})."
+
+msgid "Warning: Target is below horizon ({alt_peak}) at event peak time."
+msgstr "Ostrzeżenie: Obiekt znajduje się poniżej horyzontu ({alt_peak}) w czasie szczytu wydarzenia."
+
+msgid "Autumnal Equinox"
+msgstr "Równonoc Jesienna"
+
+msgid "Vernal Equinox"
+msgstr "Równonoc Wiosenna"
+
+msgid "Summer Solstice"
+msgstr "Przesilenie Letnie"
+
+msgid "Winter Solstice"
+msgstr "Przesilenie Zimowe"

--- a/apts/locale/pt/LC_MESSAGES/messages.po
+++ b/apts/locale/pt/LC_MESSAGES/messages.po
@@ -1198,3 +1198,21 @@ msgstr "Objeto de destino"
 
 msgid "Companion"
 msgstr "Companheiro"
+
+msgid "Peak at {time_peak} UTC ({alt_peak}) is below horizon. Chart shown for {time_chart} UTC (Alt: {alt_chart})."
+msgstr "O pico às {time_peak} UTC ({alt_peak}) está abaixo do horizonte. Gráfico mostrado para {time_chart} UTC (Alt: {alt_chart})."
+
+msgid "Warning: Target is below horizon ({alt_peak}) at event peak time."
+msgstr "Aviso: O alvo está abaixo do horizonte ({alt_peak}) no momento do pico do evento."
+
+msgid "Autumnal Equinox"
+msgstr "Equinócio de Outono"
+
+msgid "Vernal Equinox"
+msgstr "Equinócio de Primavera"
+
+msgid "Summer Solstice"
+msgstr "Solstício de Verão"
+
+msgid "Winter Solstice"
+msgstr "Solstício de Inverno"

--- a/apts/visualization/finder_chart.py
+++ b/apts/visualization/finder_chart.py
@@ -160,6 +160,56 @@ def _draw_moon_phase(
     ax.add_patch(polygon)
 
 
+def _draw_sun_disk(
+    ax: plt.Axes,
+    x: float,
+    y: float,
+    radius_deg: float,
+    theme: dict,
+):
+    """Renders a Sun disc with solar corona/glow, maintaining circular aspect ratio matching the Moon."""
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    bbox = ax.get_window_extent()
+    ax_width = bbox.width if bbox else 1.0
+    ax_height = bbox.height if bbox else 1.0
+    data_width = xlim[1] - xlim[0]
+    data_height = ylim[1] - ylim[0]
+
+    rx = radius_deg
+    ry = radius_deg * (data_height / data_width) * (ax_width / ax_height) if data_width > 0 and ax_height > 0 else radius_deg
+
+    glow_outer = patches.Ellipse((x, y), width=3.2 * rx, height=3.2 * ry, facecolor="#FDE047", alpha=0.25, edgecolor=None, zorder=10)
+    ax.add_patch(glow_outer)
+
+    glow_inner = patches.Ellipse((x, y), width=2.2 * rx, height=2.2 * ry, facecolor="#FACC15", alpha=0.4, edgecolor=None, zorder=10)
+    ax.add_patch(glow_inner)
+
+    sun_disk = patches.Ellipse((x, y), width=2 * rx, height=2 * ry, facecolor="#F59E0B", edgecolor="#FEF08A", linewidth=1.2, zorder=11)
+    ax.add_patch(sun_disk)
+
+
+def _get_event_moon_phase_frac(event_obj: "Event") -> float:
+    """Helper to determine float phase fraction (0.0-1.0) for Moon rendering."""
+    p_val = getattr(event_obj, "extra_data", {}).get("phase")
+    if isinstance(p_val, (int, float)):
+        if float(p_val) > 1.0:
+            return (float(p_val) % 360.0) / 360.0
+        return float(p_val)
+
+    title_lower = f"{event_obj.title} {event_obj.category} {p_val}".lower()
+    if "first quarter" in title_lower or "pierwsza kwadra" in title_lower or "cuarto creciente" in title_lower or "erstes viertel" in title_lower or "primeiro quarto" in title_lower:
+        return 0.25
+    if "third quarter" in title_lower or "last quarter" in title_lower or "trzecia kwadra" in title_lower or "ostatnia kwadra" in title_lower or "cuarto menguante" in title_lower or "drittes viertel" in title_lower or "quarto minguante" in title_lower:
+        return 0.75
+    if "full moon" in title_lower or "pełnia" in title_lower or "luna llena" in title_lower or "vollmond" in title_lower or "lua cheia" in title_lower:
+        return 0.5
+    if "new moon" in title_lower or "nów" in title_lower or "luna nueva" in title_lower or "neumond" in title_lower or "lua nova" in title_lower:
+        return 0.0
+
+    return 0.25
+
+
 def _parse_separation_deg(sep_str: str | None) -> float:
     """Parses angular separation degrees from string representation."""
     if not sep_str:
@@ -336,19 +386,25 @@ def _draw_single_object(
     dot_size: float,
     event_obj: "Event",
     theme: dict,
+    is_sun: bool = False,
 ):
     """Renders an individual primary or secondary target object on the finder chart."""
+    from apts.i18n import gettext_
+
     if is_moon:
-        phase = float(event_obj.extra_data.get("phase", 0.25)) if isinstance(event_obj.extra_data.get("phase"), (int, float)) else 0.25
-        _draw_moon_phase(ax, az, alt, radius_deg=0.9, phase_frac=phase, theme=theme)
+        phase_frac = _get_event_moon_phase_frac(event_obj)
+        _draw_moon_phase(ax, az, alt, radius_deg=0.9, phase_frac=phase_frac, theme=theme)
+    elif is_sun:
+        _draw_sun_disk(ax, az, alt, radius_deg=0.9, theme=theme)
     else:
         ax.scatter(az, alt, s=dot_size, color=theme[color_key], edgecolors=theme["star"], linewidth=1.0, zorder=12)
         ax.scatter(az, alt, s=glow_size, color=theme[color_key], alpha=0.25, edgecolors="none", zorder=11)
 
+    display_name = gettext_(name).title()
     ax.text(
         az,
         alt + 1.4,
-        name.title(),
+        display_name,
         color=theme["text_main"],
         fontsize=12 if color_key == "target_primary" else 11,
         fontweight="bold",
@@ -868,14 +924,14 @@ def _draw_chart_time_note_banner(ax: plt.Axes, note_text: str | None, theme: dic
     """Renders a prominent informational banner on top of the chart figure for time shift or warning notes."""
     if not note_text:
         return
+    note_lower = str(note_text).lower()
+    is_warning = any(w in note_lower for w in ("warning", "ostrzeżenie", "advertencia", "warnung", "aviso", "below", "poniżej", "debajo", "unter", "abaixo"))
     ax.text(
         0.5,
         0.96,
         note_text,
         transform=ax.transAxes,
-        color="#FACC15"
-        if "warning" in str(note_text).lower() or " poniżej" in str(note_text).lower()
-        else theme["text_main"],
+        color="#FACC15" if is_warning else theme["text_main"],
         fontsize=9,
         fontweight="bold",
         ha="center",
@@ -905,16 +961,35 @@ def _plot_primary_event_objects(
     p1_az, p1_alt = p1_pos
     obj1_name = main_objs[0] if len(main_objs) > 0 else "Target"
 
-    moon_in_event = any("moon" in str(o).lower() or "księżyc" in str(o).lower() for o in main_objs) or event_obj.category in ("OCCULTATION", "LUNAR_ECLIPSE")
-    obj1_is_moon = "moon" in obj1_name.lower() or "księżyc" in obj1_name.lower() or (moon_in_event and obj1_name == "Moon")
+    moon_kws = ("moon", "księżyc", "mond", "luna")
+    sun_kws = ("sun", "słońce", "sonne", "sol")
 
-    _draw_single_object(ax, obj1_name, p1_az, p1_alt, obj1_is_moon, "target_primary", 350, 120, event_obj, theme)
+    moon_in_event = (
+        any(any(k in str(o).lower() for k in moon_kws) for o in main_objs)
+        or event_obj.category in ("OCCULTATION", "LUNAR_ECLIPSE", "MOON_PHASE", "SUPERMOON", "MOON_LIBRATION", "LUNAR_FEATURE")
+    )
+    obj1_is_moon = (
+        any(k in obj1_name.lower() for k in moon_kws)
+        or (moon_in_event and obj1_name in ("Moon", "Księżyc", "Mond", "Luna", "Target"))
+    )
+
+    sun_in_event = (
+        any(any(k in str(o).lower() for k in sun_kws) for o in main_objs)
+        or event_obj.category in ("EQUINOX_SOLSTICE", "SOLAR_ECLIPSE")
+    )
+    obj1_is_sun = (
+        any(k in obj1_name.lower() for k in sun_kws)
+        or (sun_in_event and obj1_name in ("Sun", "Słońce", "Sonne", "Sol", "Target"))
+    )
+
+    _draw_single_object(ax, obj1_name, p1_az, p1_alt, obj1_is_moon, "target_primary", 350, 120, event_obj, theme, is_sun=obj1_is_sun)
 
     if p2_pos is not None:
         p2_az, p2_alt = p2_pos
         obj2_name = main_objs[1] if len(main_objs) > 1 else "Companion"
-        obj2_is_moon = "moon" in obj2_name.lower() or "księżyc" in obj2_name.lower()
-        _draw_single_object(ax, obj2_name, p2_az, p2_alt, obj2_is_moon, "target_secondary", 260, 90, event_obj, theme)
+        obj2_is_moon = any(k in obj2_name.lower() for k in moon_kws)
+        obj2_is_sun = any(k in obj2_name.lower() for k in sun_kws)
+        _draw_single_object(ax, obj2_name, p2_az, p2_alt, obj2_is_moon, "target_secondary", 260, 90, event_obj, theme, is_sun=obj2_is_sun)
 
         # Separation indicator
         ax.plot([p1_az, p2_az], [p1_alt, p2_alt], color=theme["separation_line"], linestyle="--", linewidth=1.2, alpha=0.85, zorder=13)

--- a/tests/unit/test_finder_chart.py
+++ b/tests/unit/test_finder_chart.py
@@ -211,3 +211,56 @@ def test_short_event_below_horizon_warning():
     assert d.get("is_below_horizon") is True
     assert "chart_time_note" in d
     assert "warning" in d["chart_time_note"].lower() or "poniżej" in d["chart_time_note"].lower() or "below horizon" in d["chart_time_note"].lower()
+
+
+def test_first_quarter_moon_phase_rendering():
+    event = Event.from_dict({
+        "event": "First Quarter",
+        "type": "Moon Phase",
+        "date": "2026-03-25T12:00:00Z",
+    })
+    assert event.objects == ["Moon"]
+    assert event.category == "MOON_PHASE"
+
+    fig = plot_finder_chart(event, format="figure")
+    assert isinstance(fig, matplotlib.figure.Figure)
+    assert len(fig.axes) == 1
+
+
+def test_autumnal_equinox_sun_rendering():
+    event = Event.from_dict({
+        "event": "Autumnal Equinox",
+        "type": "Equinox",
+        "date": "2026-09-22T12:00:00Z",
+    })
+    assert event.objects == ["Sun"]
+    assert event.category == "EQUINOX_SOLSTICE"
+
+    fig = plot_finder_chart(event, format="figure")
+    assert isinstance(fig, matplotlib.figure.Figure)
+    assert len(fig.axes) == 1
+
+
+def test_chart_time_note_translations():
+    from apts.i18n import set_language
+    set_language("pl")
+
+    event = Event(
+        category="MOON_PHASE",
+        title="First Quarter",
+        datetime_utc=datetime(2026, 3, 25, 5, 50, tzinfo=timezone.utc),
+        best_viewing_time_local="05:50",
+        location_name="Warsaw",
+        objects=["Moon"],
+        extra_data={"lat": 52.23, "lon": 21.01},
+    )
+
+    fig = plot_finder_chart(event, format="figure")
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+    d = event.to_dict()
+    assert "chart_time_note" in d
+    note = d["chart_time_note"]
+    # Check translated Polish text elements
+    assert "Szczyt" in note or "poniżej horyzontu" in note or "Wykres" in note
+    set_language("en")


### PR DESCRIPTION
Fixed Finder Chart target object resolution and horizon rendering for moon quarters (e.g. First Quarter) and equinoxes (e.g. Autumnal Equinox). Implemented Sun disk rendering, phase fraction inference, matching Sun/Moon disc dimensions, and i18n translations for chart banner notes.

---
*PR created automatically by Jules for task [1932447454128478495](https://jules.google.com/task/1932447454128478495) started by @pozar87*