### PR TITLE
🔍 Optic: Data audit for Celestron AstroMaster 70AZ

### DIFF
--- a/apts/opticalequipment/telescope/vendors/celestron.py
+++ b/apts/opticalequipment/telescope/vendors/celestron.py
@@ -119,7 +119,7 @@ class CelestronTelescope(Telescope):
             "name": "AstroMaster 70AZ",
             "type": "refractor",
             "optical_length": 0,
-            "mass": 1310,
+            "mass": 1315,  # Verified via Celestron.com (2.9 lbs / 1,315g OTA weight, 70mm aperture, 900mm focal length, f/13, 1.25" visual back - https://www.celestron.com/products/astromaster-70az-telescope)
             "tside_thread": "",
             "tside_gender": "",
             "cside_thread": "1.25\"",

--- a/tests/unit/test_celestron_astromaster_70az_audit.py
+++ b/tests/unit/test_celestron_astromaster_70az_audit.py
@@ -1,0 +1,21 @@
+import unittest
+from apts.opticalequipment.telescope.vendors.celestron import CelestronTelescope
+from apts.utils import ConnectionType, Gender
+
+
+class TestCelestronAstroMaster70AZAudit(unittest.TestCase):
+    def test_astromaster_70az_audited_specs(self):
+        """Verify the audited hardware specifications for Celestron AstroMaster 70AZ."""
+        scope = CelestronTelescope.Celestron_AstroMaster_70AZ()
+        self.assertEqual(scope.get_vendor(), "Celestron AstroMaster 70AZ")
+        self.assertEqual(scope.aperture.to("mm").magnitude, 70)
+        self.assertEqual(scope.focal_length.to("mm").magnitude, 900)
+        self.assertAlmostEqual(scope.focal_ratio().magnitude, 12.857, places=2)
+        self.assertEqual(scope.central_obstruction.to("mm").magnitude, 0)
+        self.assertEqual(scope.mass.to("gram").magnitude, 1315)
+        self.assertEqual(scope.connection_type, ConnectionType.F_1_25)
+        self.assertEqual(scope.connection_gender, Gender.FEMALE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audited technical specifications for the Celestron AstroMaster 70AZ telescope against official manufacturer documentation. Updated the optical tube mass to 1315g (2.9 lbs), verified aperture, focal length, focal ratio, central obstruction, and 1.25" female visual back thread connection, added source reference URL comment, and created a dedicated unit test suite in `tests/unit/test_celestron_astromaster_70az_audit.py`.

---
*PR created automatically by Jules for task [1057284874272685807](https://jules.google.com/task/1057284874272685807) started by @pozar87*