### PR TITLE
🔍 Optic: Data audit for ZWO ASI585MC

### DIFF
--- a/apts/opticalequipment/camera/vendors/zwo.py
+++ b/apts/opticalequipment/camera/vendors/zwo.py
@@ -1578,19 +1578,19 @@ class ZwoCamera(Camera):
             "brand": "ZWO",
             "cside_gender": "",
             "cside_thread": "",
-            "full_well_e": 40000,
+            "full_well_e": 40000,  # Verified via ZWO official product specs (40ke) - https://www.zwoastro.com/product/asi585mc/
             "height": 2160,
-            "mass": 126,
+            "mass": 126,  # Verified via ZWO (126g) - https://www.zwoastro.com/product/asi585mc/
             "name": "ASI585MC",
-            "optical_length": 6.5,
-            "pixel_size_um": 2.9,
-            "quantum_efficiency_pct": 91,
-            "read_noise_e": 0.6,
+            "optical_length": 12.5,  # Verified via ZWO (12.5mm backfocus distance / CS thread) - https://www.zwoastro.com/product/asi585mc/
+            "pixel_size_um": 2.9,  # Verified via ZWO (2.9µm pixel size) - https://www.zwoastro.com/product/asi585mc/
+            "quantum_efficiency_pct": 91,  # Verified via ZWO (91% peak QE) - https://www.zwoastro.com/product/asi585mc/
+            "read_noise_e": 0.6,  # Verified via ZWO (0.6e- read noise) - https://www.zwoastro.com/product/asi585mc/
             "reversible": False,
-            "sensor_height_mm": 6.26,
-            "sensor_width_mm": 11.13,
+            "sensor_height_mm": 6.26,  # Verified via ZWO (6.26mm x 11.13mm Sony IMX585 sensor) - https://www.zwoastro.com/product/asi585mc/
+            "sensor_width_mm": 11.13,  # Verified via ZWO (6.26mm x 11.13mm Sony IMX585 sensor) - https://www.zwoastro.com/product/asi585mc/
             "tside_gender": "Female",
-            "tside_thread": "M42",
+            "tside_thread": "CS",  # Verified via ZWO (CS-mount native thread with 12.5mm backfocus) - https://www.zwoastro.com/product/asi585mc/
             "type": "type_camera",
             "width": 3840,
         },

--- a/tests/unit/test_zwo_585mc_audit.py
+++ b/tests/unit/test_zwo_585mc_audit.py
@@ -1,0 +1,49 @@
+import unittest
+
+from pint import Quantity
+
+from apts.opticalequipment.camera.vendors.zwo import ZwoCamera
+from apts.utils.equipment import ConnectionType
+
+
+class TestZwoASI585MCAudit(unittest.TestCase):
+
+    def test_asi585mc_specs(self):
+        cam = ZwoCamera.ZWO_ASI_585MC()
+
+        # Mass: 126g
+        self.assertEqual(cam.mass.to("gram").magnitude, 126)
+
+        # Optical length / backfocus: 12.5mm
+        self.assertEqual(cam.optical_length.to("mm").magnitude, 12.5)
+        self.assertEqual(cam.backfocus, Quantity(12.5, "millimeter"))
+
+        # Connection thread: CS
+        self.assertEqual(cam.connection_type, ConnectionType.CS)
+
+        # Resolution: 3840 x 2160 (8.29MP)
+        self.assertEqual(cam.width, 3840)
+        self.assertEqual(cam.height, 2160)
+
+        # Sensor dimensions & pixel size: 2.9µm, 11.13mm x 6.26mm
+        self.assertEqual(cam.pixel_size().to("micrometer").magnitude, 2.9)
+        self.assertEqual(cam.sensor_width.to("mm").magnitude, 11.13)
+        self.assertEqual(cam.sensor_height.to("mm").magnitude, 6.26)
+
+        # Full well capacity: 40000 e-
+        self.assertEqual(cam.full_well, 40000)
+
+        # Read noise: 0.6 e-
+        self.assertEqual(cam.read_noise, 0.6)
+
+        # Peak Quantum Efficiency: 91%
+        self.assertEqual(cam.quantum_efficiency, 91)
+
+    def test_asi585mc_alias_factory_method(self):
+        cam = ZwoCamera.ZWO_ASI585MC()
+        self.assertEqual(cam.vendor, "ZWO ASI585MC")
+        self.assertEqual(cam.optical_length.to("mm").magnitude, 12.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited and corrected the ZWO ASI585MC camera specification entry in the `apts` optical equipment database against official ZWO product documentation.

Key Changes:
- Corrected `optical_length` (backfocus) from 6.5mm to 12.5mm.
- Corrected `tside_thread` from M42 to native CS female thread.
- Verified mass (126g), sensor dimensions (11.13mm x 6.26mm), pixel size (2.9µm), resolution (3840x2160), full well capacity (40,000e-), peak QE (91%), and read noise (0.6e-).
- Added inline reference comments with official ZWO documentation links.
- Added comprehensive unit test in `tests/unit/test_zwo_585mc_audit.py`.

---
*PR created automatically by Jules for task [1486809210341948738](https://jules.google.com/task/1486809210341948738) started by @pozar87*